### PR TITLE
Various fixes and improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,11 +102,16 @@ directory, for example:
 }
 ```
 
-Also `version` seems to be required by pack. I like setting it to `"0.0.0"` to
-make it clear that the version is not really being used.
+The `version` field is also required for `pack` to execute. I personally always
+set it to `"0.0.0"` to indicate that the version does not have a practical
+function.
 
 A few additional files will be included by `pack` automatically, like the
 `package.json` and `README.md` files.
+
+**Tip** If you deploy to Firebase gen2 functions, you might want to include some
+.env files in the "files" list, so they are packaged and deployed together with
+your build output.
 
 ### Use a flat structure inside your packages folders
 
@@ -212,6 +217,15 @@ Type: `string | undefined`, default: `undefined`
 The name of the build output directory name. When undefined it is automatically
 detected via `tsconfig.json`. When you are not using Typescript you can use this
 setting to specify where the build output files are located.
+
+### excludeLockfile
+
+Type: `boolean`, default: Depends on package manager.
+
+Sets the inclusion or exclusion of the lockfile as part of the deployment. For
+Yarn and NPM the lockfiles are included by default, but for PNPM they are
+excluded by default because they are not supported yet. For more information see
+[lockfiles](#lockfiles).
 
 ### includeDevDependencies
 
@@ -319,8 +333,7 @@ stored to the isolate directory.
 
 There is still [an issue with the PNPM lockfile
 conversion](https://github.com/0x80/isolate-package/issues/5). Until that is
-resolved, you can choose to exclude the lockfile by setting the configuration
-`"excludeLockfile": true`.
+resolved, the `excludeLockfile` setting for PNPM defaults to `true`.
 
 ## Used Terminology
 

--- a/README.md
+++ b/README.md
@@ -343,26 +343,27 @@ The PNPM lockfile clearly has a structure describing the different packages by
 their relative paths, and so to correct the lockfile it is adapted before being
 stored to the isolate directory.
 
-### Node 16 vs Node 18
+### NPM
 
-It seems that when deploying to the Firebase node16 runtime the `npm ci` can
-fail with a message like:
+It seems that when using NPM the `npm ci` can fail with a message like:
 
 > `npm ci` can only install packages when your package.json and
 > package-lock.json or npm-shrinkwrap.json are in sync. Please update your lock
 > file with `npm install` before continuing.
 
-I haven't been able to figure out what causes this, as the message is misleading
-(the lockfile is clearly there).
+I haven't been able to figure out what causes this. I have seen NPM deploys
+working with lockfiles, but I can not reliably reproduce it.
 
-Luckily, with Node 18 this seems to have been resolved, so if you experience
-this issue there are two options:
+If you experience this issue I have two suggestions:
 
 - Upgrade to Node 18 by setting the `"runtime": "nodejs18"` in your
   firebase.json config. Note that you most likely also have to re-create your
   lockfile using Node 18.
 - Exclude the lockfile from deployment by setting `"excludeLockfile": false` in
   your isolate.config.json file.
+
+I hope we can eventually figure out what is causing this, but more investigation
+is required.
 
 ### PNPM Lockfiles disabled for now
 

--- a/README.md
+++ b/README.md
@@ -345,8 +345,8 @@ stored to the isolate directory.
 
 ### Node 16 vs Node 18
 
-It seems that when deploying to Node 16 Firebase the `npm ci` command fails with
-a message like:
+It seems that when deploying to the Firebase node16 runtime the `npm ci` can
+fail with a message like:
 
 > `npm ci` can only install packages when your package.json and
 > package-lock.json or npm-shrinkwrap.json are in sync. Please update your lock
@@ -355,24 +355,25 @@ a message like:
 I haven't been able to figure out what causes this, as the message is misleading
 (the lockfile is clearly there).
 
-With Node 18 this seems to have been resolved. If you experience this issue
-there are two options:
+Luckily, with Node 18 this seems to have been resolved, so if you experience
+this issue there are two options:
 
-- Upgrade to Node 18, by setting the `"runtime": "nodejs18"` in your
-  firebase.json config.
+- Upgrade to Node 18 by setting the `"runtime": "nodejs18"` in your
+  firebase.json config. Note that you most likely also have to re-create your
+  lockfile using Node 18.
 - Exclude the lockfile from deployment by setting `"excludeLockfile": false` in
   your isolate.config.json file.
 
 ### PNPM Lockfiles disabled for now
 
 There is still [an issue with the PNPM lockfile
-conversion](https://github.com/0x80/isolate-package/issues/5) and it is unusable
-at the moment. Until that is resolved, the lockfile is automatically excluded
-for PNPM.
+conversion](https://github.com/0x80/isolate-package/issues/5) which makes it
+unusable at the moment. Until that is resolved, the lockfile is automatically
+excluded for PNPM.
 
-Personally, I also use PNPM and I don't see this as a big problem. I am
-declaring versions with `^` in my manifest, which means that a missing lockfile
-can only ever result in unexpected patch versions, and I am not using
+Personally I also use PNPM, and I don't see this as a big problem, because, like
+most of us, I declare versions with `^` in my manifest. This means that
+dependencies can only resolve to newer patch versions, but I am not using
 dependencies that are likely to break on patch version changes.
 
 ## Different Package Managers
@@ -394,5 +395,5 @@ lockfile that was found in the deployed package.
 If you are using Yarn 3 with zero-installs, the deployed package is not aware of
 that, because the `.yarnrc` file and `.yarn` folder are located in the root of
 your monorepo, and the version is not recorded as part of the lockfile. Therefor
-the Firebase deploy cloud pipeline will use Yarn 1 to install your
-dependencies. I don't think that is an issue but it might be good to know.
+the Firebase deploy cloud pipeline will use Yarn 1 to install your dependencies.
+I don't think that is an issue but it might be good to know.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "isolate-package",
-  "version": "1.2.0-rc-2",
+  "version": "1.2.0-rc2",
   "description": "Isolate a monorepo package by bundling the build output with its shared workspace packages and lock file to form a self-contained directory.",
   "author": "Thijs Koerselman",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "isolate-package",
-  "version": "1.2.0-rc1",
+  "version": "1.2.0-rc-2",
   "description": "Isolate a monorepo package by bundling the build output with its shared workspace packages and lock file to form a self-contained directory.",
   "author": "Thijs Koerselman",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -26,9 +26,11 @@
   },
   "scripts": {
     "build": "tsup-node",
+    "build:watch": "tsup-node --watch",
     "test": "vitest",
     "format": "prettier --write .",
-    "lint:format": "prettier --check ."
+    "lint:format": "prettier --check .",
+    "compile:watch": "tsc --noEmit -w"
   },
   "dependencies": {
     "chalk": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "isolate-package",
-  "version": "1.2.0-rc4",
+  "version": "1.2.0-rc5",
   "description": "Isolate a monorepo package by bundling the build output with its shared workspace packages and lock file to form a self-contained directory.",
   "author": "Thijs Koerselman",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "isolate-package",
-  "version": "1.2.0-rc2",
+  "version": "1.2.0-rc3",
   "description": "Isolate a monorepo package by bundling the build output with its shared workspace packages and lock file to form a self-contained directory.",
   "author": "Thijs Koerselman",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "isolate-package",
-  "version": "1.1.1",
+  "version": "1.2.0-rc1",
   "description": "Isolate a monorepo package by bundling the build output with its shared workspace packages and lock file to form a self-contained directory.",
   "author": "Thijs Koerselman",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   "scripts": {
     "build": "tsup-node",
     "test": "vitest",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "lint:format": "prettier --check ."
   },
   "dependencies": {
     "chalk": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "isolate-package",
-  "version": "1.2.0-rc3",
+  "version": "1.2.0-rc4",
   "description": "Isolate a monorepo package by bundling the build output with its shared workspace packages and lock file to form a self-contained directory.",
   "author": "Thijs Koerselman",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "lodash-es": "^4.17.21",
     "outdent": "^0.8.0",
     "source-map-support": "^0.5.21",
+    "strip-json-comments": "^5.0.1",
     "tar-fs": "^2.1.1",
     "yaml": "^2.2.2"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ dependencies:
   source-map-support:
     specifier: ^0.5.21
     version: 0.5.21
+  strip-json-comments:
+    specifier: ^5.0.1
+    version: 5.0.1
   tar-fs:
     specifier: ^2.1.1
     version: 2.1.1
@@ -1390,6 +1393,11 @@ packages:
     resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
     engines: {node: '>=6'}
     dev: true
+
+  /strip-json-comments@5.0.1:
+    resolution: {integrity: sha512-0fk9zBqO67Nq5M/m45qHCJxylV/DhBlIOVExqgOMiCCrzrhU6tCibRXNqE3jwJLftzE9SNuZtYbpzcO+i9FiKw==}
+    engines: {node: '>=14.16'}
+    dev: false
 
   /strip-literal@1.0.1:
     resolution: {integrity: sha512-QZTsipNpa2Ppr6v1AmJHESqJ3Uz247MUS0OjrnnZjFAvEoWqxuyFuXn2xLgMtRnijJShAa1HL0gtJyUs7u7n3Q==}

--- a/src/helpers/adapt-manifest-files.ts
+++ b/src/helpers/adapt-manifest-files.ts
@@ -5,18 +5,23 @@ import {
   adaptManifestWorkspaceDeps,
   getConfig,
 } from "~/helpers";
+import { createLogger } from "~/utils";
 
 export async function adaptManifestFiles(
   localDependencies: string[],
   packagesRegistry: PackagesRegistry,
   isolateDir: string
 ) {
+  const log = createLogger(getConfig().logLevel);
+
   await Promise.all(
     localDependencies.map(async (packageName) => {
       const { manifest, rootRelativeDir } = packagesRegistry[packageName];
 
+      log.debug("Adapting manifest file:", packageName);
+
       const outputManifest = adaptManifestWorkspaceDeps(
-        { manifest, packagesRegistry },
+        { manifest, packagesRegistry, parentRootRelativeDir: rootRelativeDir },
         { includeDevDependencies: getConfig().includeDevDependencies }
       );
 

--- a/src/helpers/adapt-manifest-files.ts
+++ b/src/helpers/adapt-manifest-files.ts
@@ -12,13 +12,9 @@ export async function adaptManifestFiles(
   packagesRegistry: PackagesRegistry,
   isolateDir: string
 ) {
-  const log = createLogger(getConfig().logLevel);
-
   await Promise.all(
     localDependencies.map(async (packageName) => {
       const { manifest, rootRelativeDir } = packagesRegistry[packageName];
-
-      log.debug("Adapting manifest file:", packageName);
 
       const outputManifest = adaptManifestWorkspaceDeps(
         { manifest, packagesRegistry, parentRootRelativeDir: rootRelativeDir },

--- a/src/helpers/adapt-manifest-workspace-deps.ts
+++ b/src/helpers/adapt-manifest-workspace-deps.ts
@@ -1,8 +1,9 @@
 import { omit } from "lodash-es";
-import { filterObjectUndefined } from "~/utils";
+import { createLogger, filterObjectUndefined } from "~/utils";
 import {
   PackageManifestMinimum,
   PackagesRegistry,
+  getConfig,
   patchWorkspaceEntries,
 } from ".";
 
@@ -10,21 +11,33 @@ export function adaptManifestWorkspaceDeps(
   {
     manifest,
     packagesRegistry,
+    parentRootRelativeDir,
   }: {
     manifest: PackageManifestMinimum;
     packagesRegistry: PackagesRegistry;
+    parentRootRelativeDir: string;
   },
   opts: { includeDevDependencies?: boolean } = {}
 ): PackageManifestMinimum {
+  const log = createLogger(getConfig().logLevel);
+
   return Object.assign(
     omit(manifest, ["scripts", "devDependencies"]),
     filterObjectUndefined({
       dependencies: manifest.dependencies
-        ? patchWorkspaceEntries(manifest.dependencies, packagesRegistry)
+        ? patchWorkspaceEntries(
+            manifest.dependencies,
+            packagesRegistry,
+            parentRootRelativeDir
+          )
         : undefined,
       devDependencies:
         opts.includeDevDependencies && manifest.devDependencies
-          ? patchWorkspaceEntries(manifest.devDependencies, packagesRegistry)
+          ? patchWorkspaceEntries(
+              manifest.devDependencies,
+              packagesRegistry,
+              parentRootRelativeDir
+            )
           : undefined,
     })
   );

--- a/src/helpers/adapt-manifest-workspace-deps.ts
+++ b/src/helpers/adapt-manifest-workspace-deps.ts
@@ -1,10 +1,6 @@
 import { omit } from "lodash-es";
 import { filterObjectUndefined } from "~/utils";
-import {
-  PackageManifestMinimum,
-  PackagesRegistry,
-  patchWorkspaceEntries,
-} from ".";
+import { PackageManifest, PackagesRegistry, patchWorkspaceEntries } from ".";
 
 export function adaptManifestWorkspaceDeps(
   {
@@ -12,12 +8,12 @@ export function adaptManifestWorkspaceDeps(
     packagesRegistry,
     parentRootRelativeDir,
   }: {
-    manifest: PackageManifestMinimum;
+    manifest: PackageManifest;
     packagesRegistry: PackagesRegistry;
     parentRootRelativeDir?: string;
   },
   opts: { includeDevDependencies?: boolean } = {}
-): PackageManifestMinimum {
+): PackageManifest {
   return Object.assign(
     omit(manifest, ["scripts", "devDependencies"]),
     filterObjectUndefined({

--- a/src/helpers/adapt-manifest-workspace-deps.ts
+++ b/src/helpers/adapt-manifest-workspace-deps.ts
@@ -1,9 +1,8 @@
 import { omit } from "lodash-es";
-import { createLogger, filterObjectUndefined } from "~/utils";
+import { filterObjectUndefined } from "~/utils";
 import {
   PackageManifestMinimum,
   PackagesRegistry,
-  getConfig,
   patchWorkspaceEntries,
 } from ".";
 
@@ -15,12 +14,10 @@ export function adaptManifestWorkspaceDeps(
   }: {
     manifest: PackageManifestMinimum;
     packagesRegistry: PackagesRegistry;
-    parentRootRelativeDir: string;
+    parentRootRelativeDir?: string;
   },
   opts: { includeDevDependencies?: boolean } = {}
 ): PackageManifestMinimum {
-  const log = createLogger(getConfig().logLevel);
-
   return Object.assign(
     omit(manifest, ["scripts", "devDependencies"]),
     filterObjectUndefined({

--- a/src/helpers/adapt-target-package-manifest.ts
+++ b/src/helpers/adapt-target-package-manifest.ts
@@ -1,14 +1,14 @@
 import fs from "fs-extra";
 import path from "node:path";
 import {
-  PackageManifestMinimum,
+  PackageManifest,
   PackagesRegistry,
   adaptManifestWorkspaceDeps,
   getConfig,
 } from "~/helpers";
 
 export async function adaptTargetPackageManifest(
-  manifest: PackageManifestMinimum,
+  manifest: PackageManifest,
   packagesRegistry: PackagesRegistry,
   isolateDir: string
 ) {

--- a/src/helpers/create-packages-registry.ts
+++ b/src/helpers/create-packages-registry.ts
@@ -6,8 +6,9 @@ import { createLogger, readTypedJson } from "~/utils";
 import { getConfig } from "./config";
 import { findPackagesGlobs } from "./find-packages-globs";
 
-export type PackageManifestMinimum = {
+export type PackageManifest = {
   name: string;
+  packageManager?: string;
   dependencies?: Record<string, string>;
   devDependencies?: Record<string, string>;
   main: string;
@@ -29,7 +30,7 @@ export type WorkspacePackageInfo = {
   /**
    * The package.json file contents
    */
-  manifest: PackageManifestMinimum;
+  manifest: PackageManifest;
 };
 
 export type PackagesRegistry = Record<string, WorkspacePackageInfo>;
@@ -77,7 +78,7 @@ export async function createPackagesRegistry(
         } else {
           log.debug(`Registering package ./${rootRelativeDir}`);
 
-          const manifest = await readTypedJson<PackageManifestMinimum>(
+          const manifest = await readTypedJson<PackageManifest>(
             path.join(rootRelativeDir, "package.json")
           );
 

--- a/src/helpers/detect-package-manager.ts
+++ b/src/helpers/detect-package-manager.ts
@@ -1,20 +1,47 @@
 import fs from "fs-extra";
+import { execSync } from "node:child_process";
 import path from "node:path";
 
-export type PackageManager = "pnpm" | "yarn" | "npm";
+type PackageManagerName = "pnpm" | "yarn" | "npm";
+
+export type PackageManager = {
+  name: PackageManagerName;
+  version: string;
+};
+
+let packageManager: PackageManager | undefined;
 
 export function detectPackageManager(workspaceRoot: string): PackageManager {
   if (fs.existsSync(path.join(workspaceRoot, "pnpm-lock.yaml"))) {
-    return "pnpm";
+    packageManager = { name: "pnpm", version: detectVersion("pnpm") };
   }
 
   if (fs.existsSync(path.join(workspaceRoot, "yarn.lock"))) {
-    return "yarn";
+    packageManager = { name: "yarn", version: detectVersion("yarn") };
   }
 
   if (fs.existsSync(path.join(workspaceRoot, "package-lock.json"))) {
-    return "npm";
+    packageManager = { name: "npm", version: detectVersion("npm") };
   }
 
-  throw new Error(`Failed to detect package manager`);
+  if (!packageManager) {
+    throw new Error(`Failed to detect package manager`);
+  }
+
+  return packageManager;
+}
+
+function detectVersion(packageManagerName: PackageManagerName): string {
+  const buffer = execSync(`${packageManagerName} --version`);
+  return buffer.toString().trim();
+}
+
+export function usePackageManager() {
+  if (!packageManager) {
+    throw Error(
+      "No package manager detected. Make sure to call detectPackageManager() before usePackageManager()"
+    );
+  }
+
+  return packageManager;
 }

--- a/src/helpers/detect-package-manager.ts
+++ b/src/helpers/detect-package-manager.ts
@@ -76,6 +76,13 @@ function inferFromFiles(workspaceRoot: string): PackageManager {
     }
   }
 
+  /**
+   * If no lockfile was found, it could be that there is an npm shrinkwrap file.
+   */
+  if (fs.existsSync(path.join(workspaceRoot, "npm-shrinkwrap.json"))) {
+    return { name: "npm", version: getVersion("npm") };
+  }
+
   throw new Error(`Failed to detect package manager`);
 }
 

--- a/src/helpers/detect-package-manager.ts
+++ b/src/helpers/detect-package-manager.ts
@@ -24,9 +24,13 @@ let packageManager: PackageManager | undefined;
  * different lockfiles and ask the OS to report the installed version.
  */
 export function detectPackageManager(workspaceRoot: string): PackageManager {
-  packageManager =
-    inferFromManifest(workspaceRoot) ?? inferFromFiles(workspaceRoot);
+  /**
+   * Disable infer from manifest. I doubt it is useful after all
+   */
+  // packageManager =
+  //   inferFromManifest(workspaceRoot) ?? inferFromFiles(workspaceRoot);
 
+  packageManager = inferFromFiles(workspaceRoot);
   return packageManager;
 }
 

--- a/src/helpers/detect-package-manager.ts
+++ b/src/helpers/detect-package-manager.ts
@@ -1,8 +1,14 @@
 import fs from "fs-extra";
+import assert from "node:assert";
 import { execSync } from "node:child_process";
 import path from "node:path";
+import { pack } from "tar-fs";
+import { PackageManifest } from "./create-packages-registry";
+import { getLockfileFileName } from "./process-lockfile";
 
-type PackageManagerName = "pnpm" | "yarn" | "npm";
+const supportedPackageManagerNames = ["pnpm", "yarn", "npm"] as const;
+
+export type PackageManagerName = (typeof supportedPackageManagerNames)[number];
 
 export type PackageManager = {
   name: PackageManagerName;
@@ -11,27 +17,59 @@ export type PackageManager = {
 
 let packageManager: PackageManager | undefined;
 
-export function detectPackageManager(workspaceRoot: string): PackageManager {
-  if (fs.existsSync(path.join(workspaceRoot, "pnpm-lock.yaml"))) {
-    packageManager = { name: "pnpm", version: detectVersion("pnpm") };
-  }
-
-  if (fs.existsSync(path.join(workspaceRoot, "yarn.lock"))) {
-    packageManager = { name: "yarn", version: detectVersion("yarn") };
-  }
-
-  if (fs.existsSync(path.join(workspaceRoot, "package-lock.json"))) {
-    packageManager = { name: "npm", version: detectVersion("npm") };
-  }
-
-  if (!packageManager) {
-    throw new Error(`Failed to detect package manager`);
-  }
+/**
+ * First we check if the package manager is declared in the manifest. If it is,
+ * we get the name and version from there. Otherwise we'll search for the
+ * different lockfiles and ask the OS to report the installed version.
+ */
+export function detectPackageManager(
+  workspaceRoot: string,
+  manifest: PackageManifest
+): PackageManager {
+  packageManager =
+    inferFromManifest(manifest, workspaceRoot) ?? inferFromFiles(workspaceRoot);
 
   return packageManager;
 }
 
-function detectVersion(packageManagerName: PackageManagerName): string {
+function inferFromManifest(manifest: PackageManifest, workspaceRoot: string) {
+  if (!manifest.packageManager) {
+    return;
+  }
+
+  const [name, version = "*"] = manifest.packageManager.split("@") as [
+    PackageManagerName,
+    string,
+  ];
+
+  assert(
+    supportedPackageManagerNames.includes(name),
+    `Package manager "${name}" is not currently supported`
+  );
+
+  const lockfileName = getLockfileFileName(name);
+
+  assert(
+    fs.existsSync(path.join(workspaceRoot, lockfileName)),
+    `Manifest declares ${name} to be the packageManager, but failed to find ${lockfileName} in workspace root`
+  );
+
+  return { name, version };
+}
+
+function inferFromFiles(workspaceRoot: string): PackageManager {
+  for (const name of supportedPackageManagerNames) {
+    const lockfileName = getLockfileFileName(name);
+
+    if (fs.existsSync(path.join(workspaceRoot, lockfileName))) {
+      return { name, version: getVersion(name) };
+    }
+  }
+
+  throw new Error(`Failed to detect package manager`);
+}
+
+function getVersion(packageManagerName: PackageManagerName): string {
   const buffer = execSync(`${packageManagerName} --version`);
   return buffer.toString().trim();
 }

--- a/src/helpers/detect-package-manager.ts
+++ b/src/helpers/detect-package-manager.ts
@@ -25,7 +25,8 @@ let packageManager: PackageManager | undefined;
  */
 export function detectPackageManager(workspaceRoot: string): PackageManager {
   /**
-   * Disable infer from manifest. I doubt it is useful after all
+   * Disable infer from manifest for now. I doubt it is useful after all but
+   * I'll keep the code as a reminder.
    */
   // packageManager =
   //   inferFromManifest(workspaceRoot) ?? inferFromFiles(workspaceRoot);

--- a/src/helpers/find-packages-globs.ts
+++ b/src/helpers/find-packages-globs.ts
@@ -6,7 +6,7 @@ import {
   readTypedYamlSync,
 } from "~/utils";
 import { getConfig } from "./config";
-import { detectPackageManager } from "./detect-package-manager";
+import { usePackageManager } from "./detect-package-manager";
 
 /**
  * Find the globs that define where the packages are located within the
@@ -16,9 +16,9 @@ import { detectPackageManager } from "./detect-package-manager";
 export function findPackagesGlobs(workspaceRootDir: string) {
   const log = createLogger(getConfig().logLevel);
 
-  const packageManager = detectPackageManager(workspaceRootDir);
+  const packageManager = usePackageManager();
 
-  switch (packageManager) {
+  switch (packageManager.name) {
     case "pnpm": {
       const { packages: globs } = readTypedYamlSync<{ packages: string[] }>(
         path.join(workspaceRootDir, "pnpm-workspace.yaml")

--- a/src/helpers/find-packages-globs.ts
+++ b/src/helpers/find-packages-globs.ts
@@ -1,3 +1,4 @@
+import assert from "node:assert";
 import path from "node:path";
 import {
   createLogger,
@@ -44,7 +45,22 @@ export function findPackagesGlobs(workspaceRootDir: string) {
         );
       }
 
-      return workspaces;
+      if (Array.isArray(workspaces)) {
+        return workspaces;
+      } else {
+        /**
+         * For Yarn, workspaces could be defined as an object with { packages: [],
+         * nohoist: [] }. See https://classic.yarnpkg.com/blog/2018/02/15/nohoist/
+         */
+        const workspacesObject = workspaces as { packages?: string[] };
+
+        assert(
+          workspacesObject.packages,
+          "workspaces.packages must be an array"
+        );
+
+        return workspacesObject.packages;
+      }
     }
   }
 }

--- a/src/helpers/list-local-dependencies.ts
+++ b/src/helpers/list-local-dependencies.ts
@@ -1,7 +1,4 @@
-import {
-  PackageManifestMinimum,
-  PackagesRegistry,
-} from "./create-packages-registry";
+import { PackageManifest, PackagesRegistry } from "./create-packages-registry";
 
 /**
  * Recursively list the packages from dependencies (and optionally
@@ -12,7 +9,7 @@ import {
  * that were found via the workspace glob patterns and added to the registry.
  */
 export function listLocalDependencies(
-  manifest: PackageManifestMinimum,
+  manifest: PackageManifest,
   packagesRegistry: PackagesRegistry,
   { includeDevDependencies = false } = {}
 ): string[] {

--- a/src/helpers/manifest.ts
+++ b/src/helpers/manifest.ts
@@ -1,9 +1,7 @@
 import path from "node:path";
 import { readTypedJson } from "~/utils";
-import { PackageManifestMinimum } from "./create-packages-registry";
+import { PackageManifest } from "./create-packages-registry";
 
 export async function importManifest(packageDir: string) {
-  return readTypedJson<PackageManifestMinimum>(
-    path.join(packageDir, "package.json")
-  );
+  return readTypedJson<PackageManifest>(path.join(packageDir, "package.json"));
 }

--- a/src/helpers/pack-dependencies.ts
+++ b/src/helpers/pack-dependencies.ts
@@ -2,7 +2,6 @@ import assert from "node:assert";
 import { createLogger, pack } from "~/utils";
 import { getConfig } from "./config";
 import { PackagesRegistry } from "./create-packages-registry";
-import { PackageManager } from "./detect-package-manager";
 
 /**
  * Pack dependencies so that we extract only the files that are supposed to be
@@ -26,13 +25,10 @@ export async function packDependencies({
    * configure it.
    */
   packDestinationDir,
-
-  packageManager,
 }: {
   packagesRegistry: PackagesRegistry;
   localDependencies: string[];
   packDestinationDir: string;
-  packageManager: PackageManager;
 }) {
   const config = getConfig();
   const log = createLogger(config.logLevel);
@@ -55,11 +51,7 @@ export async function packDependencies({
       continue;
     }
 
-    packedFileByName[name] = await pack(
-      def.absoluteDir,
-      packDestinationDir,
-      packageManager
-    );
+    packedFileByName[name] = await pack(def.absoluteDir, packDestinationDir);
 
     /**
      * @TODO call recursively

--- a/src/helpers/patch-workspace-entries.ts
+++ b/src/helpers/patch-workspace-entries.ts
@@ -21,13 +21,15 @@ export function patchWorkspaceEntries(
          * local deps), the parentRootRelativeDir will be passed in, and we
          * store the relative path to the isolate/packages directory, as is
          * required by some package managers.
+         *
+         * For consistency we also write the other file paths starting with
+         * ./, but it doesn't seem to be necessary for any package manager.
          */
         const relativePath = parentRootRelativeDir
           ? path.relative(parentRootRelativeDir, `./${def.rootRelativeDir}`)
           : `./${def.rootRelativeDir}`;
 
         const linkPath = `file:${relativePath}`;
-        // const linkPath = `file:${def.rootRelativeDir}`;
 
         log.debug(`Linking dependency ${key} to ${linkPath}`);
 

--- a/src/helpers/patch-workspace-entries.ts
+++ b/src/helpers/patch-workspace-entries.ts
@@ -6,7 +6,7 @@ import { PackagesRegistry } from "./create-packages-registry";
 export function patchWorkspaceEntries(
   dependencies: Record<string, string>,
   packagesRegistry: PackagesRegistry,
-  parentRootRelativeDir: string
+  parentRootRelativeDir?: string
 ) {
   const log = createLogger(getConfig().logLevel);
   const allWorkspacePackageNames = Object.keys(packagesRegistry);
@@ -20,10 +20,12 @@ export function patchWorkspaceEntries(
          * Some package managers seem to want a relative file:// link path when
          * referring to own dependencies. Others want the absolute path (?).
          */
-        const parentRelativePath = path.relative(
-          parentRootRelativeDir,
-          def.rootRelativeDir
-        );
+        const relativePath = parentRootRelativeDir
+          ? path.relative(parentRootRelativeDir, def.rootRelativeDir)
+          : def.rootRelativeDir;
+
+        log.warn("parentRootRelativeDir", parentRootRelativeDir);
+        log.warn("def.rootRelativeDir", def.rootRelativeDir);
 
         // const linkedPath = `file:${
         //   isPackageToIsolate || packageManager === "npm"
@@ -32,7 +34,7 @@ export function patchWorkspaceEntries(
         // }`;
 
         // const linkPath = `file:${def.rootRelativeDir}`;
-        const linkPath = `file:${parentRelativePath}`;
+        const linkPath = `file:${relativePath}`;
         /**
          * The rootRelativeDir is the package location in the monorepo. In the
          * isolate folder we keep the same structure so we can use the same

--- a/src/helpers/patch-workspace-entries.ts
+++ b/src/helpers/patch-workspace-entries.ts
@@ -24,9 +24,6 @@ export function patchWorkspaceEntries(
           ? path.relative(parentRootRelativeDir, def.rootRelativeDir)
           : def.rootRelativeDir;
 
-        log.warn("parentRootRelativeDir", parentRootRelativeDir);
-        log.warn("def.rootRelativeDir", def.rootRelativeDir);
-
         // const linkedPath = `file:${
         //   isPackageToIsolate || packageManager === "npm"
         //     ? def.rootRelativeDir

--- a/src/helpers/patch-workspace-entries.ts
+++ b/src/helpers/patch-workspace-entries.ts
@@ -17,26 +17,18 @@ export function patchWorkspaceEntries(
         const def = packagesRegistry[key];
 
         /**
-         * Some package managers seem to want a relative file:// link path when
-         * referring to own dependencies. Others want the absolute path (?).
+         * When nested shared dependencies are used (local deps linking to other
+         * local deps), the parentRootRelativeDir will be passed in, and we
+         * store the relative path to the isolate/packages directory, as is
+         * required by some package managers.
          */
         const relativePath = parentRootRelativeDir
-          ? path.relative(parentRootRelativeDir, def.rootRelativeDir)
-          : def.rootRelativeDir;
+          ? path.relative(parentRootRelativeDir, `./${def.rootRelativeDir}`)
+          : `./${def.rootRelativeDir}`;
 
-        // const linkedPath = `file:${
-        //   isPackageToIsolate || packageManager === "npm"
-        //     ? def.rootRelativeDir
-        //     : relativePath
-        // }`;
-
-        // const linkPath = `file:${def.rootRelativeDir}`;
         const linkPath = `file:${relativePath}`;
-        /**
-         * The rootRelativeDir is the package location in the monorepo. In the
-         * isolate folder we keep the same structure so we can use the same
-         * relative path.
-         */
+        // const linkPath = `file:${def.rootRelativeDir}`;
+
         log.debug(`Linking dependency ${key} to ${linkPath}`);
 
         return [key, linkPath];

--- a/src/helpers/process-build-output-files.ts
+++ b/src/helpers/process-build-output-files.ts
@@ -1,20 +1,17 @@
 import fs from "fs-extra";
 import path from "node:path";
-import { PackageManager } from "~/helpers";
 import { pack, unpack } from "~/utils";
 
 export async function processBuildOutputFiles({
   targetPackageDir,
   tmpDir,
-  packageManager,
   isolateDir,
 }: {
   targetPackageDir: string;
   tmpDir: string;
-  packageManager: PackageManager;
   isolateDir: string;
 }) {
-  const packedFilePath = await pack(targetPackageDir, tmpDir, packageManager);
+  const packedFilePath = await pack(targetPackageDir, tmpDir);
   const unpackDir = path.join(tmpDir, "target");
   await unpack(packedFilePath, unpackDir);
   await fs.copy(path.join(unpackDir, "package"), isolateDir);

--- a/src/helpers/process-lockfile.ts
+++ b/src/helpers/process-lockfile.ts
@@ -20,7 +20,7 @@ type PnpmLockfile = {
 };
 
 export function getLockfileFileName(packageManager: PackageManager) {
-  switch (packageManager) {
+  switch (packageManager.name) {
     case "pnpm":
       return "pnpm-lock.yaml";
     case "yarn":
@@ -60,7 +60,7 @@ export function processLockfile({
   const lockfileSrcPath = path.join(workspaceRootDir, fileName);
   const lockfileDstPath = path.join(isolateDir, fileName);
 
-  switch (packageManager) {
+  switch (packageManager.name) {
     /**
      * It seems that for Yarn v1 and NPM v3 lockfile the content is not
      * dependent on the workspace packages structure, so I am assuming we can

--- a/src/helpers/unpack-dependencies.ts
+++ b/src/helpers/unpack-dependencies.ts
@@ -1,7 +1,6 @@
 import fs from "fs-extra";
-import { dir } from "node:console";
-import path, { join } from "node:path";
-import { getIsolateRelativePath, getRootRelativePath } from "~/utils";
+import { join } from "node:path";
+import { getIsolateRelativePath } from "~/utils";
 import { createLogger } from "~/utils/logger";
 import { PackagesRegistry, getConfig } from ".";
 import { unpack } from "../utils/unpack";
@@ -13,9 +12,14 @@ export async function unpackDependencies(
   isolateDir: string
 ) {
   const log = createLogger(getConfig().logLevel);
+
+  // log.warn("packagesRegistry", JSON.stringify(packagesRegistry, null, 2));
+
   await Promise.all(
     Object.entries(packedFilesByName).map(async ([packageName, filePath]) => {
       const dir = packagesRegistry[packageName].rootRelativeDir;
+
+      log.warn("tmpDir, dir, filePath", tmpDir, dir, filePath);
 
       const unpackDir = join(tmpDir, dir);
 

--- a/src/helpers/unpack-dependencies.ts
+++ b/src/helpers/unpack-dependencies.ts
@@ -13,17 +13,11 @@ export async function unpackDependencies(
 ) {
   const log = createLogger(getConfig().logLevel);
 
-  // log.warn("packagesRegistry", JSON.stringify(packagesRegistry, null, 2));
-
   await Promise.all(
     Object.entries(packedFilesByName).map(async ([packageName, filePath]) => {
       const dir = packagesRegistry[packageName].rootRelativeDir;
-
-      log.warn("tmpDir, dir, filePath", tmpDir, dir, filePath);
-
       const unpackDir = join(tmpDir, dir);
 
-      // log.debug("Unpacking", path.basename(filePath));
       log.debug("Unpacking", filePath);
 
       await unpack(filePath, unpackDir);

--- a/src/index.ts
+++ b/src/index.ts
@@ -182,9 +182,7 @@ async function start() {
   );
   await fs.remove(tmpDir);
 
-  log.debug("Stored isolate output at", isolateDir);
-
-  log.info("Isolate completed");
+  log.info("Isolate completed at %s", isolateDir);
 }
 
 start().catch((err) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,6 @@
  */
 import fs from "fs-extra";
 import assert from "node:assert";
-import { exec } from "node:child_process";
 import path from "node:path";
 import sourceMaps from "source-map-support";
 import {
@@ -171,22 +170,6 @@ async function start() {
       isolateDir,
       packagesRegistry,
     });
-
-    if (packageManager.name === "npm") {
-      /**
-       * If there is an .npmrc file in the workspace root, copy it to the
-       * isolate because the settings there could affect how the lockfile is
-       * resolved.
-       *
-       * Also see https://github.com/npm/cli/issues/5113
-       */
-      const npmrcPath = path.join(workspaceRootDir, ".npmrc");
-
-      if (fs.existsSync(npmrcPath)) {
-        await fs.copyFileSync(npmrcPath, path.join(isolateDir, ".npmrc"));
-        log.debug("Copied .npmrc file to the isolate output");
-      }
-    }
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,14 +1,17 @@
 #!/usr/bin/env node
+/**
+ * For PNPM the hashbang at the top of the script was not required, but Yarn 3
+ * did not seem to execute without it.
+ */
 
 /**
  * A word about used terminology:
  *
  * The various package managers, while being very similar, seem to use a
- * different definition for the term "workspace". If you want to read the code it
- * might be good to know that I consider the workspace to be the monorepo itself,
- * in other words, the overall structure that holds all the packages.
+ * different definition for the term "workspace". If you want to read the code
+ * it might be good to know that I consider the workspace to be the monorepo
+ * itself, in other words, the overall structure that holds all the packages.
  */
-
 import fs from "fs-extra";
 import assert from "node:assert";
 import { exec } from "node:child_process";
@@ -171,38 +174,18 @@ async function start() {
 
     if (packageManager.name === "npm") {
       /**
-       * If there is an .npmrc file in the workspace root, copy it to the isolate
-       * because the settings there could affect how the lockfile is resolved.
+       * If there is an .npmrc file in the workspace root, copy it to the
+       * isolate because the settings there could affect how the lockfile is
+       * resolved.
        *
        * Also see https://github.com/npm/cli/issues/5113
        */
       const npmrcPath = path.join(workspaceRootDir, ".npmrc");
 
       if (fs.existsSync(npmrcPath)) {
-        log.warn("Copying .npmrc file to the isolate output");
         await fs.copyFileSync(npmrcPath, path.join(isolateDir, ".npmrc"));
+        log.debug("Copied .npmrc file to the isolate output");
       }
-
-      //   /**
-      //    * Shrinkwrap the package-lock.json file
-      //    */
-      //   log.debug("Running npm shrinkwrap");
-      //   const oldCwd = process.cwd();
-      //   process.chdir(isolateDir);
-
-      //   const stdout = await new Promise<string>((resolve, reject) => {
-      //     exec(`npm shrinkwrap`, (err, stdout) => {
-      //       if (err) {
-      //         return reject(err);
-      //       }
-
-      //       resolve(stdout);
-      //     });
-      //   });
-
-      //   log.debug(stdout);
-
-      //   process.chdir(oldCwd);
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,7 +89,7 @@ async function start() {
    * detected. We log it here because the pack function will be called
    * recursively.
    */
-  if (packageManager === "pnpm") {
+  if (packageManager.name === "pnpm") {
     log.debug("Using pnpm to pack dependencies");
   } else {
     log.debug("Using npm to pack dependencies");

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@
 
 import fs from "fs-extra";
 import assert from "node:assert";
+import { exec } from "node:child_process";
 import path from "node:path";
 import sourceMaps from "source-map-support";
 import {
@@ -86,14 +87,18 @@ async function start() {
     path.join(targetPackageDir, "package.json")
   );
 
-  const { name, version } = detectPackageManager(workspaceRootDir);
+  const packageManager = detectPackageManager(workspaceRootDir);
 
-  log.debug("Detected package manager", name, version);
+  log.debug(
+    "Detected package manager",
+    packageManager.name,
+    packageManager.version
+  );
 
   /**
    * Disable lock files for PNPM because they are not yet supported.
    */
-  if (name === "pnpm") {
+  if (packageManager.name === "pnpm") {
     config.excludeLockfile = true;
   }
 
@@ -163,6 +168,29 @@ async function start() {
       isolateDir,
       packagesRegistry,
     });
+
+    // if (packageManager.name === "npm") {
+    //   /**
+    //    * Shrinkwrap the package-lock.json file
+    //    */
+    //   log.debug("Running npm shrinkwrap");
+    //   const oldCwd = process.cwd();
+    //   process.chdir(isolateDir);
+
+    //   const stdout = await new Promise<string>((resolve, reject) => {
+    //     exec(`npm shrinkwrap`, (err, stdout) => {
+    //       if (err) {
+    //         return reject(err);
+    //       }
+
+    //       resolve(stdout);
+    //     });
+    //   });
+
+    //   log.debug(stdout);
+
+    //   process.chdir(oldCwd);
+    // }
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,6 +82,13 @@ async function start() {
   log.debug("Detected package manager", name, version);
 
   /**
+   * Disable lock files for PNPM because they are not yet supported.
+   */
+  if (name === "pnpm") {
+    config.excludeLockfile = true;
+  }
+
+  /**
    * Build a packages registry so we can find the workspace packages by name and
    * have access to their manifest files and relative paths.
    */

--- a/src/index.ts
+++ b/src/index.ts
@@ -169,28 +169,41 @@ async function start() {
       packagesRegistry,
     });
 
-    // if (packageManager.name === "npm") {
-    //   /**
-    //    * Shrinkwrap the package-lock.json file
-    //    */
-    //   log.debug("Running npm shrinkwrap");
-    //   const oldCwd = process.cwd();
-    //   process.chdir(isolateDir);
+    if (packageManager.name === "npm") {
+      /**
+       * If there is an .npmrc file in the workspace root, copy it to the isolate
+       * because the settings there could affect how the lockfile is resolved.
+       *
+       * Also see https://github.com/npm/cli/issues/5113
+       */
+      const npmrcPath = path.join(workspaceRootDir, ".npmrc");
 
-    //   const stdout = await new Promise<string>((resolve, reject) => {
-    //     exec(`npm shrinkwrap`, (err, stdout) => {
-    //       if (err) {
-    //         return reject(err);
-    //       }
+      if (fs.existsSync(npmrcPath)) {
+        log.warn("Copying .npmrc file to the isolate output");
+        await fs.copyFileSync(npmrcPath, path.join(isolateDir, ".npmrc"));
+      }
 
-    //       resolve(stdout);
-    //     });
-    //   });
+      //   /**
+      //    * Shrinkwrap the package-lock.json file
+      //    */
+      //   log.debug("Running npm shrinkwrap");
+      //   const oldCwd = process.cwd();
+      //   process.chdir(isolateDir);
 
-    //   log.debug(stdout);
+      //   const stdout = await new Promise<string>((resolve, reject) => {
+      //     exec(`npm shrinkwrap`, (err, stdout) => {
+      //       if (err) {
+      //         return reject(err);
+      //       }
 
-    //   process.chdir(oldCwd);
-    // }
+      //       resolve(stdout);
+      //     });
+      //   });
+
+      //   log.debug(stdout);
+
+      //   process.chdir(oldCwd);
+    }
   }
 
   /**

--- a/src/utils/json.ts
+++ b/src/utils/json.ts
@@ -1,4 +1,5 @@
 import fs from "fs-extra";
+import stripJsonComments from "strip-json-comments";
 import { getErrorMessage } from "./get-error-message";
 
 /**
@@ -7,7 +8,7 @@ import { getErrorMessage } from "./get-error-message";
 export function readTypedJsonSync<T>(filePath: string) {
   try {
     const rawContent = fs.readFileSync(filePath, "utf-8");
-    const data = JSON.parse(rawContent) as T;
+    const data = JSON.parse(stripJsonComments(rawContent)) as T;
     return data;
   } catch (err) {
     throw new Error(

--- a/src/utils/pack.ts
+++ b/src/utils/pack.ts
@@ -16,7 +16,7 @@ export async function pack(
    * PNPM pack seems to be a lot faster than NPM pack, so when PNPM is detected
    * we use that instead.
    */
-  switch (packageManager) {
+  switch (packageManager.name) {
     case "pnpm": {
       const stdout = await new Promise<string>((resolve, reject) => {
         exec(

--- a/src/utils/pack.ts
+++ b/src/utils/pack.ts
@@ -1,22 +1,20 @@
 import { exec } from "node:child_process";
 import path from "node:path";
-import { PackageManager, getConfig } from "~/helpers";
+import { getConfig, usePackageManager } from "~/helpers";
 import { createLogger } from "./logger";
 
-export async function pack(
-  srcDir: string,
-  destDir: string,
-  packageManager: PackageManager
-) {
+export async function pack(srcDir: string, destDir: string) {
   const log = createLogger(getConfig().logLevel);
   const cwd = process.cwd();
   process.chdir(srcDir);
+
+  const { name } = usePackageManager();
 
   /**
    * PNPM pack seems to be a lot faster than NPM pack, so when PNPM is detected
    * we use that instead.
    */
-  switch (packageManager.name) {
+  switch (name) {
     case "pnpm": {
       const stdout = await new Promise<string>((resolve, reject) => {
         exec(

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -4,8 +4,11 @@ export default defineConfig({
   entry: ["src/index.ts"],
   format: ["esm"],
   /**
-   * We need an mjs extension.
-   * See https://exploringjs.com/nodejs-shell-scripting/ch_creating-shell-scripts.html#node.js-esm-modules-as-standalone-shell-scripts-on-unix
+   * The `isolate` binary is an ES module. It is required to have the `.mjs`
+   * file extension, otherwise a non-ESM workspace will try to load it as
+   * commonJS. For details on this read [this article from Alex
+   * Rauschmayer](https://exploringjs.com/nodejs-shell-scripting/ch_creating-shell-scripts.html#node.*
+   * js-esm-modules-as-standalone-shell-scripts-on-unix)
    */
   outExtension() {
     return {


### PR DESCRIPTION
## Changes

* Use relative paths for all dependency file links. This fixes an issue with nested dependencies using Yarn #13. 
* Improve package manager detection logic.
* Introduce `usePackageManager` to avoid passing it as an argument in many functions.
* Update and improve the README. 
* Allow comments in the isolate.config.json file.
* Make excludeLockfile true by default when using PNPM, so that no configuration is needed until we figure out how to mutate the lockfile.
* Include the .npmrc file to the isolate output. This fixes a possible `npm ci` lockfile error for the Node 18 runtime.
* Include the npm-shrinkwrap.json file instead of the lockfile if available.

Fixes #13 
Closes #14 
Fixes #9 
