### PR TITLE
Increase exec max buffer size to support large amounts of files

### DIFF
--- a/src/utils/pack.ts
+++ b/src/utils/pack.ts
@@ -9,6 +9,10 @@ export async function pack(
   dstDir: string,
   usePnpmPack = false
 ) {
+  const execMaxBufferSize = {
+    maxBuffer: 10 * 1024 * 1024,
+  };
+
   const log = createLogger(getConfig().logLevel);
 
   const previousCwd = process.cwd();
@@ -22,6 +26,7 @@ export async function pack(
     ? await new Promise<string>((resolve, reject) => {
         exec(
           `pnpm pack --pack-destination ${dstDir}`,
+          execMaxBufferSize,
           (err, stdout, stderr) => {
             if (err) {
               log.error(stderr);
@@ -33,13 +38,17 @@ export async function pack(
         );
       })
     : await new Promise<string>((resolve, reject) => {
-        exec(`npm pack --pack-destination ${dstDir}`, (err, stdout) => {
-          if (err) {
-            return reject(err);
-          }
+        exec(
+          `npm pack --pack-destination ${dstDir}`,
+          execMaxBufferSize,
+          (err, stdout) => {
+            if (err) {
+              return reject(err);
+            }
 
-          resolve(stdout);
-        });
+            resolve(stdout);
+          }
+        );
       });
 
   const fileName = path.basename(stdout.trim());

--- a/src/utils/pack.ts
+++ b/src/utils/pack.ts
@@ -9,7 +9,7 @@ export async function pack(
   dstDir: string,
   usePnpmPack = false
 ) {
-  const execMaxBufferSize = {
+  const execOption = {
     maxBuffer: 10 * 1024 * 1024,
   };
 
@@ -26,7 +26,7 @@ export async function pack(
     ? await new Promise<string>((resolve, reject) => {
         exec(
           `pnpm pack --pack-destination ${dstDir}`,
-          execMaxBufferSize,
+          execOption,
           (err, stdout, stderr) => {
             if (err) {
               log.error(stderr);
@@ -40,7 +40,7 @@ export async function pack(
     : await new Promise<string>((resolve, reject) => {
         exec(
           `npm pack --pack-destination ${dstDir}`,
-          execMaxBufferSize,
+          execOption,
           (err, stdout) => {
             if (err) {
               return reject(err);

--- a/src/utils/pack.ts
+++ b/src/utils/pack.ts
@@ -9,7 +9,7 @@ export async function pack(
   dstDir: string,
   usePnpmPack = false
 ) {
-  const execOption = {
+  const execOptions = {
     maxBuffer: 10 * 1024 * 1024,
   };
 
@@ -26,7 +26,7 @@ export async function pack(
     ? await new Promise<string>((resolve, reject) => {
         exec(
           `pnpm pack --pack-destination ${dstDir}`,
-          execOption,
+          execOptions,
           (err, stdout, stderr) => {
             if (err) {
               log.error(stderr);
@@ -40,7 +40,7 @@ export async function pack(
     : await new Promise<string>((resolve, reject) => {
         exec(
           `npm pack --pack-destination ${dstDir}`,
-          execOption,
+          execOptions,
           (err, stdout) => {
             if (err) {
               return reject(err);


### PR DESCRIPTION
I'm going to build the nestjs app as isolate and use it in firebase deploy.

The following error occurs when executing isolation after nest build.

```
error RangeError: stderr maxBuffer length exceeded
    at new NodeError (node:internal/errors:372:5)
    at Socket.onChildStderr (node:child_process:485:14)
    at Socket.emit (node:events:527:28)
    at addChunk (node:internal/streams/readable:315:12)
    at readableAddChunk (node:internal/streams/readable:285:11)
    at Socket.Readable.push (node:internal/streams/readable:228:10)
    at Pipe.onStreamRead (node:internal/stream_base_commons:190:23) 
  ``` 
     //   Below is the log I captured while debugging:

``` 
Error: Error: Error: RangeError [ERR_CHILD_PROCESS_STDIO_MAXBUFFER]: stderr maxBuffer length exceeded
    at pack (file:///Users/gimsehun/Documents/PROJECT-main/node_modules/.pnpm/isolate-package@1.3.1/node_modules/isolate-package/src/utils/yaml.ts:15:7)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at processBuildOutputFiles (file:///Users/gimsehun/Documents/PROJECT-main/node_modules/.pnpm/isolate-package@1.3.1/node_modules/isolate-package/src/index.ts:76:3)
    at start (file:///Users/gimsehun/Documents/PROJECT-main/node_modules/.pnpm/isolate-package@1.3.1/node_modules/isolate-package/dist/index.mjs:768:3),[object Promise]
    at process.error (file:///Users/gimsehun/Documents/PROJECT-main/node_modules/.pnpm/isolate-package@1.3.1/node_modules/isolate-package/src/utils/pack.ts:3:8)
    at process.emit (node:events:527:28)
    at process.emit (/Users/gimsehun/Documents/PROJECT-main/node_modules/.pnpm/source-map-support@0.5.21/node_modules/source-map-support/source-map-support.js:516:21)
    at emit (node:internal/process/promises:140:20)
    at processPromiseRejections (node:internal/process/promises:274:27)
    at processTicksAndRejections (node:internal/process/task_queues:97:32)
 ``` 
 
 
 We have identified that the excessive number of src files is causing issues, so we have increased the maxBuffer size in exec to accommodate repositories with a large number of files. (200KB(Default) -> 10MB)
 
 
 After making this change and conducting tests, we have confirmed that the (JavaScript compiled) environment now compiles successfully!