### PR TITLE
add functionality to omit scripts section in package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,10 +413,10 @@ excluded for PNPM.
 
 ### A Partial Workaround
 
-If you can't use a lockfile, and you are worried about things breaking, 
-a partial workaround would be to declare 
-dependencies using exact versions in your manifest file. This doesn't prevent 
-your dependencies dependencies from installing newer versions, like a lockfile 
+If you can't use a lockfile, and you are worried about things breaking,
+a partial workaround would be to declare
+dependencies using exact versions in your manifest file. This doesn't prevent
+your dependencies dependencies from installing newer versions, like a lockfile
 would, but at least you minimize the risk of things breaking.
 
 ## Different Package Managers

--- a/src/helpers/config.ts
+++ b/src/helpers/config.ts
@@ -14,6 +14,7 @@ export type IsolateConfigResolved = {
   workspaceRoot: string;
   excludeLockfile: boolean;
   avoidPnpmPack: boolean;
+  omitScripts?: boolean;
 };
 
 export type IsolateConfig = Partial<IsolateConfigResolved>;
@@ -29,6 +30,7 @@ const configDefaults: IsolateConfigResolved = {
   workspaceRoot: "../..",
   excludeLockfile: false,
   avoidPnpmPack: false,
+  omitScripts: false,
 };
 
 /**

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -8,6 +8,7 @@ export * from "./find-packages-globs";
 export * from "./get-build-output-dir";
 export * from "./list-local-dependencies";
 export * from "./manifest";
+export * from "./omit-package-scripts";
 export * from "./pack-dependencies";
 export * from "./patch-workspace-entries";
 export * from "./process-build-output-files";

--- a/src/helpers/omit-package-scripts.ts
+++ b/src/helpers/omit-package-scripts.ts
@@ -1,0 +1,19 @@
+import { omit } from "lodash-es";
+import path from "node:path";
+import { readTypedJsonSync } from "~/utils";
+import { PackageManifest } from "./create-packages-registry";
+import fs from "fs-extra";
+
+export async function omitPackageScripts(isolateDir: string) {
+  const isolatePackageJsonPath = path.join(isolateDir, "package.json");
+  const packageManifest = readTypedJsonSync<PackageManifest>(
+    isolatePackageJsonPath
+  );
+
+  const outputManifest = omit(packageManifest, ["scripts"]);
+
+  await fs.writeFile(
+    isolatePackageJsonPath,
+    JSON.stringify(outputManifest, null, 2)
+  );
+}

--- a/src/utils/pack.ts
+++ b/src/utils/pack.ts
@@ -9,6 +9,10 @@ export async function pack(
   dstDir: string,
   usePnpmPack = false
 ) {
+  const execMaxBufferSize = {
+    maxBuffer: 10 * 1024 * 1024,
+  };
+
   const log = createLogger(getConfig().logLevel);
 
   const previousCwd = process.cwd();
@@ -22,6 +26,7 @@ export async function pack(
     ? await new Promise<string>((resolve, reject) => {
         exec(
           `pnpm pack --pack-destination ${dstDir}`,
+          execMaxBufferSize,
           (err, stdout, stderr) => {
             if (err) {
               log.error(stderr);
@@ -33,13 +38,17 @@ export async function pack(
         );
       })
     : await new Promise<string>((resolve, reject) => {
-        exec(`npm pack --pack-destination ${dstDir}`, (err, stdout) => {
-          if (err) {
-            return reject(err);
-          }
+        exec(
+          `npm pack --pack-destination ${dstDir}`,
+          execMaxBufferSize,
+          (err, stdout) => {
+            if (err) {
+              return reject(err);
+            }
 
-          resolve(stdout);
-        });
+            resolve(stdout);
+          }
+        );
       });
 
   const fileName = path.basename(stdout.trim());

--- a/src/utils/pack.ts
+++ b/src/utils/pack.ts
@@ -9,7 +9,7 @@ export async function pack(
   dstDir: string,
   usePnpmPack = false
 ) {
-  const execMaxBufferSize = {
+  const execOption = {
     maxBuffer: 10 * 1024 * 1024,
   };
 
@@ -26,7 +26,7 @@ export async function pack(
     ? await new Promise<string>((resolve, reject) => {
         exec(
           `pnpm pack --pack-destination ${dstDir}`,
-          execMaxBufferSize,
+          execOption,
           (err, stdout, stderr) => {
             if (err) {
               log.error(stderr);
@@ -40,7 +40,7 @@ export async function pack(
     : await new Promise<string>((resolve, reject) => {
         exec(
           `npm pack --pack-destination ${dstDir}`,
-          execMaxBufferSize,
+          execOption,
           (err, stdout) => {
             if (err) {
               return reject(err);

--- a/src/utils/pack.ts
+++ b/src/utils/pack.ts
@@ -9,7 +9,7 @@ export async function pack(
   dstDir: string,
   usePnpmPack = false
 ) {
-  const execOption = {
+  const execOptions = {
     maxBuffer: 10 * 1024 * 1024,
   };
 
@@ -26,7 +26,7 @@ export async function pack(
     ? await new Promise<string>((resolve, reject) => {
         exec(
           `pnpm pack --pack-destination ${dstDir}`,
-          execOption,
+          execOptions,
           (err, stdout, stderr) => {
             if (err) {
               log.error(stderr);
@@ -40,7 +40,7 @@ export async function pack(
     : await new Promise<string>((resolve, reject) => {
         exec(
           `npm pack --pack-destination ${dstDir}`,
-          execOption,
+          execOptions,
           (err, stdout) => {
             if (err) {
               return reject(err);


### PR DESCRIPTION
   Firebase Functions relies on the build script from package.json.
   However, Cloud Build only recognizes npm, not pnpm, leading to issues with
   commands like pnpm nest build. To resolve this, the script section from package.json
   is removed, as there is no need to rerun the script commands when the file, which
   should already be built and ready for deployment, is being deployed.
   
   Ensure smooth deployments in a pnpm environment by utilizing the omitScripts option to prevent issues during deployment.
   
   
============
 I am submitting this pull request due to the aforementioned issue. Currently, I am using a separately crafted "remove package script," but integrating it into isolate would be splendid as it would not only streamline the build step during a Firebase deploy but also add an additional feature to isolate!

Please consider the above matter! 😄 
   
   