### PR TITLE
Add support for NPM lockfiles

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "isolate-package",
-  "version": "1.5.2",
+  "version": "1.6.0-1",
   "description": "Isolate a monorepo package with its shared dependencies to form a self-contained directory, compatible with Firebase deploy",
   "author": "Thijs Koerselman",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "isolate-package",
-  "version": "1.6.0-1",
+  "version": "1.6.0-2",
   "description": "Isolate a monorepo package with its shared dependencies to form a self-contained directory, compatible with Firebase deploy",
   "author": "Thijs Koerselman",
   "license": "MIT",

--- a/src/helpers/generate-npm-lockfile.ts
+++ b/src/helpers/generate-npm-lockfile.ts
@@ -20,8 +20,9 @@ export async function generateNpmLockfile({
 }) {
   const log = useLogger();
 
+  log.debug("Generating NPM lockfile...");
+
   const internalPackageNames = Object.keys(packagesRegistry);
-  log.debug("Internal packages", internalPackageNames);
 
   const arborist = new Arborist({ path: targetPackageDir });
 

--- a/src/helpers/generate-npm-lockfile.ts
+++ b/src/helpers/generate-npm-lockfile.ts
@@ -10,27 +10,23 @@ import type { PackagesRegistry } from "./create-packages-registry";
  * non-descriptive errors and my patience and time for now is running out...
  */
 export async function generateNpmLockfile({
-  workspaceRootDir,
-  targetPackageName,
+  targetPackageDir,
   packagesRegistry,
   isolateDir,
 }: {
-  workspaceRootDir: string;
-  targetPackageName: string;
+  targetPackageDir: string;
   packagesRegistry: PackagesRegistry;
   isolateDir: string;
 }) {
   const log = useLogger();
 
-  log.warn("Generating NPM lockfile NOT IMPLEMENTED YET");
-
   const internalPackageNames = Object.keys(packagesRegistry);
   log.debug("Internal packages", internalPackageNames);
 
-  const arborist = new Arborist({ path: workspaceRootDir });
+  const arborist = new Arborist({ path: targetPackageDir });
 
   const { meta } = await arborist.buildIdealTree({
-    add: [targetPackageName, ...internalPackageNames],
+    rm: internalPackageNames,
   });
   meta?.commit();
 

--- a/src/helpers/generate-pnpm-lockfile.ts
+++ b/src/helpers/generate-pnpm-lockfile.ts
@@ -27,13 +27,13 @@ export async function generatePnpmLockfile({
   const { includeDevDependencies } = useConfig();
   const log = useLogger();
 
-  log.debug("Generating PNPM lockfile");
+  log.debug("Generating PNPM lockfile...");
 
   const lockfile = await readWantedLockfile(workspaceRootDir, {
     ignoreIncompatible: false,
   });
 
-  assert(lockfile, "No lockfile found");
+  assert(lockfile, `No input lockfile found at ${workspaceRootDir}`);
 
   const targetImporterId = getLockfileImporterId(
     workspaceRootDir,

--- a/src/helpers/process-lockfile.ts
+++ b/src/helpers/process-lockfile.ts
@@ -87,39 +87,20 @@ export async function processLockfile({
 
   const fileName = getLockfileFileName(name);
 
-  const lockfileSrcPath = path.join(workspaceRootDir, fileName);
-  const lockfileDstPath = path.join(isolateDir, fileName);
-
   switch (name) {
     case "npm": {
-      /** If there is a shrinkwrap file we copy that instead of the lockfile */
-      const shrinkwrapSrcPath = path.join(
-        workspaceRootDir,
-        "npm-shrinkwrap.json"
-      );
-      const shrinkwrapDstPath = path.join(isolateDir, "npm-shrinkwrap.json");
-
-      if (fs.existsSync(shrinkwrapSrcPath)) {
-        fs.copyFileSync(shrinkwrapSrcPath, shrinkwrapDstPath);
-        log.debug("Copied shrinkwrap to", shrinkwrapDstPath);
-      } else {
-        fs.copyFileSync(lockfileSrcPath, lockfileDstPath);
-        log.debug("Copied lockfile to", lockfileDstPath);
-      }
-
-      if (false) {
-        /** Generate the lockfile */
-        await generateNpmLockfile({
-          workspaceRootDir,
-          targetPackageName,
-          isolateDir,
-          packagesRegistry,
-        });
-      }
+      await generateNpmLockfile({
+        targetPackageDir,
+        isolateDir,
+        packagesRegistry,
+      });
 
       break;
     }
     case "yarn": {
+      const lockfileSrcPath = path.join(workspaceRootDir, fileName);
+      const lockfileDstPath = path.join(isolateDir, fileName);
+
       fs.copyFileSync(lockfileSrcPath, lockfileDstPath);
       log.debug("Copied lockfile to", lockfileDstPath);
       break;

--- a/src/helpers/process-lockfile.ts
+++ b/src/helpers/process-lockfile.ts
@@ -72,7 +72,6 @@ export async function processLockfile({
   isolateDir,
   internalDepPackageNames,
   targetPackageDir,
-  targetPackageName,
 }: {
   workspaceRootDir: string;
   packagesRegistry: PackagesRegistry;

--- a/src/isolate.ts
+++ b/src/isolate.ts
@@ -173,11 +173,11 @@ export async function isolate(
 
   /**
    * If the user has not explicitly set the excludeLockfile option, we will
-   * exclude the lockfile for NPM and Yarn, because we still need to figure out
-   * how to generate the lockfile for those package managers.
+   * exclude the lockfile for Yarn, because we still need to figure out how to
+   * generate the isolated lockfile for it.
    */
   if (!isDefined(userDefinedConfig.excludeLockfile)) {
-    if (packageManager.name === "npm" || packageManager.name === "yarn") {
+    if (packageManager.name === "yarn") {
       config.excludeLockfile = true;
     }
   }
@@ -236,5 +236,3 @@ export async function isolate(
 
   return isolateDir;
 }
-
-// process.on("unhandledRejection", log.error);


### PR DESCRIPTION
Adds support for generating an isolated lockfiles based on the contents of the currently installed node_modules. This effectively creates the lockfile based on the current root lockfile.