### PR TITLE
Generate npm lockfile based on installed modules

### DIFF
--- a/src/isolate.ts
+++ b/src/isolate.ts
@@ -201,7 +201,6 @@ export async function isolate(
      * or file: specifiers. It requires the directory to be configured as a
      * workspace, so we copy the workspace config file to the isolate output.
      */
-
     fs.copyFileSync(
       path.join(workspaceRootDir, "pnpm-workspace.yaml"),
       path.join(isolateDir, "pnpm-workspace.yaml")

--- a/src/lib/lockfile/process-lockfile.ts
+++ b/src/lib/lockfile/process-lockfile.ts
@@ -77,7 +77,9 @@ export async function processLockfile({
   switch (name) {
     case "npm": {
       await generateNpmLockfile({
+        workspaceRootDir,
         isolateDir,
+        packagesRegistry,
       });
 
       break;


### PR DESCRIPTION
This fixes the NPM lockfile generation by using the installed node_modulues from the root of the monorepo. It moves them temporarily into the isolate output, before generating the lockfile and moving them back to the root.