### PR TITLE
Set package manager version on NPM fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "isolate-package",
-  "version": "1.9.1-0",
+  "version": "1.9.1-1",
   "description": "Isolate a monorepo package with its shared dependencies to form a self-contained directory, compatible with Firebase deploy",
   "author": "Thijs Koerselman",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "isolate-package",
-  "version": "1.9.1-1",
+  "version": "1.9.0",
   "description": "Isolate a monorepo package with its shared dependencies to form a self-contained directory, compatible with Firebase deploy",
   "author": "Thijs Koerselman",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "isolate-package",
-  "version": "1.9.0",
+  "version": "1.9.1-0",
   "description": "Isolate a monorepo package with its shared dependencies to form a self-contained directory, compatible with Firebase deploy",
   "author": "Thijs Koerselman",
   "license": "MIT",

--- a/src/isolate.ts
+++ b/src/isolate.ts
@@ -177,16 +177,12 @@ export async function isolate(
      * When we fall back to NPM, we set the manifest package manager to the
      * available NPM version.
      */
-    const inputManifest = await readManifest(isolateDir);
+    const manifest = await readManifest(isolateDir);
 
-    const systemNpmVersion = getVersion("npm");
+    const npmVersion = getVersion("npm");
+    manifest.packageManager = `npm@${npmVersion}`;
 
-    const outputManifest = {
-      ...inputManifest,
-      packageManager: systemNpmVersion,
-    };
-
-    await writeManifest(isolateDir, outputManifest);
+    await writeManifest(isolateDir, manifest);
   }
 
   if (packageManager.name === "pnpm" && !config.forceNpm) {

--- a/src/isolate.ts
+++ b/src/isolate.ts
@@ -1,7 +1,6 @@
 import fs from "fs-extra";
 import assert from "node:assert";
 import path from "node:path";
-import { omit } from "ramda";
 import type { IsolateConfig } from "./lib/config";
 import { resolveConfig, setUserConfig } from "./lib/config";
 import { processLockfile } from "./lib/lockfile";
@@ -20,6 +19,7 @@ import {
   unpackDependencies,
 } from "./lib/output";
 import { detectPackageManager } from "./lib/package-manager";
+import { getVersion } from "./lib/package-manager/helpers/infer-from-files";
 import { createPackagesRegistry, listInternalPackages } from "./lib/registry";
 import type { PackageManifest } from "./lib/types";
 import { getDirname, getRootRelativePath, readTypedJson } from "./lib/utils";
@@ -174,13 +174,17 @@ export async function isolate(
 
   if (usedFallbackToNpm) {
     /**
-     * When we fall back to NPM, we strip the package manager declaration from
-     * the manifest, so the default NPM version from the host environment can be
-     * used.
+     * When we fall back to NPM, we set the manifest package manager to the
+     * available NPM version.
      */
     const inputManifest = await readManifest(isolateDir);
 
-    const outputManifest = omit(["packageManager"], inputManifest);
+    const systemNpmVersion = getVersion("npm");
+
+    const outputManifest = {
+      ...inputManifest,
+      packageManager: systemNpmVersion,
+    };
 
     await writeManifest(isolateDir, outputManifest);
   }

--- a/src/lib/lockfile/helpers/generate-npm-lockfile.ts
+++ b/src/lib/lockfile/helpers/generate-npm-lockfile.ts
@@ -42,7 +42,6 @@ export async function generateNpmLockfile({
     log.debug(`Build tree`);
     const { meta } = await arborist.buildIdealTree();
 
-    log.debug(`Commit tree`);
     meta?.commit();
 
     const lockfilePath = path.join(isolateDir, "package-lock.json");

--- a/src/lib/package-manager/helpers/infer-from-files.ts
+++ b/src/lib/package-manager/helpers/infer-from-files.ts
@@ -20,7 +20,8 @@ export function inferFromFiles(workspaceRoot: string): PackageManager {
 
   throw new Error(`Failed to detect package manager`);
 }
-function getVersion(packageManagerName: PackageManagerName): string {
+
+export function getVersion(packageManagerName: PackageManagerName): string {
   const buffer = execSync(`${packageManagerName} --version`);
   return buffer.toString().trim();
 }


### PR DESCRIPTION
Set the available npm version as the packageManager field in the manifest when falling back to NPM. This is required for deployment environments that require the field to be present, like the current firebase-tools deploy.