### PR TITLE
Support parsing jsonc and json with trailing comas

### DIFF
--- a/src/lib/utils/json.ts
+++ b/src/lib/utils/json.ts
@@ -6,7 +6,7 @@ import { getErrorMessage } from "./get-error-message";
 export function readTypedJsonSync<T>(filePath: string) {
   try {
     const rawContent = fs.readFileSync(filePath, "utf-8");
-    const data = JSON.parse(stripJsonComments(rawContent)) as T;
+    const data = JSON.parse(stripJsonComments(rawContent, { trailingCommas: true })) as T;
     return data;
   } catch (err) {
     throw new Error(
@@ -18,7 +18,7 @@ export function readTypedJsonSync<T>(filePath: string) {
 export async function readTypedJson<T>(filePath: string) {
   try {
     const rawContent = await fs.readFile(filePath, "utf-8");
-    const data = JSON.parse(rawContent) as T;
+    const data = JSON.parse(stripJsonComments(rawContent, { trailingCommas: true })) as T;
     return data;
   } catch (err) {
     throw new Error(


### PR DESCRIPTION
Recently prettier [started adding trailing `,` to tsconfig.json](https://github.com/prettier/prettier/issues/15942). This resulted in breaking the workflow for many project. So lets support it.

`JSON.parse(jsonWithTrailingComa) ---> error`

Error:
```
Error: Failed to read JSON from /Users/vajahathahmed/Projects/mono/out/apps/functions/tsconfig.json: Unexpected token } in JSON at position 151
    at readTypedJson (file:///Users/vajahathahmed/Projects/mono/out/node_modules/.pnpm/isolate-package@1.10.1/node_modules/isolate-package/src/lib/utils/pack.ts:1:10)
    at getBuildOutputDir (file:///Users/vajahathahmed/Projects/mono/out/node_modules/.pnpm/isolate-package@1.10.1/node_modules/isolate-package/src/lib/output/get-build-output-dir.ts:33:8)
    at isolate (file:///Users/vajahathahmed/Projects/mono/out/node_modules/.pnpm/isolate-package@1.10.1/node_modules/isolate-package/src/isolate.ts:78:5)
    at run (file:///Users/vajahathahmed/Projects/mono/out/node_modules/.pnpm/isolate-package@1.10.1/node_modules/isolate-package/src/isolate-bin.ts:17:5)
```

Generally tools should support jsonc.

This PR fixes it via https://github.com/sindresorhus/strip-json-comments?tab=readme-ov-file#trailingcommas