### PR TITLE
Prune pnpm lockfile before writing to disk

### DIFF
--- a/src/isolate.ts
+++ b/src/isolate.ts
@@ -156,12 +156,13 @@ export async function isolate(
    * Copy the target manifest file to the isolate location and adapt its
    * workspace dependencies to point to the isolated packages.
    */
-  await adaptTargetPackageManifest({
+  const outputManifest = await adaptTargetPackageManifest({
     manifest: targetPackageManifest,
     packagesRegistry,
-    isolateDir,
     workspaceRootDir,
   });
+
+  await writeManifest(isolateDir, outputManifest);
 
   /** Generate an isolated lockfile based on the original one */
   const usedFallbackToNpm = await processLockfile({
@@ -171,6 +172,7 @@ export async function isolate(
     internalDepPackageNames: internalPackageNames,
     targetPackageDir,
     targetPackageName: targetPackageManifest.name,
+    targetPackageManifest: outputManifest,
   });
 
   if (usedFallbackToNpm) {

--- a/src/lib/lockfile/process-lockfile.ts
+++ b/src/lib/lockfile/process-lockfile.ts
@@ -1,7 +1,7 @@
 import { useConfig } from "../config";
 import { useLogger } from "../logger";
 import { usePackageManager } from "../package-manager";
-import type { PackagesRegistry } from "../types";
+import type { PackageManifest, PackagesRegistry } from "../types";
 import {
   generateNpmLockfile,
   generatePnpmLockfile,
@@ -21,6 +21,7 @@ export async function processLockfile({
   isolateDir,
   internalDepPackageNames,
   targetPackageDir,
+  targetPackageManifest,
 }: {
   workspaceRootDir: string;
   packagesRegistry: PackagesRegistry;
@@ -28,6 +29,7 @@ export async function processLockfile({
   internalDepPackageNames: string[];
   targetPackageDir: string;
   targetPackageName: string;
+  targetPackageManifest: PackageManifest;
 }) {
   const log = useLogger();
 
@@ -86,6 +88,7 @@ export async function processLockfile({
         isolateDir,
         internalDepPackageNames,
         packagesRegistry,
+        targetPackageManifest,
       });
       break;
     }

--- a/src/lib/manifest/adapt-target-package-manifest.ts
+++ b/src/lib/manifest/adapt-target-package-manifest.ts
@@ -3,7 +3,6 @@ import { useConfig } from "../config";
 import { usePackageManager } from "../package-manager";
 import type { PackageManifest, PackagesRegistry } from "../types";
 import { adaptManifestInternalDeps, adoptPnpmFieldsFromRoot } from "./helpers";
-import { writeManifest } from "./io";
 
 /**
  * Adapt the output package manifest, so that:
@@ -15,12 +14,10 @@ import { writeManifest } from "./io";
 export async function adaptTargetPackageManifest({
   manifest,
   packagesRegistry,
-  isolateDir,
   workspaceRootDir,
 }: {
   manifest: PackageManifest;
   packagesRegistry: PackagesRegistry;
-  isolateDir: string;
   workspaceRootDir: string;
 }) {
   const packageManager = usePackageManager();
@@ -46,7 +43,7 @@ export async function adaptTargetPackageManifest({
           packagesRegistry,
         });
 
-  const outputManifest = {
+  return {
     ...adaptedManifest,
     /**
      * Scripts are removed by default if not explicitly picked or omitted via
@@ -58,6 +55,4 @@ export async function adaptTargetPackageManifest({
         ? omit(manifest.scripts ?? {}, omitFromScripts)
         : undefined,
   };
-
-  await writeManifest(isolateDir, outputManifest);
 }


### PR DESCRIPTION
Call the `@pnpm/prune-lockfile` function before writing the adapted lockfile to disk. While not being installed, all of the packages were still listed in the lockfile. This step removes anything that's not necessary.