### PR TITLE
Codebase support

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -85,12 +85,14 @@ export function resolveConfig(): IsolateConfigResolved {
   } else {
     log.debug(`Attempting to load config from ${configFilePath}`);
 
+    const fallbackUserConfig = process.env.NO_ISOLATE_CONFIG_CACHE ? undefined : {};
+
     _user_defined_config = fs.existsSync(configFilePath)
       ? readTypedJsonSync<IsolateConfig>(configFilePath)
-      : {};
+      : fallbackUserConfig;
   }
 
-  const foreignKeys = Object.keys(_user_defined_config).filter(
+  const foreignKeys = Object.keys(_user_defined_config || {}).filter(
     (key) => !validConfigKeys.includes(key)
   );
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -70,7 +70,7 @@ export function useConfig() {
  * called before this, it does not attempt to read a config file from disk.
  */
 export function resolveConfig(): IsolateConfigResolved {
-  if (_resolvedConfig) {
+  if (_resolvedConfig && !process.env.NO_ISOLATE_CONFIG_CACHE) {
     return _resolvedConfig;
   }
 


### PR DESCRIPTION
See [the PR](https://github.com/0x80/firebase-tools-with-isolate/pull/4) on `firebase-tools-with-isolate` for context, but basically this PR allows for switching the library into "no-cache" mode so that repeated calls to `isolate()` don't reuse the state config, which is a problem when I use firebase codebases. Setting `process.env.NO_ISOLATE_CONFIG_CACHE` to a truthy value switches this mode on.