### PR TITLE
Add config option to omit packageManager field

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@
   - [Use a flat structure inside your packages folders](#use-a-flat-structure-inside-your-packages-folders)
 - [Configuration Options](#configuration-options)
   - [logLevel](#loglevel)
-  - [forceNpm](#forcenpm)
   - [buildDirName](#builddirname)
   - [includeDevDependencies](#includedevdependencies)
   - [pickFromScripts](#pickfromscripts)
   - [omitFromScripts](#omitfromscripts)
+  - [omitPackageManager](#omitpackagemanager)
   - [isolateDirName](#isolatedirname)
   - [targetPackagePath](#targetpackagepath)
   - [tsconfigPath](#tsconfigpath)
@@ -244,6 +244,15 @@ you want to preserve all of the other scripts, set it to `["build"]`.
 
 By default, all scripts are omitted, and the [pickFromScripts](#pickfromscripts)
 configuration overrules this configuration.
+
+### omitPackageManager
+
+Type: `boolean`, default: `false`
+
+By default the packageManager field from the root manifest is copied to the
+target manifest. I have found that some platforms (Cloud Run, April 2024) can
+fail on this for some reason. This option allows you to omit the field from the
+isolated package manifest.
 
 ### isolateDirName
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -18,6 +18,7 @@ export type IsolateConfigResolved = {
   forceNpm: boolean;
   pickFromScripts?: string[];
   omitFromScripts?: string[];
+  omitPackageManager?: boolean;
 };
 
 export type IsolateConfig = Partial<IsolateConfigResolved>;
@@ -35,6 +36,7 @@ const configDefaults: IsolateConfigResolved = {
   forceNpm: false,
   pickFromScripts: undefined,
   omitFromScripts: undefined,
+  omitPackageManager: false,
 };
 
 /**

--- a/src/lib/manifest/adapt-target-package-manifest.ts
+++ b/src/lib/manifest/adapt-target-package-manifest.ts
@@ -21,8 +21,12 @@ export async function adaptTargetPackageManifest({
   workspaceRootDir: string;
 }) {
   const packageManager = usePackageManager();
-  const { includeDevDependencies, pickFromScripts, omitFromScripts } =
-    useConfig();
+  const {
+    includeDevDependencies,
+    pickFromScripts,
+    omitFromScripts,
+    omitPackageManager,
+  } = useConfig();
 
   /** Dev dependencies are omitted by default */
   const inputManifest = includeDevDependencies
@@ -45,8 +49,14 @@ export async function adaptTargetPackageManifest({
 
   return {
     ...adaptedManifest,
-    /** Adopt the package manager definition from the root manifest if available. */
-    packageManager: packageManager.packageManagerString,
+    /**
+     * Adopt the package manager definition from the root manifest if available.
+     * The option to omit is there because some platforms might not handle it
+     * properly (Cloud Run, April 24th 2024, does not handle pnpm v9)
+     */
+    packageManager: omitPackageManager
+      ? undefined
+      : packageManager.packageManagerString,
     /**
      * Scripts are removed by default if not explicitly picked or omitted via
      * config.


### PR DESCRIPTION
By default the packageManager field from the root manifest is copied to the target manifest. I have found that some platforms (Cloud Run, April 2024) can fail on this for some reason. This option allows you to omit the field from the isolated package manifest.