### PR TITLE
Fix relative link paths in pnpm lockfile

### DIFF
--- a/src/lib/lockfile/helpers/generate-pnpm-lockfile.ts
+++ b/src/lib/lockfile/helpers/generate-pnpm-lockfile.ts
@@ -118,7 +118,7 @@ export async function generatePnpmLockfile({
 
           return [
             ".",
-            pnpmMapImporter(importer, {
+            pnpmMapImporter(".", importer, {
               includeDevDependencies,
               includePatchedDependencies,
               directoryByPackageName,
@@ -130,7 +130,7 @@ export async function generatePnpmLockfile({
 
         return [
           importerId,
-          pnpmMapImporter(importer, {
+          pnpmMapImporter(importerId, importer, {
             includeDevDependencies,
             includePatchedDependencies,
             directoryByPackageName,


### PR DESCRIPTION
#### Problem Breakdown
Right now, if you have a monorepo setup with an internal dependency depending on another internal package, the generated `pnpm-lock.yaml` file does not resolve the paths correctly.

Let's say we have a dependency tree like this.
`@package/to-be-isolated` (located at `packages/to-be-isolated`) -> `@package/first` (located at `packages/first`) -> `@package/second` (located at `packages/second`)
The expected `pnpm-lock.yaml` content is
```yaml
importers:

  .:
    dependencies:
      '@package/first':
        specifier: workspace:*
        version: link:./packages/first

  packages/first:
    dependencies:
      '@package/second':
        specifier: workspace:*
        version: link:../second

  packages/second: {}
```

However, the actual output is
```yaml
importers:

  .:
    dependencies:
      '@package/first':
        specifier: workspace:*
        version: link:./packages/first

  packages/first:
    dependencies:
      '@package/second':
        specifier: workspace:*
        version: link:./packages/second # <-THIS IS INCORRECT

  packages/second: {}
```