### PR TITLE
Add basic support for Bun package manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ integrated, check out [mono-ts](https://github.com/0x80/mono-ts)
   deployments.
 - Preserve packages file structure, without code bundling
 - Should work with any package manager, and tested with NPM, PNPM, and Yarn
-  (both classic and modern).
+  (both classic and modern)
   - There is partial support for Bun - the process will detect the Bun package manager but will not output a Bun lockfile for the isolated package; instead it will fall back to generating an NPM lockfile.
 - Zero-config for the vast majority of use-cases
 - Isolates dependencies recursively. If package A depends on internal package B

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ integrated, check out [mono-ts](https://github.com/0x80/mono-ts)
   deployments.
 - Preserve packages file structure, without code bundling
 - Should work with any package manager, and tested with NPM, PNPM, and Yarn
-  (both classic and modern)
+  (both classic and modern).
+  - There is partial support for Bun - the process will detect the Bun package manager but will not output a Bun lockfile for the isolated package; instead it will fall back to generating an NPM lockfile.
 - Zero-config for the vast majority of use-cases
 - Isolates dependencies recursively. If package A depends on internal package B
   which depends on internal package C, all of them will be included

--- a/src/lib/lockfile/process-lockfile.ts
+++ b/src/lib/lockfile/process-lockfile.ts
@@ -77,6 +77,16 @@ export async function processLockfile({
       });
       break;
     }
+    case "bun": {
+      log.warn(`Ouput lockfiles for Bun are not yet supported. Using NPM for output`);
+      await generateNpmLockfile({
+        workspaceRootDir,
+        isolateDir,
+      });
+
+      usedFallbackToNpm = true;
+      break;
+    }
     default:
       log.warn(`Unexpected package manager ${name}. Using NPM for output`);
       await generateNpmLockfile({

--- a/src/lib/lockfile/process-lockfile.ts
+++ b/src/lib/lockfile/process-lockfile.ts
@@ -78,7 +78,9 @@ export async function processLockfile({
       break;
     }
     case "bun": {
-      log.warn(`Ouput lockfiles for Bun are not yet supported. Using NPM for output`);
+      log.warn(
+        `Ouput lockfiles for Bun are not yet supported. Using NPM for output`
+      );
       await generateNpmLockfile({
         workspaceRootDir,
         isolateDir,

--- a/src/lib/package-manager/names.ts
+++ b/src/lib/package-manager/names.ts
@@ -1,4 +1,4 @@
-export const supportedPackageManagerNames = ["pnpm", "yarn", "npm"] as const;
+export const supportedPackageManagerNames = ["pnpm", "yarn", "npm", "bun"] as const;
 
 export type PackageManagerName = (typeof supportedPackageManagerNames)[number];
 
@@ -11,6 +11,8 @@ export type PackageManager = {
 
 export function getLockfileFileName(name: PackageManagerName) {
   switch (name) {
+    case "bun":
+      return "bun.lockb";
     case "pnpm":
       return "pnpm-lock.yaml";
     case "yarn":

--- a/src/lib/package-manager/names.ts
+++ b/src/lib/package-manager/names.ts
@@ -1,4 +1,9 @@
-export const supportedPackageManagerNames = ["pnpm", "yarn", "npm", "bun"] as const;
+export const supportedPackageManagerNames = [
+  "pnpm",
+  "yarn",
+  "npm",
+  "bun",
+] as const;
 
 export type PackageManagerName = (typeof supportedPackageManagerNames)[number];
 

--- a/src/lib/registry/helpers/find-packages-globs.ts
+++ b/src/lib/registry/helpers/find-packages-globs.ts
@@ -27,6 +27,7 @@ export function findPackagesGlobs(workspaceRootDir: string) {
       log.debug("Detected pnpm packages globs:", inspectValue(globs));
       return globs;
     }
+    case "bun":
     case "yarn":
     case "npm": {
       const workspaceRootManifestPath = path.join(


### PR DESCRIPTION
Hello, I was able to successfully isolate and deploy a Firebase Functions project inside a Bun (v1.1.20) workspace by making these changes to `isolate-package`. The output lockfile falls back to NPM - which is fine for Firebase Functions, since I don't think Bun is supported anyway.