### PR TITLE
Fix for Windows Git Bash w/ pnpm

### DIFF
--- a/src/lib/lockfile/helpers/generate-pnpm-lockfile.ts
+++ b/src/lib/lockfile/helpers/generate-pnpm-lockfile.ts
@@ -95,12 +95,11 @@ export async function generatePnpmLockfile({
        * Split the path by the OS separator and join it back with the POSIX
        * separator.
        *
-       * The importerIds are built from directory names, so Windows Git
-       * Bash environments will have double backslashes in their ids:
-       *   packages\\common  vs.  packages/common
-       * Without this split & join, any packages not on the top-level will
-       * have ill-formatted importerIds and their entries will be missing
-       * from the lockfile.importers list.
+       * The importerIds are built from directory names, so Windows Git Bash
+       * environments will have double backslashes in their ids:
+       * "packages\common" vs. "packages/common". Without this split & join, any
+       * packages not on the top-level will have ill-formatted importerIds and
+       * their entries will be missing from the lockfile.importers list.
        */
     ].map((x) => x.split(path.sep).join(path.posix.sep));
 

--- a/src/lib/lockfile/helpers/generate-pnpm-lockfile.ts
+++ b/src/lib/lockfile/helpers/generate-pnpm-lockfile.ts
@@ -91,7 +91,18 @@ export async function generatePnpmLockfile({
        * importer ids in the context of a lockfile.
        */
       ...Object.values(directoryByPackageName),
-    ];
+      /**
+       * Split the path by the OS separator and join it back with the POSIX
+       * separator.
+       *
+       * The importerIds are built from directory names, so Windows Git
+       * Bash environments will have double backslashes in their ids:
+       *   packages\\common  vs.  packages/common
+       * Without this split & join, any packages not on the top-level will
+       * have ill-formatted importerIds and their entries will be missing
+       * from the lockfile.importers list.
+       */
+    ].map((x) => x.split(path.sep).join(path.posix.sep));
 
     log.debug("Relevant importer ids:", relevantImporterIds);
 

--- a/src/lib/lockfile/helpers/pnpm-map-importer.ts
+++ b/src/lib/lockfile/helpers/pnpm-map-importer.ts
@@ -50,11 +50,9 @@ function pnpmMapDependenciesLinks(
     }
 
     // Replace backslashes with forward slashes to support Windows Git Bash
-    const relativePath = path.relative(
-      importerPath,
-      directoryByPackageName[key]
-    ).replace(path.sep, path.posix.sep);
-
+    const relativePath = path
+      .relative(importerPath, directoryByPackageName[key])
+      .replace(path.sep, path.posix.sep);
 
     return relativePath.startsWith(".")
       ? `link:${relativePath}`

--- a/src/lib/lockfile/helpers/pnpm-map-importer.ts
+++ b/src/lib/lockfile/helpers/pnpm-map-importer.ts
@@ -49,10 +49,12 @@ function pnpmMapDependenciesLinks(
       return value;
     }
 
+    // Replace backslashes with forward slashes to support Windows Git Bash
     const relativePath = path.relative(
       importerPath,
       directoryByPackageName[key]
-    );
+    ).replace(path.sep, path.posix.sep);
+
 
     return relativePath.startsWith(".")
       ? `link:${relativePath}`


### PR DESCRIPTION
I want to say upfront that this tool is fantastic, and so is the typescript mono repo example.  I was able to finally restructure my mono-repo the way I've been hoping to and remove all my home-grown firebase publishing hacks.  

This PR addresses problems I had with "packages/common" in a Windows git bash environment using pnpm.  Naturally, both changes have to do with forward vs back slashes.

