### PR TITLE
Update bun lock file name

### DIFF
--- a/src/lib/package-manager/names.ts
+++ b/src/lib/package-manager/names.ts
@@ -17,7 +17,7 @@ export type PackageManager = {
 export function getLockfileFileName(name: PackageManagerName) {
   switch (name) {
     case "bun":
-      return "bun.lockb";
+      return "bun.lock";
     case "pnpm":
       return "pnpm-lock.yaml";
     case "yarn":


### PR DESCRIPTION
Since bun 1.2 a text based lock file is the default: https://bun.sh/blog/bun-v1.2#problems-with-bun-lockb