### PR TITLE
Prevent empty pnpm-workspace file

### DIFF
--- a/src/lib/registry/helpers/find-packages-globs.ts
+++ b/src/lib/registry/helpers/find-packages-globs.ts
@@ -20,9 +20,17 @@ export function findPackagesGlobs(workspaceRootDir: string) {
 
   switch (packageManager.name) {
     case "pnpm": {
-      const { packages: globs } = readTypedYamlSync<{ packages: string[] }>(
+      const workspaceConfig = readTypedYamlSync<{ packages: string[] }>(
         path.join(workspaceRootDir, "pnpm-workspace.yaml")
       );
+
+      if (!workspaceConfig) {
+        throw new Error(
+          "pnpm-workspace.yaml file is empty. Please specify packages configuration."
+        );
+      }
+
+      const { packages: globs } = workspaceConfig;
 
       log.debug("Detected pnpm packages globs:", inspectValue(globs));
       return globs;


### PR DESCRIPTION
Throw a specific error when `pnpm-workspace.yaml` is empty to prevent a `TypeError`. Fixes #83 