### PR TITLE
Fix pnpm workspace validation bug

### DIFF
--- a/src/lib/registry/helpers/find-packages-globs.ts
+++ b/src/lib/registry/helpers/find-packages-globs.ts
@@ -30,6 +30,11 @@ export function findPackagesGlobs(workspaceRootDir: string) {
         );
       }
 
+      assert(
+        workspaceConfig.packages,
+        "packages property must be defined in pnpm-workspace.yaml"
+      );
+
       const { packages: globs } = workspaceConfig;
 
       log.debug("Detected pnpm packages globs:", inspectValue(globs));


### PR DESCRIPTION
Add validation for the `packages` property in `pnpm-workspace.yaml` to prevent `undefined` globs and ensure consistent error handling.