### PR TITLE
Only validate package fields for internal packages

### DIFF
--- a/src/isolate.ts
+++ b/src/isolate.ts
@@ -10,8 +10,8 @@ import {
   adaptInternalPackageManifests,
   adaptTargetPackageManifest,
   readManifest,
-  writeManifest,
   validateManifestMandatoryFields,
+  writeManifest,
 } from "./lib/manifest";
 import {
   getBuildOutputDir,
@@ -132,6 +132,15 @@ export function createIsolator(config?: IsolateConfig) {
         includeDevDependencies: config.includeDevDependencies,
       }
     );
+
+    /** Validate mandatory fields for all internal packages that will be isolated */
+    for (const packageName of internalPackageNames) {
+      const packageDef = packagesRegistry[packageName];
+      validateManifestMandatoryFields(
+        packageDef.manifest,
+        getRootRelativeLogPath(packageDef.absoluteDir, workspaceRootDir)
+      );
+    }
 
     const packedFilesByName = await packDependencies({
       internalPackageNames,

--- a/src/lib/registry/create-packages-registry.ts
+++ b/src/lib/registry/create-packages-registry.ts
@@ -2,7 +2,6 @@ import fs from "fs-extra";
 import { globSync } from "glob";
 import path from "node:path";
 import { useLogger } from "../logger";
-import { validateManifestMandatoryFields } from "../manifest";
 import type { PackageManifest, PackagesRegistry } from "../types";
 import { isRushWorkspace, readTypedJson, readTypedJsonSync } from "../utils";
 import { findPackagesGlobs } from "./helpers";
@@ -46,9 +45,6 @@ export async function createPackagesRegistry(
           const manifest = await readTypedJson<PackageManifest>(
             path.join(absoluteDir, "package.json")
           );
-
-          /** Validate mandatory fields for all packages */
-          validateManifestMandatoryFields(manifest, rootRelativeDir);
 
           return {
             manifest,


### PR DESCRIPTION
We don't want to enforce the mandatory fields on all workspace packages. Only the ones that are being isolated.