### PR TITLE
Keep only target package dev dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 dist
 *.log
 .DS_Store
+PR_SUMMARY.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -149,7 +149,9 @@ const packageManager = usePackageManager();
 
 **Always create a PR summary when completing a task that involves code changes:**
 
-1. Create a `PR_SUMMARY.md` file at the project root
+1. Create or overwrite the `PR_SUMMARY.md` file at the project root
+   - Note: This file is not in version control and may already exist from previous tasks
+   - Always completely overwrite the existing content with new summary
 2. Include the following sections:
    - **Problem**: Clear description of the issue being solved
    - **Root Cause**: Technical explanation of why the issue occurred

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,6 +145,24 @@ const packageManager = usePackageManager();
 - Include clear commit messages
 - Consider backward compatibility
 
+### PR Summary Documentation
+
+**Always create a PR summary when completing a task that involves code changes:**
+
+1. Create a `PR_SUMMARY.md` file at the project root
+2. Include the following sections:
+   - **Problem**: Clear description of the issue being solved
+   - **Root Cause**: Technical explanation of why the issue occurred
+   - **Solution**: Code changes made with examples
+   - **Benefits**: List of improvements and guarantees
+   - **Testing**: Verification steps taken (tests, compilation, build)
+   - **Impact**: How this affects users and resolves the original issue
+3. Link to relevant GitHub issues/PRs using markdown format
+4. Use clear, technical language suitable for code review
+5. Include code snippets to illustrate key changes
+
+This documentation helps maintain project history and assists with code reviews.
+
 ## Common Pitfalls to Avoid
 
 1. Don't assume a specific package manager - always detect

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "scripts": {
     "build": "tsup-node",
     "dev": "tsup-node --watch",
-    "test": "vitest",
+    "test": "vitest --run",
     "format": "prettier --write .",
     "lint": "eslint . --max-warnings 0",
     "lint:format": "prettier --check .",

--- a/src/lib/lockfile/helpers/generate-pnpm-lockfile.ts
+++ b/src/lib/lockfile/helpers/generate-pnpm-lockfile.ts
@@ -143,7 +143,7 @@ export async function generatePnpmLockfile({
         return [
           importerId,
           pnpmMapImporter(importerId, importer!, {
-            includeDevDependencies,
+            includeDevDependencies: false, // Only include dev deps for target package
             includePatchedDependencies,
             directoryByPackageName,
           }),


### PR DESCRIPTION
Restrict `includeDevDependencies` to only the target package in the PNPM lockfile 

Fixes #120 

Previously, the `includeDevDependencies` option would incorrectly include dev dependencies for all packages (including internal ones) in the PNPM lockfile. This created an inconsistency because internal package manifests have their dev dependencies stripped. This change ensures that only the target package's dev dependencies are included, aligning the lockfile with the manifest adaptation.