### PR TITLE
Include packageExtensionsChecksum in generated pnpm.lock.yaml

### DIFF
--- a/src/lib/lockfile/helpers/generate-pnpm-lockfile.ts
+++ b/src/lib/lockfile/helpers/generate-pnpm-lockfile.ts
@@ -164,7 +164,8 @@ export async function generatePnpmLockfile({
 
     /** Add packageExtensionsChecksum back to the pruned lockfile if present */
     if (lockfile.packageExtensionsChecksum) {
-      prunedLockfile.packageExtensionsChecksum = lockfile.packageExtensionsChecksum;
+      prunedLockfile.packageExtensionsChecksum =
+        lockfile.packageExtensionsChecksum;
     }
 
     /**


### PR DESCRIPTION
Fixes #141 

Ran into this issue after adding packageExtensions to my pnpm-workspace. Installs in isolated directory fail with 

> ERR_PNPM_LOCKFILE_CONFIG_MISMATCH  Cannot proceed with the frozen installation. The current "packageExtensionsChecksum" configuration doesn't match the value found in the lockfile
