### PR TITLE
Add oxlint configuration and fix lint violations

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "./node_modules/oxlint/configuration_schema.json",
+  "plugins": ["typescript"],
+  "categories": {
+    "correctness": "error",
+    "suspicious": "warn",
+    "perf": "warn"
+  },
+  "rules": {
+    "typescript/no-floating-promises": "error",
+    "typescript/no-misused-promises": "error",
+    "typescript/await-thenable": "error",
+    "typescript/no-unused-vars": ["warn", { "argsIgnorePattern": "^_" }],
+    "typescript/no-unsafe-type-assertion": "off",
+    "no-await-in-loop": "off"
+  },
+  "ignorePatterns": ["*.d.ts", "*.d.mts"]
+}

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "dev": "tsdown --watch",
     "test": "vitest run",
     "format": "prettier --write .",
-    "lint": "oxlint --type-aware",
+    "lint": "oxlint -c .oxlintrc.json --type-aware",
     "check-format": "prettier --check .",
     "check-types": "tsc --noEmit",
     "prepare": "pnpm check-types && pnpm build"

--- a/src/lib/lockfile/helpers/generate-pnpm-lockfile.ts
+++ b/src/lib/lockfile/helpers/generate-pnpm-lockfile.ts
@@ -131,7 +131,7 @@ export async function generatePnpmLockfile({
 
           return [
             ".",
-            pnpmMapImporter(".", importer!, {
+            pnpmMapImporter(".", importer, {
               includeDevDependencies,
               directoryByPackageName,
             }),
@@ -142,7 +142,7 @@ export async function generatePnpmLockfile({
 
         return [
           importerId,
-          pnpmMapImporter(importerId, importer!, {
+          pnpmMapImporter(importerId, importer, {
             includeDevDependencies: false,
             directoryByPackageName,
           }),

--- a/src/lib/package-manager/helpers/infer-from-files.ts
+++ b/src/lib/package-manager/helpers/infer-from-files.ts
@@ -17,7 +17,8 @@ export function inferFromFiles(workspaceRoot: string): PackageManager {
         return { name, version, majorVersion: getMajorVersion(version) };
       } catch (err) {
         throw new Error(
-          `Failed to find package manager version for ${name}: ${getErrorMessage(err)}`
+          `Failed to find package manager version for ${name}: ${getErrorMessage(err)}`,
+          { cause: err }
         );
       }
     }

--- a/src/lib/utils/json.ts
+++ b/src/lib/utils/json.ts
@@ -12,7 +12,8 @@ export function readTypedJsonSync<T>(filePath: string) {
     return data;
   } catch (err) {
     throw new Error(
-      `Failed to read JSON from ${filePath}: ${getErrorMessage(err)}`
+      `Failed to read JSON from ${filePath}: ${getErrorMessage(err)}`,
+      { cause: err }
     );
   }
 }
@@ -26,7 +27,8 @@ export async function readTypedJson<T>(filePath: string) {
     return data;
   } catch (err) {
     throw new Error(
-      `Failed to read JSON from ${filePath}: ${getErrorMessage(err)}`
+      `Failed to read JSON from ${filePath}: ${getErrorMessage(err)}`,
+      { cause: err }
     );
   }
 }

--- a/src/lib/utils/yaml.ts
+++ b/src/lib/utils/yaml.ts
@@ -10,7 +10,8 @@ export function readTypedYamlSync<T>(filePath: string) {
     return data as T;
   } catch (err) {
     throw new Error(
-      `Failed to read YAML from ${filePath}: ${getErrorMessage(err)}`
+      `Failed to read YAML from ${filePath}: ${getErrorMessage(err)}`,
+      { cause: err }
     );
   }
 }


### PR DESCRIPTION
Add a minimal `.oxlintrc.json` that enables the `suspicious` and `perf` categories alongside `correctness`, and adds type-aware rules for catching floating promises, misused promises, and unnecessary await on non-thenables.

Fixes surfaced by the new rules:
- Preserve error cause chain with `{ cause: err }` in re-thrown errors across json, yaml, and package manager utilities
- Remove unnecessary non-null assertions in the PNPM lockfile generator