### PR TITLE
Add detectMonorepo helper for workspace root detection

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+pnpm lint-staged

--- a/package.json
+++ b/package.json
@@ -49,12 +49,6 @@
     "docs:build": "vitepress build docs",
     "docs:preview": "vitepress preview docs"
   },
-  "lint-staged": {
-    "*.{ts,tsx,js,mjs,cjs}": [
-      "oxfmt",
-      "oxlint -c .oxlintrc.json"
-    ]
-  },
   "dependencies": {
     "@npmcli/arborist": "^9.4.2",
     "@npmcli/config": "^10.8.1",
@@ -94,6 +88,12 @@
     "vite": "^7.0.0",
     "vitepress": "^1.6.3",
     "vitest": "^4.1.3"
+  },
+  "lint-staged": {
+    "*.{ts,tsx,js,mjs,cjs}": [
+      "oxfmt",
+      "oxlint -c .oxlintrc.json"
+    ]
   },
   "engines": {
     "node": ">=22.12.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "isolate-package",
-  "version": "1.30.0",
+  "version": "1.31.0",
   "description": "Isolate monorepo packages to form a self-contained deployable unit",
   "keywords": [
     "ci",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "isolate-package",
-  "version": "1.31.0",
+  "version": "1.30.0",
   "description": "Isolate monorepo packages to form a self-contained deployable unit",
   "keywords": [
     "ci",

--- a/package.json
+++ b/package.json
@@ -44,10 +44,16 @@
     "lint": "oxlint -c .oxlintrc.json --type-aware",
     "check-format": "oxfmt --check",
     "check-types": "tsc --noEmit",
-    "prepare": "pnpm check-types && pnpm build",
+    "prepare": "husky && pnpm check-types && pnpm build",
     "docs:dev": "vitepress dev docs",
     "docs:build": "vitepress build docs",
     "docs:preview": "vitepress preview docs"
+  },
+  "lint-staged": {
+    "*.{ts,tsx,js,mjs,cjs}": [
+      "oxfmt",
+      "oxlint -c .oxlintrc.json"
+    ]
   },
   "dependencies": {
     "@npmcli/arborist": "^9.4.2",
@@ -78,6 +84,8 @@
     "@types/npmcli__config": "^6.0.3",
     "@types/source-map-support": "^0.5.10",
     "@types/tar-fs": "^2.0.4",
+    "husky": "^9.1.7",
+    "lint-staged": "^16.4.0",
     "oxfmt": "^0.44.0",
     "oxlint": "^1.59.0",
     "oxlint-tsgolint": "^0.20.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,12 @@ importers:
       '@types/tar-fs':
         specifier: ^2.0.4
         version: 2.0.4
+      husky:
+        specifier: ^9.1.7
+        version: 9.1.7
+      lint-staged:
+        specifier: ^16.4.0
+        version: 16.4.0
       oxfmt:
         specifier: ^0.44.0
         version: 0.44.0
@@ -1548,6 +1554,18 @@ packages:
     resolution: {integrity: sha512-Tse7vx7WOvbU+kpq/L3BrBhSWTPbtMa59zIEhMn+Z2NoxZlpcCRUDCRxQ7kDFs1T3CHxDgvb+mDuILiBBpBaAA==}
     engines: {node: '>= 14.0.0'}
 
+  ansi-escapes@7.3.0:
+    resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
+    engines: {node: '>=18'}
+
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
+
   ansis@4.2.0:
     resolution: {integrity: sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==}
     engines: {node: '>=14'}
@@ -1671,12 +1689,27 @@ packages:
     resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
     engines: {node: '>=8'}
 
+  cli-cursor@5.0.0:
+    resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
+    engines: {node: '>=18'}
+
+  cli-truncate@5.2.0:
+    resolution: {integrity: sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==}
+    engines: {node: '>=20'}
+
   cmd-shim@8.0.0:
     resolution: {integrity: sha512-Jk/BK6NCapZ58BKUxlSI+ouKRbjH1NLZCgJkYoab+vEHUY3f6OzpNBN9u7HFSv9J6TRDGs4PLOHezoKGaFRSCA==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
+  colorette@2.0.20:
+    resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
+
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
+
+  commander@14.0.3:
+    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
+    engines: {node: '>=20'}
 
   common-ancestor-path@2.0.0:
     resolution: {integrity: sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng==}
@@ -1747,6 +1780,9 @@ packages:
   emoji-regex-xs@1.0.0:
     resolution: {integrity: sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==}
 
+  emoji-regex@10.6.0:
+    resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
+
   empathic@2.0.0:
     resolution: {integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==}
     engines: {node: '>=14'}
@@ -1766,6 +1802,10 @@ packages:
     resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
     engines: {node: '>=6'}
 
+  environment@1.1.0:
+    resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
+    engines: {node: '>=18'}
+
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
 
@@ -1784,6 +1824,9 @@ packages:
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
   events-universal@1.0.1:
     resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
@@ -1832,6 +1875,10 @@ packages:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  get-east-asian-width@1.5.0:
+    resolution: {integrity: sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==}
+    engines: {node: '>=18'}
 
   get-npm-tarball-url@2.1.0:
     resolution: {integrity: sha512-ro+DiMu5DXgRBabqXupW38h7WPZ9+Ad8UjwhvsmmN8w1sU7ab0nzAXvVZ4kqYg57OrqomRtJvepX5/xvFKNtjA==}
@@ -1893,6 +1940,11 @@ packages:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
 
+  husky@9.1.7:
+    resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
@@ -1925,6 +1977,10 @@ packages:
   ip-address@10.1.0:
     resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
     engines: {node: '>= 12'}
+
+  is-fullwidth-code-point@5.1.0:
+    resolution: {integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==}
+    engines: {node: '>=18'}
 
   is-plain-obj@2.1.0:
     resolution: {integrity: sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==}
@@ -2040,6 +2096,19 @@ packages:
     resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
+  lint-staged@16.4.0:
+    resolution: {integrity: sha512-lBWt8hujh/Cjysw5GYVmZpFHXDCgZzhrOm8vbcUdobADZNOK/bRshr2kM3DfgrrtR1DQhfupW9gnIXOfiFi+bw==}
+    engines: {node: '>=20.17'}
+    hasBin: true
+
+  listr2@9.0.5:
+    resolution: {integrity: sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==}
+    engines: {node: '>=20.0.0'}
+
+  log-update@6.1.0:
+    resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
+    engines: {node: '>=18'}
+
   lru-cache@11.3.3:
     resolution: {integrity: sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==}
     engines: {node: 20 || >=22}
@@ -2098,6 +2167,10 @@ packages:
   mimic-fn@3.1.0:
     resolution: {integrity: sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==}
     engines: {node: '>=8'}
+
+  mimic-function@5.0.1:
+    resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
+    engines: {node: '>=18'}
 
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
@@ -2211,6 +2284,10 @@ packages:
   onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
+
+  onetime@7.0.0:
+    resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
+    engines: {node: '>=18'}
 
   oniguruma-to-es@3.1.1:
     resolution: {integrity: sha512-bUH8SDvPkH3ho3dvwJwfonjlQ4R80vjyvrU8YpxuROddv55vAEJrTuCuCVUhhsHbtlD9tGGbaNApGQckXhS8iQ==}
@@ -2339,6 +2416,10 @@ packages:
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
+  restore-cursor@5.1.0:
+    resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
+    engines: {node: '>=18'}
+
   rfc4648@1.5.3:
     resolution: {integrity: sha512-MjOWxM065+WswwnmNONOT+bD1nXzY9Km6u3kzvnx8F8/HXGZdz3T6e6vZJ8Q/RIMUSp/nxqjH3GwvJDy8ijeQQ==}
 
@@ -2423,6 +2504,14 @@ packages:
     resolution: {integrity: sha512-/fUgUhYghuLzVT/gaJoeVehLCgZiUxPCPMcyVNY0lIf/cTCz58K/WTI7PefDarXxp9nUKpEwg1yyz3eSBMTtgA==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
+  slice-ansi@7.1.2:
+    resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
+    engines: {node: '>=18'}
+
+  slice-ansi@8.0.0:
+    resolution: {integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==}
+    engines: {node: '>=20'}
+
   smart-buffer@4.2.0:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
     engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
@@ -2483,8 +2572,24 @@ packages:
   streamx@2.25.0:
     resolution: {integrity: sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==}
 
+  string-argv@0.3.2:
+    resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
+    engines: {node: '>=0.6.19'}
+
+  string-width@7.2.0:
+    resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
+    engines: {node: '>=18'}
+
+  string-width@8.2.0:
+    resolution: {integrity: sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==}
+    engines: {node: '>=20'}
+
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
 
   strip-bom@4.0.0:
     resolution: {integrity: sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==}
@@ -2793,6 +2898,10 @@ packages:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
     hasBin: true
+
+  wrap-ansi@9.0.2:
+    resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
+    engines: {node: '>=18'}
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
@@ -4103,6 +4212,14 @@ snapshots:
       '@algolia/requester-fetch': 5.49.0
       '@algolia/requester-node-http': 5.49.0
 
+  ansi-escapes@7.3.0:
+    dependencies:
+      environment: 1.1.0
+
+  ansi-regex@6.2.2: {}
+
+  ansi-styles@6.2.3: {}
+
   ansis@4.2.0: {}
 
   argparse@2.0.1: {}
@@ -4208,9 +4325,22 @@ snapshots:
 
   ci-info@4.4.0: {}
 
+  cli-cursor@5.0.0:
+    dependencies:
+      restore-cursor: 5.1.0
+
+  cli-truncate@5.2.0:
+    dependencies:
+      slice-ansi: 8.0.0
+      string-width: 8.2.0
+
   cmd-shim@8.0.0: {}
 
+  colorette@2.0.20: {}
+
   comma-separated-tokens@2.0.3: {}
+
+  commander@14.0.3: {}
 
   common-ancestor-path@2.0.0: {}
 
@@ -4255,6 +4385,8 @@ snapshots:
 
   emoji-regex-xs@1.0.0: {}
 
+  emoji-regex@10.6.0: {}
+
   empathic@2.0.0: {}
 
   encode-registry@3.0.1:
@@ -4268,6 +4400,8 @@ snapshots:
   entities@7.0.1: {}
 
   env-paths@2.2.1: {}
+
+  environment@1.1.0: {}
 
   es-module-lexer@2.0.0: {}
 
@@ -4332,6 +4466,8 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
 
+  eventemitter3@5.0.4: {}
+
   events-universal@1.0.1:
     dependencies:
       bare-events: 2.8.2
@@ -4380,6 +4516,8 @@ snapshots:
 
   fsevents@2.3.3:
     optional: true
+
+  get-east-asian-width@1.5.0: {}
 
   get-npm-tarball-url@2.1.0: {}
 
@@ -4454,6 +4592,8 @@ snapshots:
 
   human-signals@2.1.0: {}
 
+  husky@9.1.7: {}
+
   iconv-lite@0.7.2:
     dependencies:
       safer-buffer: 2.1.2
@@ -4479,6 +4619,10 @@ snapshots:
   ini@6.0.0: {}
 
   ip-address@10.1.0: {}
+
+  is-fullwidth-code-point@5.1.0:
+    dependencies:
+      get-east-asian-width: 1.5.0
 
   is-plain-obj@2.1.0: {}
 
@@ -4558,6 +4702,32 @@ snapshots:
       lightningcss-win32-x64-msvc: 1.32.0
     optional: true
 
+  lint-staged@16.4.0:
+    dependencies:
+      commander: 14.0.3
+      listr2: 9.0.5
+      picomatch: 4.0.4
+      string-argv: 0.3.2
+      tinyexec: 1.1.1
+      yaml: 2.8.3
+
+  listr2@9.0.5:
+    dependencies:
+      cli-truncate: 5.2.0
+      colorette: 2.0.20
+      eventemitter3: 5.0.4
+      log-update: 6.1.0
+      rfdc: 1.4.1
+      wrap-ansi: 9.0.2
+
+  log-update@6.1.0:
+    dependencies:
+      ansi-escapes: 7.3.0
+      cli-cursor: 5.0.0
+      slice-ansi: 7.1.2
+      strip-ansi: 7.2.0
+      wrap-ansi: 9.0.2
+
   lru-cache@11.3.3: {}
 
   lru-cache@6.0.0:
@@ -4632,6 +4802,8 @@ snapshots:
   mimic-fn@2.1.0: {}
 
   mimic-fn@3.1.0: {}
+
+  mimic-function@5.0.1: {}
 
   minimatch@10.2.5:
     dependencies:
@@ -4761,6 +4933,10 @@ snapshots:
   onetime@5.1.2:
     dependencies:
       mimic-fn: 2.1.0
+
+  onetime@7.0.0:
+    dependencies:
+      mimic-function: 5.0.1
 
   oniguruma-to-es@3.1.1:
     dependencies:
@@ -4929,6 +5105,11 @@ snapshots:
 
   resolve-pkg-maps@1.0.0: {}
 
+  restore-cursor@5.1.0:
+    dependencies:
+      onetime: 7.0.0
+      signal-exit: 4.1.0
+
   rfc4648@1.5.3: {}
 
   rfdc@1.4.1: {}
@@ -5061,6 +5242,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  slice-ansi@7.1.2:
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
+
+  slice-ansi@8.0.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      is-fullwidth-code-point: 5.1.0
+
   smart-buffer@4.2.0: {}
 
   socks-proxy-agent@8.0.5:
@@ -5121,10 +5312,27 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
+  string-argv@0.3.2: {}
+
+  string-width@7.2.0:
+    dependencies:
+      emoji-regex: 10.6.0
+      get-east-asian-width: 1.5.0
+      strip-ansi: 7.2.0
+
+  string-width@8.2.0:
+    dependencies:
+      get-east-asian-width: 1.5.0
+      strip-ansi: 7.2.0
+
   stringify-entities@4.0.4:
     dependencies:
       character-entities-html4: 2.1.0
       character-entities-legacy: 3.0.0
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
 
   strip-bom@4.0.0: {}
 
@@ -5427,6 +5635,12 @@ snapshots:
     dependencies:
       siginfo: 2.0.0
       stackback: 0.0.2
+
+  wrap-ansi@9.0.2:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 7.2.0
+      strip-ansi: 7.2.0
 
   wrappy@1.0.2: {}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,8 @@
+import type { detectMonorepo } from "./lib/detect-monorepo";
 import type { isolate } from "./isolate";
 export { isolate } from "./isolate";
+export { detectMonorepo } from "./lib/detect-monorepo";
+export type { MonorepoInfo } from "./lib/detect-monorepo";
 export { getInternalPackageNames } from "./get-internal-package-names";
 export { defineConfig } from "./lib/config";
 export type { IsolateConfig } from "./lib/config";
@@ -8,4 +11,5 @@ export type { Logger } from "./lib/logger";
 /** Used by firebase-tools-with-isolate to type the dynamic import */
 export type IsolateExports = {
   isolate: typeof isolate;
+  detectMonorepo: typeof detectMonorepo;
 };

--- a/src/lib/detect-monorepo.test.ts
+++ b/src/lib/detect-monorepo.test.ts
@@ -145,7 +145,7 @@ describe("detectMonorepo", () => {
       path.join(tmpRoot, "package.json"),
       [
         "{",
-        '  // root manifest',
+        "  // root manifest",
         '  "name": "root",',
         '  "version": "1.0.0",',
         '  "workspaces": ["packages/*"],',

--- a/src/lib/detect-monorepo.test.ts
+++ b/src/lib/detect-monorepo.test.ts
@@ -140,6 +140,27 @@ describe("detectMonorepo", () => {
     });
   });
 
+  it("parses a package.json containing comments and trailing commas", () => {
+    fs.writeFileSync(
+      path.join(tmpRoot, "package.json"),
+      [
+        "{",
+        '  // root manifest',
+        '  "name": "root",',
+        '  "version": "1.0.0",',
+        '  "workspaces": ["packages/*"],',
+        "}",
+      ].join("\n"),
+    );
+
+    const result = detectMonorepo(tmpRoot);
+
+    expect(result).toEqual({
+      rootDir: tmpRoot,
+      kind: "workspaces",
+    });
+  });
+
   it("ignores a malformed package.json and continues upward", () => {
     fs.writeFileSync(
       path.join(tmpRoot, "pnpm-workspace.yaml"),

--- a/src/lib/detect-monorepo.test.ts
+++ b/src/lib/detect-monorepo.test.ts
@@ -1,0 +1,176 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { detectMonorepo } from "./detect-monorepo";
+
+describe("detectMonorepo", () => {
+  let tmpRoot: string;
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "detect-monorepo-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("detects a pnpm workspace via pnpm-workspace.yaml", () => {
+    fs.writeFileSync(
+      path.join(tmpRoot, "pnpm-workspace.yaml"),
+      "packages:\n  - 'packages/*'\n",
+    );
+    fs.writeFileSync(
+      path.join(tmpRoot, "package.json"),
+      JSON.stringify({ name: "root", version: "1.0.0" }),
+    );
+
+    const result = detectMonorepo(tmpRoot);
+
+    expect(result).toEqual({
+      rootDir: tmpRoot,
+      kind: "pnpm",
+    });
+  });
+
+  it("detects a workspaces array in package.json (npm/yarn/bun)", () => {
+    fs.writeFileSync(
+      path.join(tmpRoot, "package.json"),
+      JSON.stringify({
+        name: "root",
+        version: "1.0.0",
+        workspaces: ["packages/*"],
+      }),
+    );
+
+    const result = detectMonorepo(tmpRoot);
+
+    expect(result).toEqual({
+      rootDir: tmpRoot,
+      kind: "workspaces",
+    });
+  });
+
+  it("detects a workspaces object form in package.json (yarn nohoist)", () => {
+    fs.writeFileSync(
+      path.join(tmpRoot, "package.json"),
+      JSON.stringify({
+        name: "root",
+        version: "1.0.0",
+        workspaces: { packages: ["packages/*"], nohoist: [] },
+      }),
+    );
+
+    const result = detectMonorepo(tmpRoot);
+
+    expect(result).toEqual({
+      rootDir: tmpRoot,
+      kind: "workspaces",
+    });
+  });
+
+  it("detects a rush workspace via rush.json", () => {
+    fs.writeFileSync(path.join(tmpRoot, "rush.json"), "{}");
+
+    const result = detectMonorepo(tmpRoot);
+
+    expect(result).toEqual({
+      rootDir: tmpRoot,
+      kind: "rush",
+    });
+  });
+
+  it("returns null for a standalone package with no workspace markers", () => {
+    fs.writeFileSync(
+      path.join(tmpRoot, "package.json"),
+      JSON.stringify({ name: "standalone", version: "1.0.0" }),
+    );
+
+    const result = detectMonorepo(tmpRoot);
+
+    expect(result).toBeNull();
+  });
+
+  it("finds a marker two levels up from the start directory", () => {
+    fs.writeFileSync(
+      path.join(tmpRoot, "pnpm-workspace.yaml"),
+      "packages:\n  - 'packages/*'\n",
+    );
+    const nested = path.join(tmpRoot, "packages", "api");
+    fs.mkdirSync(nested, { recursive: true });
+    fs.writeFileSync(
+      path.join(nested, "package.json"),
+      JSON.stringify({ name: "api", version: "1.0.0" }),
+    );
+
+    const result = detectMonorepo(nested);
+
+    expect(result).toEqual({
+      rootDir: tmpRoot,
+      kind: "pnpm",
+    });
+  });
+
+  it("stops searching after MAX_DEPTH (4) levels", () => {
+    fs.writeFileSync(
+      path.join(tmpRoot, "pnpm-workspace.yaml"),
+      "packages:\n  - 'apps/*/functions/src'\n",
+    );
+    const tooDeep = path.join(tmpRoot, "apps", "firebase", "functions", "src");
+    fs.mkdirSync(tooDeep, { recursive: true });
+
+    const result = detectMonorepo(tooDeep);
+
+    expect(result).toBeNull();
+  });
+
+  it("finds a marker exactly at MAX_DEPTH (3 levels up)", () => {
+    fs.writeFileSync(
+      path.join(tmpRoot, "pnpm-workspace.yaml"),
+      "packages:\n  - 'apps/*/functions'\n",
+    );
+    const deep = path.join(tmpRoot, "apps", "firebase", "functions");
+    fs.mkdirSync(deep, { recursive: true });
+
+    const result = detectMonorepo(deep);
+
+    expect(result).toEqual({
+      rootDir: tmpRoot,
+      kind: "pnpm",
+    });
+  });
+
+  it("ignores a malformed package.json and continues upward", () => {
+    fs.writeFileSync(
+      path.join(tmpRoot, "pnpm-workspace.yaml"),
+      "packages:\n  - 'packages/*'\n",
+    );
+    const nested = path.join(tmpRoot, "packages", "api");
+    fs.mkdirSync(nested, { recursive: true });
+    fs.writeFileSync(path.join(nested, "package.json"), "{ not valid json");
+
+    const result = detectMonorepo(nested);
+
+    expect(result).toEqual({
+      rootDir: tmpRoot,
+      kind: "pnpm",
+    });
+  });
+
+  it("does not match a package.json without a workspaces field", () => {
+    const nested = path.join(tmpRoot, "subdir");
+    fs.mkdirSync(nested);
+    fs.writeFileSync(
+      path.join(tmpRoot, "package.json"),
+      JSON.stringify({ name: "root", version: "1.0.0" }),
+    );
+    fs.writeFileSync(
+      path.join(nested, "package.json"),
+      JSON.stringify({ name: "child", version: "1.0.0" }),
+    );
+
+    const result = detectMonorepo(nested);
+
+    expect(result).toBeNull();
+  });
+});

--- a/src/lib/detect-monorepo.test.ts
+++ b/src/lib/detect-monorepo.test.ts
@@ -178,6 +178,36 @@ describe("detectMonorepo", () => {
     });
   });
 
+  it("ignores an unexpected workspaces shape", () => {
+    fs.writeFileSync(
+      path.join(tmpRoot, "package.json"),
+      JSON.stringify({
+        name: "root",
+        version: "1.0.0",
+        workspaces: "packages/*",
+      }),
+    );
+
+    const result = detectMonorepo(tmpRoot);
+
+    expect(result).toBeNull();
+  });
+
+  it("ignores a workspaces object without a packages array", () => {
+    fs.writeFileSync(
+      path.join(tmpRoot, "package.json"),
+      JSON.stringify({
+        name: "root",
+        version: "1.0.0",
+        workspaces: { nohoist: [] },
+      }),
+    );
+
+    const result = detectMonorepo(tmpRoot);
+
+    expect(result).toBeNull();
+  });
+
   it("does not match a package.json without a workspaces field", () => {
     const nested = path.join(tmpRoot, "subdir");
     fs.mkdirSync(nested);

--- a/src/lib/detect-monorepo.ts
+++ b/src/lib/detect-monorepo.ts
@@ -1,0 +1,52 @@
+import fs from "node:fs";
+import path from "node:path";
+
+export type MonorepoInfo = {
+  /** Absolute path to the monorepo workspace root. */
+  rootDir: string;
+  /** Which workspace marker was found. "workspaces" covers npm/yarn/bun. */
+  kind: "pnpm" | "workspaces" | "rush";
+};
+
+const MAX_DEPTH = 4;
+
+/**
+ * Walk upward from `startDir` looking for a monorepo workspace root. Returns
+ * null if none is found within `MAX_DEPTH` levels (startDir itself plus three
+ * parents) or before reaching the filesystem root.
+ *
+ * Supported markers:
+ * - `pnpm-workspace.yaml`
+ * - `package.json` containing a `workspaces` field (npm, yarn, bun)
+ * - `rush.json`
+ */
+export function detectMonorepo(
+  startDir: string = process.cwd(),
+): MonorepoInfo | null {
+  let current = path.resolve(startDir);
+  for (let i = 0; i < MAX_DEPTH; i++) {
+    if (fs.existsSync(path.join(current, "pnpm-workspace.yaml"))) {
+      return { rootDir: current, kind: "pnpm" };
+    }
+    if (fs.existsSync(path.join(current, "rush.json"))) {
+      return { rootDir: current, kind: "rush" };
+    }
+    const pkgPath = path.join(current, "package.json");
+    if (fs.existsSync(pkgPath)) {
+      try {
+        const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8")) as {
+          workspaces?: unknown;
+        };
+        if (pkg.workspaces) {
+          return { rootDir: current, kind: "workspaces" };
+        }
+      } catch {
+        // Malformed package.json — ignore and continue upward.
+      }
+    }
+    const parent = path.dirname(current);
+    if (parent === current) return null;
+    current = parent;
+  }
+  return null;
+}

--- a/src/lib/detect-monorepo.ts
+++ b/src/lib/detect-monorepo.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import { readTypedJsonSync } from "./utils/json";
+import { readTypedJsonSync } from "./utils";
 
 export type MonorepoInfo = {
   /** Absolute path to the monorepo workspace root. */
@@ -36,7 +36,7 @@ export function detectMonorepo(
     if (fs.existsSync(pkgPath)) {
       try {
         const pkg = readTypedJsonSync<{ workspaces?: unknown }>(pkgPath);
-        if (pkg.workspaces) {
+        if (hasWorkspacesField(pkg.workspaces)) {
           return { rootDir: current, kind: "workspaces" };
         }
       } catch {
@@ -48,4 +48,18 @@ export function detectMonorepo(
     current = parent;
   }
   return null;
+}
+
+/**
+ * Mirrors the shapes accepted by the rest of the codebase (see
+ * `find-packages-globs.ts`): an array of globs, or a Yarn-style object with a
+ * `packages` array. Anything else is treated as not a workspace root.
+ */
+function hasWorkspacesField(value: unknown): boolean {
+  if (Array.isArray(value)) return true;
+  if (typeof value === "object" && value !== null) {
+    const packages = (value as { packages?: unknown }).packages;
+    return Array.isArray(packages);
+  }
+  return false;
 }

--- a/src/lib/detect-monorepo.ts
+++ b/src/lib/detect-monorepo.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { readTypedJsonSync } from "./utils/json";
 
 export type MonorepoInfo = {
   /** Absolute path to the monorepo workspace root. */
@@ -34,14 +35,12 @@ export function detectMonorepo(
     const pkgPath = path.join(current, "package.json");
     if (fs.existsSync(pkgPath)) {
       try {
-        const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8")) as {
-          workspaces?: unknown;
-        };
+        const pkg = readTypedJsonSync<{ workspaces?: unknown }>(pkgPath);
         if (pkg.workspaces) {
           return { rootDir: current, kind: "workspaces" };
         }
       } catch {
-        // Malformed package.json — ignore and continue upward.
+        /** Malformed package.json — ignore and continue upward. */
       }
     }
     const parent = path.dirname(current);


### PR DESCRIPTION
Exposes a new `detectMonorepo` function that walks upward from a start directory (up to four levels) looking for a monorepo workspace root. Supported markers are `pnpm-workspace.yaml`, a `workspaces` field in `package.json` (npm, yarn, bun) and `rush.json`. It returns the resolved root directory together with the kind of workspace that was matched, or `null` when no marker is found within range.

The helper is exported from the package entry point and added to `IsolateExports` so that consumers such as `firebase-tools-with-isolate` can reuse the same detection logic to decide whether to run isolation at all, instead of duplicating the heuristic. Parsing of `package.json` goes through the existing `readTypedJsonSync` utility so JSONC-style comments and trailing commas are handled consistently with the rest of the codebase.

Also sets up a husky pre-commit hook that runs `lint-staged` to format and lint staged source files locally.

Scope: packages (isolate-package)
Visibility: user-facing