### PR TITLE
Preserve resolved versions when generating NPM lockfile

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -55,8 +55,14 @@ by name.
 
 - PNPM: Prunes and adapts lockfile using `@pnpm/lockfile-file` and
   `@pnpm/prune-lockfile` (supports v8 and v9)
-- NPM: Uses `@npmcli/arborist` to generate from node_modules
-- Yarn: Generates from node_modules
+- NPM: Uses `@npmcli/arborist`'s `loadVirtual` + `workspaceDependencySet`
+  to compute the target's transitive closure, then copies matching entries
+  verbatim from the root `package-lock.json` (preserves original resolved
+  versions and integrity). Falls back to Arborist's `buildIdealTree` when
+  no root `package-lock.json` exists (e.g. `forceNpm` from pnpm/bun/yarn).
+- Yarn: Copies the root `yarn.lock` and runs `yarn install` locally to
+  prune it (Yarn v1 only; v2+ falls through to the NPM generator)
+- Bun: Walks and prunes the root `bun.lock` manually
 
 **output/** - Handles file operations:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,11 +131,21 @@ const packageManager = usePackageManager();
 - Handle Rush workspaces specially (generate workspace config)
 - Prune lockfiles before writing
 
-### NPM/Yarn
+### NPM
+
+- Replace workspace specifiers with `file:` paths
+- Preserve original resolved versions and integrity by reading the root
+  `package-lock.json` via Arborist `loadVirtual` and copying matching
+  entries into the isolated lockfile
+- Fall back to Arborist's `buildIdealTree` (generating from node_modules)
+  when no root `package-lock.json` exists (`forceNpm` from non-npm
+  monorepos, or modern Yarn v2+)
+
+### Yarn
 
 - Replace workspace specifiers with file paths
-- Generate lockfiles based on node_modules content
-- Handle different workspace configuration formats
+- Yarn v1: copy `yarn.lock` and run a local `yarn install` to prune
+- Yarn v2+: fall through to the NPM generator
 
 ## Pull Request Guidelines
 

--- a/src/lib/lockfile/helpers/__fixtures__/internal-deps/workspace/package-lock.json
+++ b/src/lib/lockfile/helpers/__fixtures__/internal-deps/workspace/package-lock.json
@@ -1,0 +1,82 @@
+{
+  "name": "iso-test-internal",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "iso-test-internal",
+      "version": "0.0.0",
+      "workspaces": [
+        "packages/*"
+      ]
+    },
+    "node_modules/api": {
+      "resolved": "packages/api",
+      "link": true
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shared": {
+      "resolved": "packages/shared",
+      "link": true
+    },
+    "node_modules/utils": {
+      "resolved": "packages/utils",
+      "link": true
+    },
+    "packages/api": {
+      "version": "1.0.0",
+      "dependencies": {
+        "semver": "^7.6.0",
+        "shared": "*"
+      }
+    },
+    "packages/shared": {
+      "version": "1.0.0",
+      "dependencies": {
+        "ms": "^2.1.3",
+        "utils": "*"
+      }
+    },
+    "packages/utils": {
+      "version": "1.0.0",
+      "dependencies": {
+        "debug": "^4.3.0"
+      }
+    }
+  }
+}

--- a/src/lib/lockfile/helpers/__fixtures__/internal-deps/workspace/package.json
+++ b/src/lib/lockfile/helpers/__fixtures__/internal-deps/workspace/package.json
@@ -2,5 +2,7 @@
   "name": "iso-test-internal",
   "version": "0.0.0",
   "private": true,
-  "workspaces": ["packages/*"]
+  "workspaces": [
+    "packages/*"
+  ]
 }

--- a/src/lib/lockfile/helpers/__fixtures__/internal-deps/workspace/package.json
+++ b/src/lib/lockfile/helpers/__fixtures__/internal-deps/workspace/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "iso-test-internal",
+  "version": "0.0.0",
+  "private": true,
+  "workspaces": ["packages/*"]
+}

--- a/src/lib/lockfile/helpers/__fixtures__/internal-deps/workspace/packages/api/package.json
+++ b/src/lib/lockfile/helpers/__fixtures__/internal-deps/workspace/packages/api/package.json
@@ -1,10 +1,12 @@
 {
   "name": "api",
   "version": "1.0.0",
+  "files": [
+    "index.js"
+  ],
   "main": "index.js",
-  "files": ["index.js"],
   "dependencies": {
-    "shared": "*",
-    "semver": "^7.6.0"
+    "semver": "^7.6.0",
+    "shared": "*"
   }
 }

--- a/src/lib/lockfile/helpers/__fixtures__/internal-deps/workspace/packages/api/package.json
+++ b/src/lib/lockfile/helpers/__fixtures__/internal-deps/workspace/packages/api/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "api",
+  "version": "1.0.0",
+  "main": "index.js",
+  "files": ["index.js"],
+  "dependencies": {
+    "shared": "*",
+    "semver": "^7.6.0"
+  }
+}

--- a/src/lib/lockfile/helpers/__fixtures__/internal-deps/workspace/packages/shared/package.json
+++ b/src/lib/lockfile/helpers/__fixtures__/internal-deps/workspace/packages/shared/package.json
@@ -1,10 +1,12 @@
 {
   "name": "shared",
   "version": "1.0.0",
+  "files": [
+    "index.js"
+  ],
   "main": "index.js",
-  "files": ["index.js"],
   "dependencies": {
-    "utils": "*",
-    "ms": "^2.1.3"
+    "ms": "^2.1.3",
+    "utils": "*"
   }
 }

--- a/src/lib/lockfile/helpers/__fixtures__/internal-deps/workspace/packages/shared/package.json
+++ b/src/lib/lockfile/helpers/__fixtures__/internal-deps/workspace/packages/shared/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "shared",
+  "version": "1.0.0",
+  "main": "index.js",
+  "files": ["index.js"],
+  "dependencies": {
+    "utils": "*",
+    "ms": "^2.1.3"
+  }
+}

--- a/src/lib/lockfile/helpers/__fixtures__/internal-deps/workspace/packages/utils/package.json
+++ b/src/lib/lockfile/helpers/__fixtures__/internal-deps/workspace/packages/utils/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "utils",
+  "version": "1.0.0",
+  "main": "index.js",
+  "files": ["index.js"],
+  "dependencies": {
+    "debug": "^4.3.0"
+  }
+}

--- a/src/lib/lockfile/helpers/__fixtures__/internal-deps/workspace/packages/utils/package.json
+++ b/src/lib/lockfile/helpers/__fixtures__/internal-deps/workspace/packages/utils/package.json
@@ -1,8 +1,10 @@
 {
   "name": "utils",
   "version": "1.0.0",
+  "files": [
+    "index.js"
+  ],
   "main": "index.js",
-  "files": ["index.js"],
   "dependencies": {
     "debug": "^4.3.0"
   }

--- a/src/lib/lockfile/helpers/__fixtures__/nested-version-override/workspace/package-lock.json
+++ b/src/lib/lockfile/helpers/__fixtures__/nested-version-override/workspace/package-lock.json
@@ -1,0 +1,56 @@
+{
+  "name": "iso-test-111",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "iso-test-111",
+      "version": "0.0.0",
+      "workspaces": [
+        "packages/*"
+      ]
+    },
+    "node_modules/api": {
+      "resolved": "packages/api",
+      "link": true
+    },
+    "node_modules/other": {
+      "resolved": "packages/other",
+      "link": true
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "packages/api": {
+      "version": "1.0.0",
+      "dependencies": {
+        "semver": "^6.3.0"
+      }
+    },
+    "packages/api/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "packages/other": {
+      "version": "1.0.0",
+      "dependencies": {
+        "semver": "^7.6.0"
+      }
+    }
+  }
+}

--- a/src/lib/lockfile/helpers/__fixtures__/nested-version-override/workspace/package.json
+++ b/src/lib/lockfile/helpers/__fixtures__/nested-version-override/workspace/package.json
@@ -2,5 +2,7 @@
   "name": "iso-test-111",
   "version": "0.0.0",
   "private": true,
-  "workspaces": ["packages/*"]
+  "workspaces": [
+    "packages/*"
+  ]
 }

--- a/src/lib/lockfile/helpers/__fixtures__/nested-version-override/workspace/package.json
+++ b/src/lib/lockfile/helpers/__fixtures__/nested-version-override/workspace/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "iso-test-111",
+  "version": "0.0.0",
+  "private": true,
+  "workspaces": ["packages/*"]
+}

--- a/src/lib/lockfile/helpers/__fixtures__/nested-version-override/workspace/packages/api/package.json
+++ b/src/lib/lockfile/helpers/__fixtures__/nested-version-override/workspace/packages/api/package.json
@@ -1,8 +1,10 @@
 {
   "name": "api",
   "version": "1.0.0",
+  "files": [
+    "index.js"
+  ],
   "main": "index.js",
-  "files": ["index.js"],
   "dependencies": {
     "semver": "^6.3.0"
   }

--- a/src/lib/lockfile/helpers/__fixtures__/nested-version-override/workspace/packages/api/package.json
+++ b/src/lib/lockfile/helpers/__fixtures__/nested-version-override/workspace/packages/api/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "api",
+  "version": "1.0.0",
+  "main": "index.js",
+  "files": ["index.js"],
+  "dependencies": {
+    "semver": "^6.3.0"
+  }
+}

--- a/src/lib/lockfile/helpers/__fixtures__/nested-version-override/workspace/packages/other/package.json
+++ b/src/lib/lockfile/helpers/__fixtures__/nested-version-override/workspace/packages/other/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "other",
+  "version": "1.0.0",
+  "main": "index.js",
+  "files": ["index.js"],
+  "dependencies": {
+    "semver": "^7.6.0"
+  }
+}

--- a/src/lib/lockfile/helpers/__fixtures__/nested-version-override/workspace/packages/other/package.json
+++ b/src/lib/lockfile/helpers/__fixtures__/nested-version-override/workspace/packages/other/package.json
@@ -1,8 +1,10 @@
 {
   "name": "other",
   "version": "1.0.0",
+  "files": [
+    "index.js"
+  ],
   "main": "index.js",
-  "files": ["index.js"],
   "dependencies": {
     "semver": "^7.6.0"
   }

--- a/src/lib/lockfile/helpers/generate-npm-lockfile.integration.test.ts
+++ b/src/lib/lockfile/helpers/generate-npm-lockfile.integration.test.ts
@@ -1,0 +1,124 @@
+import fs from "fs-extra";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { generateNpmLockfile } from "./generate-npm-lockfile";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const FIXTURES_DIR = path.join(__dirname, "__fixtures__");
+
+/**
+ * Copy a fixture's `workspace/` tree into a fresh tmp directory so that the
+ * integration test can run Arborist against real files without polluting the
+ * checked-in fixture.
+ */
+async function setupFixture(name: string) {
+  const srcWorkspace = path.join(FIXTURES_DIR, name, "workspace");
+  const tmpBase = await fs.mkdtemp(
+    path.join(os.tmpdir(), `isolate-package-${name}-`),
+  );
+  const workspaceRoot = path.join(tmpBase, "workspace");
+  await fs.copy(srcWorkspace, workspaceRoot);
+  return { tmpBase, workspaceRoot };
+}
+
+describe("generateNpmLockfile integration", () => {
+  let cleanupPaths: string[] = [];
+
+  beforeEach(() => {
+    cleanupPaths = [];
+  });
+
+  afterEach(async () => {
+    for (const p of cleanupPaths) {
+      await fs.remove(p).catch(() => undefined);
+    }
+  });
+
+  /**
+   * Reproduction of https://github.com/0x80/isolate-package/issues/111.
+   *
+   * The fixture is a real npm workspaces monorepo (produced by `npm install`)
+   * where the target package `api` pins `semver@^6` while a sibling `other`
+   * pins `semver@^7`. npm hoists 7.7.4 to the root `node_modules/semver` and
+   * places 6.3.1 at `packages/api/node_modules/semver` as a nested override.
+   *
+   * When isolating `api`, the isolated lockfile must surface the nested 6.3.1
+   * at the isolate's root `node_modules/semver` (with the original resolved
+   * and integrity preserved), and must not include the hoisted 7.7.4 that
+   * only `other` needs.
+   */
+  it("preserves the target's nested dependency version (#111)", async () => {
+    const { tmpBase, workspaceRoot } = await setupFixture(
+      "nested-version-override",
+    );
+    cleanupPaths.push(tmpBase);
+
+    const isolateDir = path.join(workspaceRoot, "packages/api/isolate");
+    await fs.ensureDir(isolateDir);
+
+    const targetManifest = (await fs.readJson(
+      path.join(workspaceRoot, "packages/api/package.json"),
+    )) as {
+      name: string;
+      version: string;
+      dependencies: Record<string, string>;
+    };
+
+    /** Write the adapted manifest into the isolate dir (no internal deps so no adaptation needed). */
+    await fs.writeJson(path.join(isolateDir, "package.json"), targetManifest);
+
+    await generateNpmLockfile({
+      workspaceRootDir: workspaceRoot,
+      isolateDir,
+      targetPackageName: "api",
+      targetPackageManifest: targetManifest,
+      packagesRegistry: {},
+      internalDepPackageNames: [],
+    });
+
+    const output = (await fs.readJson(
+      path.join(isolateDir, "package-lock.json"),
+    )) as {
+      name: string;
+      version: string;
+      lockfileVersion: number;
+      packages: Record<
+        string,
+        { version?: string; resolved?: string; integrity?: string }
+      >;
+    };
+
+    /** Top-level metadata reflects the target package, not the monorepo root. */
+    expect(output.name).toBe("api");
+    expect(output.version).toBe("1.0.0");
+    expect(output.lockfileVersion).toBe(3);
+
+    /** The nested 6.3.1 is surfaced at the isolate's root node_modules. */
+    const semverEntry = output.packages["node_modules/semver"];
+    expect(semverEntry?.version).toBe("6.3.1");
+    expect(semverEntry?.resolved).toBe(
+      "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+    );
+    expect(semverEntry?.integrity).toMatch(/^sha512-/);
+
+    /** The original nested path must not leak into the output. */
+    expect(output.packages["packages/api/node_modules/semver"]).toBeUndefined();
+
+    /** The sibling workspace and its hoisted semver@7 must not appear. */
+    expect(output.packages["packages/other"]).toBeUndefined();
+    expect(output.packages["node_modules/other"]).toBeUndefined();
+
+    /** No stray references to the unrelated hoisted 7.7.4. */
+    for (const entry of Object.values(output.packages)) {
+      if (entry.version === "7.7.4") {
+        throw new Error(
+          "isolated lockfile unexpectedly contains hoisted semver 7.7.4",
+        );
+      }
+    }
+  });
+});

--- a/src/lib/lockfile/helpers/generate-npm-lockfile.integration.test.ts
+++ b/src/lib/lockfile/helpers/generate-npm-lockfile.integration.test.ts
@@ -121,4 +121,123 @@ describe("generateNpmLockfile integration", () => {
       }
     }
   });
+
+  /**
+   * Covers the internal-dep overlay path: when an internal dep's manifest
+   * has been adapted (workspace references rewritten to `file:`), that
+   * overlay must propagate into the isolated lockfile's entry for that
+   * dep — otherwise `npm ci` would try to resolve `utils: "*"` from the
+   * registry instead of linking the local `../utils` directory.
+   */
+  it("rewrites workspace refs to file: refs in internal dep lockfile entries", async () => {
+    const { tmpBase, workspaceRoot } = await setupFixture("internal-deps");
+    cleanupPaths.push(tmpBase);
+
+    const isolateDir = path.join(workspaceRoot, "packages/api/isolate");
+    await fs.ensureDir(isolateDir);
+
+    /**
+     * Simulate what adaptInternalPackageManifests + unpackDependencies
+     * produce: the isolate dir contains the target manifest at the root
+     * and each internal dep's adapted manifest at its rootRelativeDir.
+     */
+    await fs.writeJson(path.join(isolateDir, "package.json"), {
+      name: "api",
+      version: "1.0.0",
+      dependencies: {
+        shared: "file:./packages/shared",
+        semver: "^7.6.0",
+      },
+    });
+
+    await fs.ensureDir(path.join(isolateDir, "packages/shared"));
+    await fs.writeJson(path.join(isolateDir, "packages/shared/package.json"), {
+      name: "shared",
+      version: "1.0.0",
+      dependencies: {
+        utils: "file:../utils",
+        ms: "^2.1.3",
+      },
+    });
+
+    await fs.ensureDir(path.join(isolateDir, "packages/utils"));
+    await fs.writeJson(path.join(isolateDir, "packages/utils/package.json"), {
+      name: "utils",
+      version: "1.0.0",
+      dependencies: {
+        debug: "^4.3.0",
+      },
+    });
+
+    await generateNpmLockfile({
+      workspaceRootDir: workspaceRoot,
+      isolateDir,
+      targetPackageName: "api",
+      targetPackageManifest: {
+        name: "api",
+        version: "1.0.0",
+        dependencies: {
+          shared: "file:./packages/shared",
+          semver: "^7.6.0",
+        },
+      },
+      packagesRegistry: {
+        shared: {
+          absoluteDir: path.join(workspaceRoot, "packages/shared"),
+          rootRelativeDir: "packages/shared",
+          manifest: { name: "shared", version: "1.0.0" },
+        },
+        utils: {
+          absoluteDir: path.join(workspaceRoot, "packages/utils"),
+          rootRelativeDir: "packages/utils",
+          manifest: { name: "utils", version: "1.0.0" },
+        },
+      },
+      internalDepPackageNames: ["shared", "utils"],
+    });
+
+    const output = (await fs.readJson(
+      path.join(isolateDir, "package-lock.json"),
+    )) as {
+      packages: Record<
+        string,
+        {
+          version?: string;
+          dependencies?: Record<string, string>;
+          link?: boolean;
+          resolved?: string;
+        }
+      >;
+    };
+
+    /** Internal dep entries are present at their original relative paths. */
+    expect(output.packages["packages/shared"]).toBeDefined();
+    expect(output.packages["packages/utils"]).toBeDefined();
+
+    /** The adapted manifest's file: refs are applied to shared's entry. */
+    expect(output.packages["packages/shared"]!.dependencies).toEqual({
+      utils: "file:../utils",
+      ms: "^2.1.3",
+    });
+
+    /** utils keeps its external-only deps unchanged (no cross-internal refs). */
+    expect(output.packages["packages/utils"]!.dependencies).toEqual({
+      debug: "^4.3.0",
+    });
+
+    /** Link entries for internal deps point at the expected relative paths. */
+    expect(output.packages["node_modules/shared"]).toEqual({
+      resolved: "packages/shared",
+      link: true,
+    });
+    expect(output.packages["node_modules/utils"]).toEqual({
+      resolved: "packages/utils",
+      link: true,
+    });
+
+    /** External transitive deps needed by the closure are preserved verbatim. */
+    expect(output.packages["node_modules/semver"]?.version).toBe("7.7.4");
+    expect(output.packages["node_modules/ms"]?.version).toBe("2.1.3");
+    expect(output.packages["node_modules/debug"]?.version).toMatch(/^4\./);
+  });
 });

--- a/src/lib/lockfile/helpers/generate-npm-lockfile.test.ts
+++ b/src/lib/lockfile/helpers/generate-npm-lockfile.test.ts
@@ -318,6 +318,114 @@ describe("buildIsolatedLockfileJson", () => {
   });
 
   /**
+   * When the target's nested entry remaps onto the same path as a hoisted
+   * entry still needed by another reachable dependency, and the two
+   * entries differ in content, we must refuse to produce the lockfile
+   * rather than silently drop one version.
+   */
+  it("throws on a remap collision with conflicting entries", () => {
+    const srcData: Parameters<typeof buildIsolatedLockfileJson>[0]["srcData"] =
+      {
+        name: "root",
+        version: "0.0.0",
+        lockfileVersion: 3,
+        requires: true,
+        packages: {
+          "": { name: "root", version: "0.0.0", workspaces: ["packages/*"] },
+          "packages/api": {
+            name: "api",
+            version: "1.0.0",
+            dependencies: { semver: "^6", shared: "*" },
+          },
+          "packages/shared": {
+            name: "shared",
+            version: "1.0.0",
+            dependencies: { semver: "^7" },
+          },
+          "node_modules/shared": { resolved: "packages/shared", link: true },
+          /** Hoisted v7 used by the internal dep. */
+          "node_modules/semver": {
+            version: "7.7.4",
+            resolved: "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+            integrity: "sha512-hoisted-v7",
+          },
+          /** Nested v6 used by the target — will collide with the hoisted one. */
+          "packages/api/node_modules/semver": {
+            version: "6.3.1",
+            resolved: "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+            integrity: "sha512-nested-v6",
+          },
+        },
+      };
+
+    const reachable: ReachableNode[] = [
+      { location: "packages/api", isLink: false },
+      {
+        location: "node_modules/shared",
+        isLink: true,
+        target: { location: "packages/shared" },
+      },
+      { location: "packages/shared", isLink: false },
+      { location: "node_modules/semver", isLink: false },
+      { location: "packages/api/node_modules/semver", isLink: false },
+    ];
+
+    expect(() =>
+      buildIsolatedLockfileJson({
+        srcData,
+        reachable,
+        targetImporterLoc: "packages/api",
+        targetLinkLoc: "node_modules/api",
+        targetPackageManifest: { name: "api", version: "1.0.0" },
+      }),
+    ).toThrow(/Path collision at "node_modules\/semver"/);
+  });
+
+  /**
+   * Identical entries at colliding paths should not throw — copying the
+   * same content twice is a no-op.
+   */
+  it("does not throw when colliding entries are identical", () => {
+    const srcData: Parameters<typeof buildIsolatedLockfileJson>[0]["srcData"] =
+      {
+        name: "root",
+        version: "0.0.0",
+        lockfileVersion: 3,
+        requires: true,
+        packages: {
+          "": { name: "root", version: "0.0.0" },
+          "packages/api": { name: "api", version: "1.0.0" },
+          "node_modules/semver": {
+            version: "7.7.4",
+            resolved: "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+            integrity: "sha512-same",
+          },
+          "packages/api/node_modules/semver": {
+            version: "7.7.4",
+            resolved: "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+            integrity: "sha512-same",
+          },
+        },
+      };
+
+    const reachable: ReachableNode[] = [
+      { location: "packages/api", isLink: false },
+      { location: "node_modules/semver", isLink: false },
+      { location: "packages/api/node_modules/semver", isLink: false },
+    ];
+
+    expect(() =>
+      buildIsolatedLockfileJson({
+        srcData,
+        reachable,
+        targetImporterLoc: "packages/api",
+        targetLinkLoc: "node_modules/api",
+        targetPackageManifest: { name: "api", version: "1.0.0" },
+      }),
+    ).not.toThrow();
+  });
+
+  /**
    * Reproduces the scenario from issue #111 (mono-ts): the target workspace
    * depends on a different version of a package than is hoisted at the root,
    * so the target has its own nested node_modules entry. The isolated

--- a/src/lib/lockfile/helpers/generate-npm-lockfile.test.ts
+++ b/src/lib/lockfile/helpers/generate-npm-lockfile.test.ts
@@ -302,6 +302,93 @@ describe("buildIsolatedLockfileJson", () => {
     expect(out.overrides).toBeUndefined();
   });
 
+  it("throws when the target importer is not in the reachable set", () => {
+    const srcData = createSrcLockfile();
+    /** Reachable set without the target importer — simulates an upstream bug. */
+    const reachable: ReachableNode[] = [
+      { location: "node_modules/express", isLink: false },
+    ];
+    expect(() =>
+      buildIsolatedLockfileJson({
+        srcData,
+        reachable,
+        targetImporterLoc: "packages/my-app",
+        targetLinkLoc: "node_modules/my-app",
+        targetPackageManifest: { name: "my-app", version: "1.0.0" },
+      }),
+    ).toThrow(/was not present in the reachable node set/);
+  });
+
+  it("does not emit a `requires` field when the source omitted it", () => {
+    const srcData = createSrcLockfile();
+    /** Source lockfile without `requires` (some npm versions omit it). */
+    delete (srcData as { requires?: boolean }).requires;
+
+    const out = buildIsolatedLockfileJson({
+      srcData,
+      reachable: createReachable(),
+      targetImporterLoc: "packages/my-app",
+      targetLinkLoc: "node_modules/my-app",
+      targetPackageManifest: { name: "my-app", version: "1.0.0" },
+    });
+
+    expect("requires" in out).toBe(false);
+  });
+
+  it("preserves `requires` when the source has it", () => {
+    const srcData = createSrcLockfile();
+    expect(srcData.requires).toBe(true);
+
+    const out = buildIsolatedLockfileJson({
+      srcData,
+      reachable: createReachable(),
+      targetImporterLoc: "packages/my-app",
+      targetLinkLoc: "node_modules/my-app",
+      targetPackageManifest: { name: "my-app", version: "1.0.0" },
+    });
+
+    expect(out.requires).toBe(true);
+  });
+
+  it("does not remap non-node_modules paths under the target", () => {
+    /**
+     * A target importer at `packages/my-app` with a sibling importer
+     * nested inside it (`packages/my-app/lib/core`) must keep its source
+     * path — remapping it would break both the output lockfile's install
+     * paths and the internal-dep overlay lookup.
+     */
+    const srcData: Parameters<typeof buildIsolatedLockfileJson>[0]["srcData"] =
+      {
+        name: "root",
+        version: "0.0.0",
+        lockfileVersion: 3,
+        requires: true,
+        packages: {
+          "": { name: "root", version: "0.0.0" },
+          "packages/my-app": { name: "my-app", version: "1.0.0" },
+          "packages/my-app/lib/core": { name: "core", version: "1.0.0" },
+        },
+      };
+
+    const reachable: ReachableNode[] = [
+      { location: "packages/my-app", isLink: false },
+      { location: "packages/my-app/lib/core", isLink: false },
+    ];
+
+    const out = buildIsolatedLockfileJson({
+      srcData,
+      reachable,
+      targetImporterLoc: "packages/my-app",
+      targetLinkLoc: "node_modules/my-app",
+      targetPackageManifest: { name: "my-app", version: "1.0.0" },
+    });
+
+    /** Nested importer stays at its source path. */
+    expect(out.packages["packages/my-app/lib/core"]).toBeDefined();
+    /** It must NOT be remapped to "lib/core". */
+    expect(out.packages["lib/core"]).toBeUndefined();
+  });
+
   it("removes dep fields from root entry when adapted manifest omits them", () => {
     const srcData = createSrcLockfile();
     const out = buildIsolatedLockfileJson({

--- a/src/lib/lockfile/helpers/generate-npm-lockfile.test.ts
+++ b/src/lib/lockfile/helpers/generate-npm-lockfile.test.ts
@@ -1,0 +1,319 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildIsolatedLockfileJson,
+  type ReachableNode,
+} from "./generate-npm-lockfile";
+
+/**
+ * Builds a fixture lockfile representing a monorepo with:
+ *   - root workspace at ""
+ *   - target workspace "my-app" at "packages/my-app"
+ *   - internal workspace "shared" at "packages/shared"
+ *   - unrelated workspace "other" at "packages/other"
+ *   - hoisted external deps express@4, lodash@4
+ *   - transitive dep body-parser nested under express due to a version pin
+ */
+function createSrcLockfile() {
+  return {
+    name: "root",
+    version: "0.0.0",
+    lockfileVersion: 3,
+    requires: true,
+    packages: {
+      "": {
+        name: "root",
+        version: "0.0.0",
+        workspaces: ["packages/*"],
+      },
+      "packages/my-app": {
+        name: "my-app",
+        version: "1.0.0",
+        dependencies: {
+          shared: "*",
+          express: "^4.0.0",
+        },
+        devDependencies: {
+          lodash: "^4.17.0",
+        },
+      },
+      "packages/shared": {
+        name: "shared",
+        version: "1.0.0",
+        dependencies: {
+          lodash: "^4.17.0",
+        },
+      },
+      "packages/other": {
+        name: "other",
+        version: "1.0.0",
+      },
+      "node_modules/my-app": {
+        resolved: "packages/my-app",
+        link: true,
+      },
+      "node_modules/shared": {
+        resolved: "packages/shared",
+        link: true,
+      },
+      "node_modules/other": {
+        resolved: "packages/other",
+        link: true,
+      },
+      "node_modules/express": {
+        version: "4.18.2",
+        resolved: "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
+        integrity: "sha512-fake-express-integrity",
+        dependencies: {
+          "body-parser": "1.20.0",
+        },
+      },
+      "node_modules/express/node_modules/body-parser": {
+        version: "1.20.0",
+        resolved:
+          "https://registry.npmjs.org/body-parser/-/body-parser-1.20.0.tgz",
+        integrity: "sha512-fake-body-parser-integrity",
+      },
+      "node_modules/lodash": {
+        version: "4.17.21",
+        resolved: "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+        integrity: "sha512-fake-lodash-integrity",
+        dev: true,
+      },
+    },
+  };
+}
+
+/**
+ * Builds the reachable node set that Arborist's workspaceDependencySet would
+ * produce for the target "my-app", plus the explicit inclusion of the target's
+ * real importer Node (which workspaceDependencySet omits).
+ */
+function createReachable(): ReachableNode[] {
+  return [
+    {
+      location: "node_modules/my-app",
+      isLink: true,
+      target: { location: "packages/my-app" },
+    },
+    { location: "packages/my-app", isLink: false },
+    {
+      location: "node_modules/shared",
+      isLink: true,
+      target: { location: "packages/shared" },
+    },
+    { location: "packages/shared", isLink: false },
+    { location: "node_modules/express", isLink: false },
+    {
+      location: "node_modules/express/node_modules/body-parser",
+      isLink: false,
+    },
+    { location: "node_modules/lodash", isLink: false },
+  ];
+}
+
+describe("buildIsolatedLockfileJson", () => {
+  it("maps target workspace to root and drops target self-link", () => {
+    const srcData = createSrcLockfile();
+    const out = buildIsolatedLockfileJson({
+      srcData,
+      reachable: createReachable(),
+      targetImporterLoc: "packages/my-app",
+      targetLinkLoc: "node_modules/my-app",
+      targetPackageManifest: {
+        name: "my-app",
+        version: "1.0.0",
+        dependencies: {
+          shared: "file:./packages/shared",
+          express: "^4.0.0",
+        },
+      },
+    });
+
+    expect(out.packages[""]).toBeDefined();
+    expect(out.packages[""]!.name).toBe("my-app");
+    expect(out.packages[""]!.version).toBe("1.0.0");
+    expect(out.packages["packages/my-app"]).toBeUndefined();
+    expect(out.packages["node_modules/my-app"]).toBeUndefined();
+  });
+
+  it("preserves external package resolved/integrity verbatim", () => {
+    const srcData = createSrcLockfile();
+    const out = buildIsolatedLockfileJson({
+      srcData,
+      reachable: createReachable(),
+      targetImporterLoc: "packages/my-app",
+      targetLinkLoc: "node_modules/my-app",
+      targetPackageManifest: { name: "my-app", version: "1.0.0" },
+    });
+
+    expect(out.packages["node_modules/express"]).toEqual(
+      srcData.packages["node_modules/express"],
+    );
+    expect(out.packages["node_modules/lodash"]).toEqual(
+      srcData.packages["node_modules/lodash"],
+    );
+  });
+
+  it("preserves nested node_modules paths (hoisting duplicates)", () => {
+    const srcData = createSrcLockfile();
+    const out = buildIsolatedLockfileJson({
+      srcData,
+      reachable: createReachable(),
+      targetImporterLoc: "packages/my-app",
+      targetLinkLoc: "node_modules/my-app",
+      targetPackageManifest: { name: "my-app", version: "1.0.0" },
+    });
+
+    expect(
+      out.packages["node_modules/express/node_modules/body-parser"],
+    ).toEqual(
+      srcData.packages["node_modules/express/node_modules/body-parser"],
+    );
+  });
+
+  it("excludes unrelated workspaces and their link entries", () => {
+    const srcData = createSrcLockfile();
+    const out = buildIsolatedLockfileJson({
+      srcData,
+      reachable: createReachable(),
+      targetImporterLoc: "packages/my-app",
+      targetLinkLoc: "node_modules/my-app",
+      targetPackageManifest: { name: "my-app", version: "1.0.0" },
+    });
+
+    expect(out.packages["packages/other"]).toBeUndefined();
+    expect(out.packages["node_modules/other"]).toBeUndefined();
+  });
+
+  it("preserves internal workspace link entries", () => {
+    const srcData = createSrcLockfile();
+    const out = buildIsolatedLockfileJson({
+      srcData,
+      reachable: createReachable(),
+      targetImporterLoc: "packages/my-app",
+      targetLinkLoc: "node_modules/my-app",
+      targetPackageManifest: { name: "my-app", version: "1.0.0" },
+    });
+
+    expect(out.packages["node_modules/shared"]).toEqual({
+      resolved: "packages/shared",
+      link: true,
+    });
+    expect(out.packages["packages/shared"]).toBeDefined();
+    expect(out.packages["packages/shared"]!.name).toBe("shared");
+  });
+
+  it("overlays root entry deps from the adapted target manifest", () => {
+    const srcData = createSrcLockfile();
+    const out = buildIsolatedLockfileJson({
+      srcData,
+      reachable: createReachable(),
+      targetImporterLoc: "packages/my-app",
+      targetLinkLoc: "node_modules/my-app",
+      targetPackageManifest: {
+        name: "my-app",
+        version: "1.0.0",
+        dependencies: {
+          shared: "file:./packages/shared",
+          express: "^4.0.0",
+        },
+        devDependencies: {
+          lodash: "^4.17.0",
+        },
+      },
+    });
+
+    expect(out.packages[""]!.dependencies).toEqual({
+      shared: "file:./packages/shared",
+      express: "^4.0.0",
+    });
+    expect(out.packages[""]!.devDependencies).toEqual({
+      lodash: "^4.17.0",
+    });
+  });
+
+  it("strips workspaces field from root entry", () => {
+    const srcData = createSrcLockfile();
+    const out = buildIsolatedLockfileJson({
+      srcData,
+      reachable: createReachable(),
+      targetImporterLoc: "packages/my-app",
+      targetLinkLoc: "node_modules/my-app",
+      targetPackageManifest: { name: "my-app", version: "1.0.0" },
+    });
+
+    expect(out.packages[""]!.workspaces).toBeUndefined();
+  });
+
+  it("preserves lockfileVersion and requires from source", () => {
+    const srcData = createSrcLockfile();
+    const out = buildIsolatedLockfileJson({
+      srcData,
+      reachable: createReachable(),
+      targetImporterLoc: "packages/my-app",
+      targetLinkLoc: "node_modules/my-app",
+      targetPackageManifest: { name: "my-app", version: "1.0.0" },
+    });
+
+    expect(out.lockfileVersion).toBe(3);
+    expect(out.requires).toBe(true);
+  });
+
+  it("sets top-level name and version from target manifest", () => {
+    const srcData = createSrcLockfile();
+    const out = buildIsolatedLockfileJson({
+      srcData,
+      reachable: createReachable(),
+      targetImporterLoc: "packages/my-app",
+      targetLinkLoc: "node_modules/my-app",
+      targetPackageManifest: { name: "my-app", version: "2.3.4" },
+    });
+
+    expect(out.name).toBe("my-app");
+    expect(out.version).toBe("2.3.4");
+  });
+
+  it("preserves overrides from source lockfile", () => {
+    const srcData = {
+      ...createSrcLockfile(),
+      overrides: { lodash: "4.17.21" },
+    };
+    const out = buildIsolatedLockfileJson({
+      srcData,
+      reachable: createReachable(),
+      targetImporterLoc: "packages/my-app",
+      targetLinkLoc: "node_modules/my-app",
+      targetPackageManifest: { name: "my-app", version: "1.0.0" },
+    });
+
+    expect(out.overrides).toEqual({ lodash: "4.17.21" });
+  });
+
+  it("omits overrides when source has none", () => {
+    const srcData = createSrcLockfile();
+    const out = buildIsolatedLockfileJson({
+      srcData,
+      reachable: createReachable(),
+      targetImporterLoc: "packages/my-app",
+      targetLinkLoc: "node_modules/my-app",
+      targetPackageManifest: { name: "my-app", version: "1.0.0" },
+    });
+
+    expect(out.overrides).toBeUndefined();
+  });
+
+  it("removes dep fields from root entry when adapted manifest omits them", () => {
+    const srcData = createSrcLockfile();
+    const out = buildIsolatedLockfileJson({
+      srcData,
+      reachable: createReachable(),
+      targetImporterLoc: "packages/my-app",
+      targetLinkLoc: "node_modules/my-app",
+      /** Adapted manifest with no deps */
+      targetPackageManifest: { name: "my-app", version: "1.0.0" },
+    });
+
+    expect(out.packages[""]!.dependencies).toBeUndefined();
+    expect(out.packages[""]!.devDependencies).toBeUndefined();
+  });
+});

--- a/src/lib/lockfile/helpers/generate-npm-lockfile.test.ts
+++ b/src/lib/lockfile/helpers/generate-npm-lockfile.test.ts
@@ -316,4 +316,94 @@ describe("buildIsolatedLockfileJson", () => {
     expect(out.packages[""]!.dependencies).toBeUndefined();
     expect(out.packages[""]!.devDependencies).toBeUndefined();
   });
+
+  /**
+   * Reproduces the scenario from issue #111 (mono-ts): the target workspace
+   * depends on a different version of a package than is hoisted at the root,
+   * so the target has its own nested node_modules entry. The isolated
+   * lockfile must surface that nested version at the root-level
+   * node_modules (because the target becomes the isolate root) and it must
+   * preserve the original resolved/integrity exactly.
+   */
+  it("remaps nested node_modules under the target to the isolate root", () => {
+    const srcData = {
+      name: "root",
+      version: "0.0.0",
+      lockfileVersion: 3,
+      requires: true,
+      packages: {
+        "": { name: "root", version: "0.0.0", workspaces: ["services/*"] },
+        "services/api": {
+          name: "api",
+          version: "1.0.0",
+          dependencies: { "firebase-admin": "^12.0.0" },
+        },
+        "services/other": {
+          name: "other",
+          version: "1.0.0",
+          dependencies: { "firebase-admin": "^11.0.0" },
+        },
+        "node_modules/api": { resolved: "services/api", link: true },
+        "node_modules/other": { resolved: "services/other", link: true },
+        /** Hoisted old version used by the root and "other". */
+        "node_modules/firebase-admin": {
+          version: "11.11.1",
+          resolved:
+            "https://registry.npmjs.org/firebase-admin/-/firebase-admin-11.11.1.tgz",
+          integrity: "sha512-hoisted-v11-integrity",
+        },
+        /** Nested new version used by the target "api". */
+        "services/api/node_modules/firebase-admin": {
+          version: "12.7.0",
+          resolved:
+            "https://registry.npmjs.org/firebase-admin/-/firebase-admin-12.7.0.tgz",
+          integrity: "sha512-nested-v12-integrity",
+        },
+      },
+    };
+
+    const reachable: ReachableNode[] = [
+      {
+        location: "node_modules/api",
+        isLink: true,
+        target: { location: "services/api" },
+      },
+      { location: "services/api", isLink: false },
+      /** Only the nested v12 is reachable from the target. */
+      {
+        location: "services/api/node_modules/firebase-admin",
+        isLink: false,
+      },
+    ];
+
+    const out = buildIsolatedLockfileJson({
+      srcData,
+      reachable,
+      targetImporterLoc: "services/api",
+      targetLinkLoc: "node_modules/api",
+      targetPackageManifest: {
+        name: "api",
+        version: "1.0.0",
+        dependencies: { "firebase-admin": "^12.0.0" },
+      },
+    });
+
+    /** Nested entry is hoisted to the isolate's root node_modules. */
+    expect(out.packages["node_modules/firebase-admin"]).toEqual({
+      version: "12.7.0",
+      resolved:
+        "https://registry.npmjs.org/firebase-admin/-/firebase-admin-12.7.0.tgz",
+      integrity: "sha512-nested-v12-integrity",
+    });
+
+    /** The original nested path must not leak into the output. */
+    expect(
+      out.packages["services/api/node_modules/firebase-admin"],
+    ).toBeUndefined();
+
+    /** The hoisted v11 must not leak in either. */
+    expect(out.packages["node_modules/firebase-admin"]!.version).not.toBe(
+      "11.11.1",
+    );
+  });
 });

--- a/src/lib/lockfile/helpers/generate-npm-lockfile.ts
+++ b/src/lib/lockfile/helpers/generate-npm-lockfile.ts
@@ -275,7 +275,7 @@ export function buildIsolatedLockfileJson({
     );
   }
 
-  const targetPrefix = `${targetImporterLoc}/`;
+  const targetNestedNodeModulesPrefix = `${targetImporterLoc}/node_modules/`;
 
   /** Track the source location each output entry came from, so we can
    * produce a clear error if two source paths remap to the same target.
@@ -294,16 +294,16 @@ export function buildIsolatedLockfileJson({
      *   "packages/app/node_modules/<name>"     -> "node_modules/<name>"
      *   "packages/app/node_modules/a/node_modules/b" -> "node_modules/a/node_modules/b"
      *
-     * This matters when the target has its own nested version overrides
-     * in the source lockfile — those nested entries need to live at the
-     * isolate's root-level `node_modules` instead of remaining under the
-     * target's old workspace path (which does not exist in the isolate).
+     * Only `node_modules` subpaths under the target are remapped — other
+     * paths (e.g. a nested workspace importer like
+     * `packages/app/lib/core`) are preserved verbatim because their disk
+     * location in the isolate is unchanged.
      */
     let newLoc: string;
     if (origLoc === targetImporterLoc) {
       newLoc = "";
-    } else if (origLoc.startsWith(targetPrefix)) {
-      newLoc = origLoc.slice(targetPrefix.length);
+    } else if (origLoc.startsWith(targetNestedNodeModulesPrefix)) {
+      newLoc = origLoc.slice(targetImporterLoc.length + 1);
     } else {
       newLoc = origLoc;
     }
@@ -329,6 +329,17 @@ export function buildIsolatedLockfileJson({
     origLocByNewLoc.set(newLoc, origLoc);
   }
 
+  /**
+   * If the target importer didn't make it into the reachable set for any
+   * reason (upstream Arborist bug, programmer error), bail loudly rather
+   * than emit a synthesised root entry with no source metadata.
+   */
+  if (!outPackages[""]) {
+    throw new Error(
+      `Target importer "${targetImporterLoc}" was not present in the reachable node set; cannot construct isolate root entry`,
+    );
+  }
+
   /** Overlay the isolate root with the adapted target manifest. */
   const rootEntry: LockfilePackageEntry = { ...outPackages[""] };
   rootEntry.name = targetPackageManifest.name;
@@ -352,9 +363,16 @@ export function buildIsolatedLockfileJson({
     name: targetPackageManifest.name,
     version: targetPackageManifest.version,
     lockfileVersion: srcData.lockfileVersion ?? 3,
-    requires: srcData.requires ?? true,
     packages: outPackages,
   };
+  /**
+   * `requires` is propagated via the `...srcData` spread when the source
+   * has it. Don't invent one when the source omitted it — that would be
+   * an unnecessary diff from the original lockfile shape.
+   */
+  if (srcData.requires === undefined) {
+    delete out.requires;
+  }
   delete out.dependencies;
 
   return out;

--- a/src/lib/lockfile/helpers/generate-npm-lockfile.ts
+++ b/src/lib/lockfile/helpers/generate-npm-lockfile.ts
@@ -2,50 +2,329 @@ import Arborist from "@npmcli/arborist";
 import fs from "fs-extra";
 import path from "node:path";
 import { useLogger } from "~/lib/logger";
+import type { PackageManifest, PackagesRegistry } from "~/lib/types";
 import { getErrorMessage } from "~/lib/utils";
 import { loadNpmConfig } from "./load-npm-config";
 
 /**
- * Generate an isolated / pruned lockfile, based on the contents of installed
- * node_modules from the monorepo root plus the adapted package manifest in the
- * isolate directory.
+ * Subset of a package-lock.json v2/v3 `packages[location]` entry that we
+ * care about when rewriting. Arborist / npm preserve any additional fields
+ * we don't enumerate here via object spread.
+ */
+type LockfilePackageEntry = {
+  name?: string;
+  version?: string;
+  resolved?: string;
+  integrity?: string;
+  link?: boolean;
+  dev?: boolean;
+  optional?: boolean;
+  peer?: boolean;
+  devOptional?: boolean;
+  extraneous?: boolean;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+  peerDependenciesMeta?: Record<string, unknown>;
+  bundleDependencies?: string[] | boolean;
+  workspaces?: string[] | Record<string, unknown>;
+  engines?: Record<string, string>;
+  os?: string[];
+  cpu?: string[];
+  libc?: string[];
+  bin?: Record<string, string> | string;
+  funding?: unknown;
+  license?: string;
+  hasInstallScript?: boolean;
+  inBundle?: boolean;
+  deprecated?: string;
+};
+
+type NpmLockfile = {
+  name?: string;
+  version?: string;
+  lockfileVersion: number;
+  requires?: boolean;
+  packages: Record<string, LockfilePackageEntry>;
+  overrides?: Record<string, unknown>;
+};
+
+/**
+ * Minimal node shape we consume from Arborist. Kept narrow so the pure JSON
+ * rewriter can be tested without instantiating a real tree.
+ */
+export type ReachableNode = {
+  location: string;
+  isLink: boolean;
+  target?: { location: string };
+};
+
+/**
+ * Generate an isolated NPM lockfile for the target package.
+ *
+ * When a root `package-lock.json` exists we preserve original resolved
+ * versions and integrity by copying entries verbatim from the source
+ * lockfile. When it doesn't (forceNpm from pnpm/bun/yarn or modern-Yarn
+ * fallback), we fall back to Arborist's `buildIdealTree` against the
+ * isolate directory, which matches the prior behaviour.
  */
 export async function generateNpmLockfile({
+  workspaceRootDir,
+  isolateDir,
+  targetPackageName,
+  targetPackageManifest,
+  packagesRegistry,
+  internalDepPackageNames,
+}: {
+  workspaceRootDir: string;
+  isolateDir: string;
+  targetPackageName: string;
+  targetPackageManifest: PackageManifest;
+  packagesRegistry: PackagesRegistry;
+  internalDepPackageNames: string[];
+}) {
+  const log = useLogger();
+
+  try {
+    const rootLockfilePath = path.join(workspaceRootDir, "package-lock.json");
+
+    if (fs.existsSync(rootLockfilePath)) {
+      log.debug("Generating NPM lockfile from root package-lock.json...");
+      await generateFromRootLockfile({
+        workspaceRootDir,
+        isolateDir,
+        targetPackageName,
+        targetPackageManifest,
+        packagesRegistry,
+        internalDepPackageNames,
+      });
+    } else {
+      log.debug(
+        "No root package-lock.json found; falling back to buildIdealTree generation",
+      );
+      await generateViaBuildIdealTree({ workspaceRootDir, isolateDir });
+    }
+
+    log.debug(
+      "Created lockfile at",
+      path.join(isolateDir, "package-lock.json"),
+    );
+  } catch (err) {
+    log.error(`Failed to generate lockfile: ${getErrorMessage(err)}`);
+    throw err;
+  }
+}
+
+async function generateFromRootLockfile({
+  workspaceRootDir,
+  isolateDir,
+  targetPackageName,
+  targetPackageManifest,
+  packagesRegistry,
+  internalDepPackageNames,
+}: {
+  workspaceRootDir: string;
+  isolateDir: string;
+  targetPackageName: string;
+  targetPackageManifest: PackageManifest;
+  packagesRegistry: PackagesRegistry;
+  internalDepPackageNames: string[];
+}) {
+  const log = useLogger();
+
+  const config = await loadNpmConfig({ npmPath: workspaceRootDir });
+
+  const arborist = new Arborist({
+    path: workspaceRootDir,
+    ...config.flat,
+  });
+
+  /**
+   * `loadVirtual` hydrates every Node with `resolved` and `integrity` taken
+   * directly from the lockfile entries. It performs no registry calls.
+   */
+  const rootTree = await arborist.loadVirtual();
+
+  const workspaceNodes = arborist.workspaceNodes(rootTree, [targetPackageName]);
+  const targetLink = workspaceNodes[0];
+
+  if (!targetLink) {
+    throw new Error(
+      `Target workspace "${targetPackageName}" not found in root package-lock.json`,
+    );
+  }
+
+  /**
+   * `workspaceDependencySet` seeds with the workspace Link nodes and walks
+   * `edgesOut`, adding Link targets along the way. It does not add the
+   * target workspace's own importer Node, so we add it explicitly below.
+   */
+  const reachableNodes = arborist.workspaceDependencySet(
+    rootTree,
+    [targetPackageName],
+    false,
+  );
+  reachableNodes.add(targetLink.target);
+
+  const srcData = rootTree.meta?.data as NpmLockfile | undefined;
+  if (!srcData || !srcData.packages) {
+    throw new Error(
+      "Failed to load source lockfile data from Arborist virtual tree",
+    );
+  }
+
+  const reachable: ReachableNode[] = [...reachableNodes].map((node) => ({
+    location: node.location,
+    isLink: node.isLink,
+    target: node.target ? { location: node.target.location } : undefined,
+  }));
+
+  const internalDepLocs = new Map<string, string>();
+  for (const depName of internalDepPackageNames) {
+    const pkg = packagesRegistry[depName];
+    if (!pkg) {
+      throw new Error(`Package ${depName} not found in packages registry`);
+    }
+    internalDepLocs.set(depName, toPosix(pkg.rootRelativeDir));
+  }
+
+  const out = buildIsolatedLockfileJson({
+    srcData,
+    reachable,
+    targetImporterLoc: targetLink.target.location,
+    targetLinkLoc: targetLink.location,
+    targetPackageManifest,
+  });
+
+  /**
+   * Overlay each internal dep's adapted manifest onto its lockfile entry
+   * so cross-internal-dep references use `file:` instead of `workspace:*`.
+   */
+  for (const [, depLoc] of internalDepLocs) {
+    if (!out.packages[depLoc]) continue;
+    const adaptedManifestPath = path.join(isolateDir, depLoc, "package.json");
+    if (!fs.existsSync(adaptedManifestPath)) {
+      log.debug(
+        `Adapted internal dep manifest missing at ${adaptedManifestPath}; leaving lockfile entry unchanged`,
+      );
+      continue;
+    }
+    const adapted = (await fs.readJson(adaptedManifestPath)) as PackageManifest;
+    overlayManifestDeps(out.packages[depLoc], adapted);
+  }
+
+  const outPath = path.join(isolateDir, "package-lock.json");
+  await fs.writeFile(outPath, JSON.stringify(out, null, 2) + "\n");
+}
+
+/**
+ * Pure JSON rewrite of the source lockfile into an isolated lockfile.
+ * Extracted so it can be unit tested without mocking Arborist.
+ */
+export function buildIsolatedLockfileJson({
+  srcData,
+  reachable,
+  targetImporterLoc,
+  targetLinkLoc,
+  targetPackageManifest,
+}: {
+  srcData: NpmLockfile;
+  reachable: ReachableNode[];
+  /** Source location of the target workspace's real importer (e.g. "packages/app") */
+  targetImporterLoc: string;
+  /** Source location of the target workspace's Link (e.g. "node_modules/app") */
+  targetLinkLoc: string;
+  targetPackageManifest: PackageManifest;
+}): NpmLockfile {
+  const outPackages: Record<string, LockfilePackageEntry> = {};
+  const srcPackages = srcData.packages;
+
+  for (const node of reachable) {
+    const origLoc = node.location;
+
+    /** The target's self-link has no place in the isolate (root IS the target). */
+    if (origLoc === targetLinkLoc) continue;
+
+    const newLoc = origLoc === targetImporterLoc ? "" : origLoc;
+
+    const srcEntry = srcPackages[origLoc];
+    if (!srcEntry) continue;
+
+    outPackages[newLoc] = { ...srcEntry };
+  }
+
+  /** Overlay the isolate root with the adapted target manifest. */
+  const rootEntry: LockfilePackageEntry = { ...outPackages[""] };
+  rootEntry.name = targetPackageManifest.name;
+  if (targetPackageManifest.version) {
+    rootEntry.version = targetPackageManifest.version;
+  }
+  overlayManifestDeps(rootEntry, targetPackageManifest);
+  /** The isolate is no longer a workspace root. */
+  delete rootEntry.workspaces;
+  outPackages[""] = rootEntry;
+
+  const out: NpmLockfile = {
+    name: targetPackageManifest.name,
+    version: targetPackageManifest.version,
+    lockfileVersion: srcData.lockfileVersion ?? 3,
+    requires: srcData.requires ?? true,
+    packages: outPackages,
+  };
+  if (srcData.overrides) {
+    out.overrides = srcData.overrides;
+  }
+
+  return out;
+}
+
+function overlayManifestDeps(
+  entry: LockfilePackageEntry,
+  manifest: PackageManifest,
+) {
+  const fields = [
+    "dependencies",
+    "devDependencies",
+    "optionalDependencies",
+    "peerDependencies",
+  ] as const;
+  for (const field of fields) {
+    const value = manifest[field];
+    if (value) {
+      entry[field] = value;
+    } else {
+      delete entry[field];
+    }
+  }
+}
+
+function toPosix(p: string): string {
+  return p.split(path.sep).join(path.posix.sep);
+}
+
+async function generateViaBuildIdealTree({
   workspaceRootDir,
   isolateDir,
 }: {
   workspaceRootDir: string;
   isolateDir: string;
 }) {
-  const log = useLogger();
-
-  log.debug("Generating NPM lockfile...");
-
   const nodeModulesPath = path.join(workspaceRootDir, "node_modules");
-
-  try {
-    if (!fs.existsSync(nodeModulesPath)) {
-      throw new Error(`Failed to find node_modules at ${nodeModulesPath}`);
-    }
-
-    const config = await loadNpmConfig({ npmPath: workspaceRootDir });
-
-    const arborist = new Arborist({
-      path: isolateDir,
-      ...config.flat,
-    });
-
-    const { meta } = await arborist.buildIdealTree();
-
-    meta?.commit();
-
-    const lockfilePath = path.join(isolateDir, "package-lock.json");
-
-    await fs.writeFile(lockfilePath, String(meta));
-
-    log.debug("Created lockfile at", lockfilePath);
-  } catch (err) {
-    log.error(`Failed to generate lockfile: ${getErrorMessage(err)}`);
-    throw err;
+  if (!fs.existsSync(nodeModulesPath)) {
+    throw new Error(`Failed to find node_modules at ${nodeModulesPath}`);
   }
+
+  const config = await loadNpmConfig({ npmPath: workspaceRootDir });
+
+  const arborist = new Arborist({
+    path: isolateDir,
+    ...config.flat,
+  });
+
+  const { meta } = await arborist.buildIdealTree();
+  meta?.commit();
+
+  const lockfilePath = path.join(isolateDir, "package-lock.json");
+  await fs.writeFile(lockfilePath, String(meta));
 }

--- a/src/lib/lockfile/helpers/generate-npm-lockfile.ts
+++ b/src/lib/lockfile/helpers/generate-npm-lockfile.ts
@@ -48,6 +48,10 @@ type NpmLockfile = {
   requires?: boolean;
   packages: Record<string, LockfilePackageEntry>;
   overrides?: Record<string, unknown>;
+  /** Legacy v2 nested-tree representation; dropped when emitting the isolate lockfile. */
+  dependencies?: unknown;
+  /** Allow unknown top-level fields to flow through. */
+  [key: string]: unknown;
 };
 
 /**
@@ -147,25 +151,31 @@ async function generateFromRootLockfile({
   const rootTree = await arborist.loadVirtual();
 
   const workspaceNodes = arborist.workspaceNodes(rootTree, [targetPackageName]);
-  const targetLink = workspaceNodes[0];
+  const targetImporterNode = workspaceNodes[0];
 
-  if (!targetLink) {
+  if (!targetImporterNode) {
     throw new Error(
       `Target workspace "${targetPackageName}" not found in root package-lock.json`,
     );
   }
 
+  if (typeof targetImporterNode.location !== "string") {
+    throw new Error(
+      `Target workspace "${targetPackageName}" resolved to a node without a location`,
+    );
+  }
+
   /**
-   * `workspaceDependencySet` seeds with the workspace Link nodes and walks
-   * `edgesOut`, adding Link targets along the way. It does not add the
-   * target workspace's own importer Node, so we add it explicitly below.
+   * `workspaceDependencySet` walks `edgesOut` from each seed node. It does
+   * not add the seed node itself to the result, so ensure the target
+   * importer is included.
    */
   const reachableNodes = arborist.workspaceDependencySet(
     rootTree,
     [targetPackageName],
     false,
   );
-  reachableNodes.add(targetLink.target);
+  reachableNodes.add(targetImporterNode);
 
   const srcData = rootTree.meta?.data as NpmLockfile | undefined;
   if (!srcData || !srcData.packages) {
@@ -192,8 +202,14 @@ async function generateFromRootLockfile({
   const out = buildIsolatedLockfileJson({
     srcData,
     reachable,
-    targetImporterLoc: targetLink.target.location,
-    targetLinkLoc: targetLink.location,
+    targetImporterLoc: targetImporterNode.location,
+    /**
+     * npm's lockfile exposes each workspace as a Link at
+     * `node_modules/<name>`. This link is pointless in the isolate (the
+     * target becomes the root), so filter it out if it shows up in the
+     * reachable set.
+     */
+    targetLinkLoc: `node_modules/${targetPackageName}`,
     targetPackageManifest,
   });
 
@@ -240,6 +256,12 @@ export function buildIsolatedLockfileJson({
   const outPackages: Record<string, LockfilePackageEntry> = {};
   const srcPackages = srcData.packages;
 
+  if (!srcPackages[targetImporterLoc]) {
+    throw new Error(
+      `Source lockfile has no entry for target importer "${targetImporterLoc}"`,
+    );
+  }
+
   const targetPrefix = `${targetImporterLoc}/`;
 
   for (const node of reachable) {
@@ -269,7 +291,11 @@ export function buildIsolatedLockfileJson({
     }
 
     const srcEntry = srcPackages[origLoc];
-    if (!srcEntry) continue;
+    if (!srcEntry) {
+      throw new Error(
+        `Reachable node "${origLoc}" has no entry in source lockfile packages`,
+      );
+    }
 
     outPackages[newLoc] = { ...srcEntry };
   }
@@ -285,16 +311,22 @@ export function buildIsolatedLockfileJson({
   delete rootEntry.workspaces;
   outPackages[""] = rootEntry;
 
+  /**
+   * Spread unknown top-level fields from the source lockfile so future
+   * npm-introduced metadata survives isolation. Then override identity
+   * fields and the recomputed `packages`, and drop the legacy
+   * `dependencies` tree which would be stale now that `packages` has
+   * been subsetted.
+   */
   const out: NpmLockfile = {
+    ...srcData,
     name: targetPackageManifest.name,
     version: targetPackageManifest.version,
     lockfileVersion: srcData.lockfileVersion ?? 3,
     requires: srcData.requires ?? true,
     packages: outPackages,
   };
-  if (srcData.overrides) {
-    out.overrides = srcData.overrides;
-  }
+  delete out.dependencies;
 
   return out;
 }

--- a/src/lib/lockfile/helpers/generate-npm-lockfile.ts
+++ b/src/lib/lockfile/helpers/generate-npm-lockfile.ts
@@ -240,13 +240,33 @@ export function buildIsolatedLockfileJson({
   const outPackages: Record<string, LockfilePackageEntry> = {};
   const srcPackages = srcData.packages;
 
+  const targetPrefix = `${targetImporterLoc}/`;
+
   for (const node of reachable) {
     const origLoc = node.location;
 
     /** The target's self-link has no place in the isolate (root IS the target). */
     if (origLoc === targetLinkLoc) continue;
 
-    const newLoc = origLoc === targetImporterLoc ? "" : origLoc;
+    /**
+     * The target workspace becomes the isolate root, so:
+     *   "packages/app"                         -> ""
+     *   "packages/app/node_modules/<name>"     -> "node_modules/<name>"
+     *   "packages/app/node_modules/a/node_modules/b" -> "node_modules/a/node_modules/b"
+     *
+     * This matters when the target has its own nested version overrides
+     * in the source lockfile — those nested entries need to live at the
+     * isolate's root-level `node_modules` instead of remaining under the
+     * target's old workspace path (which does not exist in the isolate).
+     */
+    let newLoc: string;
+    if (origLoc === targetImporterLoc) {
+      newLoc = "";
+    } else if (origLoc.startsWith(targetPrefix)) {
+      newLoc = origLoc.slice(targetPrefix.length);
+    } else {
+      newLoc = origLoc;
+    }
 
     const srcEntry = srcPackages[origLoc];
     if (!srcEntry) continue;

--- a/src/lib/lockfile/helpers/generate-npm-lockfile.ts
+++ b/src/lib/lockfile/helpers/generate-npm-lockfile.ts
@@ -178,10 +178,23 @@ async function generateFromRootLockfile({
   reachableNodes.add(targetImporterNode);
 
   const srcData = rootTree.meta?.data as NpmLockfile | undefined;
-  if (!srcData || !srcData.packages) {
-    throw new Error(
-      "Failed to load source lockfile data from Arborist virtual tree",
+  if (
+    !srcData ||
+    !srcData.packages ||
+    Object.keys(srcData.packages).length === 0
+  ) {
+    /**
+     * Arborist normalises v1 lockfiles to v3 in `loadVirtual`, but fall
+     * back defensively if the virtual tree still has no `packages` map
+     * (e.g. an unusual lockfile shape). The fallback generator reads
+     * node_modules and won't preserve original versions, but it will
+     * produce a valid lockfile rather than failing.
+     */
+    useLogger().debug(
+      "Source lockfile has no `packages` map; falling back to buildIdealTree",
     );
+    await generateViaBuildIdealTree({ workspaceRootDir, isolateDir });
+    return;
   }
 
   const reachable: ReachableNode[] = [...reachableNodes].map((node) => ({
@@ -264,6 +277,11 @@ export function buildIsolatedLockfileJson({
 
   const targetPrefix = `${targetImporterLoc}/`;
 
+  /** Track the source location each output entry came from, so we can
+   * produce a clear error if two source paths remap to the same target.
+   */
+  const origLocByNewLoc = new Map<string, string>();
+
   for (const node of reachable) {
     const origLoc = node.location;
 
@@ -297,7 +315,18 @@ export function buildIsolatedLockfileJson({
       );
     }
 
+    const existing = outPackages[newLoc];
+    if (existing && !entriesAreEquivalent(existing, srcEntry)) {
+      const previousOrigLoc = origLocByNewLoc.get(newLoc) ?? "<unknown>";
+      throw new Error(
+        `Path collision at "${newLoc}": source locations "${previousOrigLoc}" and "${origLoc}" both map there with conflicting entries. ` +
+          `This happens when the target pins a nested version override that collides with a hoisted version still needed by another reachable dependency. ` +
+          `Please report a reproduction at https://github.com/0x80/isolate-package/issues.`,
+      );
+    }
+
     outPackages[newLoc] = { ...srcEntry };
+    origLocByNewLoc.set(newLoc, origLoc);
   }
 
   /** Overlay the isolate root with the adapted target manifest. */
@@ -329,6 +358,24 @@ export function buildIsolatedLockfileJson({
   delete out.dependencies;
 
   return out;
+}
+
+/**
+ * Two source entries that map to the same output location are only
+ * "equivalent" if they install identical content. We compare the fields
+ * that actually determine what npm fetches and stores — version, resolved
+ * URL, integrity, and the link flag for workspace links.
+ */
+function entriesAreEquivalent(
+  a: LockfilePackageEntry,
+  b: LockfilePackageEntry,
+): boolean {
+  return (
+    a.version === b.version &&
+    a.resolved === b.resolved &&
+    a.integrity === b.integrity &&
+    !!a.link === !!b.link
+  );
 }
 
 function overlayManifestDeps(

--- a/src/lib/lockfile/process-lockfile.test.ts
+++ b/src/lib/lockfile/process-lockfile.test.ts
@@ -72,6 +72,10 @@ describe("processLockfile", () => {
     expect(generateNpmLockfile).toHaveBeenCalledWith({
       workspaceRootDir: "/workspace",
       isolateDir: "/workspace/apps/my-app/isolate",
+      targetPackageName: "my-app",
+      targetPackageManifest: { name: "my-app", version: "1.0.0" },
+      packagesRegistry: {},
+      internalDepPackageNames: [],
     });
     expect(result).toBe(false);
   });

--- a/src/lib/lockfile/process-lockfile.ts
+++ b/src/lib/lockfile/process-lockfile.ts
@@ -22,6 +22,7 @@ export async function processLockfile({
   isolateDir,
   internalDepPackageNames,
   targetPackageDir,
+  targetPackageName,
   targetPackageManifest,
   patchedDependencies,
   config,
@@ -39,13 +40,19 @@ export async function processLockfile({
 }) {
   const log = useLogger();
 
+  const npmGeneratorParams = {
+    workspaceRootDir,
+    isolateDir,
+    targetPackageName,
+    targetPackageManifest,
+    packagesRegistry,
+    internalDepPackageNames,
+  };
+
   if (config.forceNpm) {
     log.debug("Forcing to use NPM for isolate output");
 
-    await generateNpmLockfile({
-      workspaceRootDir,
-      isolateDir,
-    });
+    await generateNpmLockfile(npmGeneratorParams);
 
     return true;
   }
@@ -55,10 +62,7 @@ export async function processLockfile({
 
   switch (name) {
     case "npm": {
-      await generateNpmLockfile({
-        workspaceRootDir,
-        isolateDir,
-      });
+      await generateNpmLockfile(npmGeneratorParams);
 
       break;
     }
@@ -73,10 +77,7 @@ export async function processLockfile({
           "Detected modern version of Yarn. Using NPM lockfile fallback.",
         );
 
-        await generateNpmLockfile({
-          workspaceRootDir,
-          isolateDir,
-        });
+        await generateNpmLockfile(npmGeneratorParams);
 
         usedFallbackToNpm = true;
       }
@@ -112,10 +113,7 @@ export async function processLockfile({
       log.warn(
         `Unexpected package manager ${name as string}. Using NPM for output`,
       );
-      await generateNpmLockfile({
-        workspaceRootDir,
-        isolateDir,
-      });
+      await generateNpmLockfile(npmGeneratorParams);
 
       usedFallbackToNpm = true;
   }


### PR DESCRIPTION
Closes #111.

The NPM lockfile generator previously called `arborist.buildIdealTree()`
on the isolate directory, which ignores the monorepo's root
`package-lock.json` and resolves dependencies against the isolate's
adapted manifest. The isolated lockfile could therefore contain
different versions and integrity hashes than the monorepo's lockfile,
breaking reproducibility for deployments.

The new implementation uses Arborist only for graph traversal.
`loadVirtual` at the workspace root hydrates every Node with the
original `resolved` and `integrity` from the root lockfile (no registry
calls), and `workspaceDependencySet` identifies the transitive closure
needed by the target. The isolated `package-lock.json` is then built
by copying matching entries verbatim from the source lockfile, so
versions and integrity are preserved exactly.

Path remapping handles the target becoming the isolate root:
- `packages/<target>` becomes `""`
- `packages/<target>/node_modules/<dep>` becomes `node_modules/<dep>`
  — this is the case from #111 where the target pins a different
  version than is hoisted at the workspace root
- The target's own `node_modules/<target>` self-link is dropped
- External `node_modules/…` paths and internal deps' paths are kept
  verbatim

The root `""` entry and each internal dependency entry are overlaid
with their adapted manifest deps so workspace references become `file:`
references.

When no root `package-lock.json` exists (`forceNpm` from pnpm/bun/yarn,
or the modern-Yarn fallback), the generator falls back to the prior
`buildIdealTree` behavior unchanged.

A checked-in fixture reproduces the #111 scenario (real npm workspaces
monorepo where the target pins semver@^6 and a sibling pins semver@^7,
so npm hoists 7.7.4 at root and nests 6.3.1 under the target). The
integration test runs `generateNpmLockfile` against it and asserts the
isolated lockfile surfaces the nested 6.3.1 at the isolate root and
excludes the sibling's hoisted 7.7.4.

Scope: lockfile (npm)
Visibility: user-facing