### PR TITLE
Preserve patches for transitive dependencies via internal packages

### DIFF
--- a/src/isolate.ts
+++ b/src/isolate.ts
@@ -233,6 +233,7 @@ export function createIsolator(config?: IsolateConfig) {
       ? await copyPatches({
           workspaceRootDir,
           targetPackageManifest: outputManifest,
+          packagesRegistry,
           isolateDir,
           includeDevDependencies: config.includeDevDependencies,
         })

--- a/src/lib/patches/copy-patches.test.ts
+++ b/src/lib/patches/copy-patches.test.ts
@@ -67,6 +67,7 @@ describe("copyPatches", () => {
       workspaceRootDir: "/workspace",
       targetPackageManifest: { name: "test", version: "1.0.0" },
       isolateDir: "/workspace/isolate",
+      packagesRegistry: {},
       includeDevDependencies: false,
     });
 
@@ -127,6 +128,7 @@ describe("copyPatches", () => {
         workspaceRootDir: "/workspace",
         targetPackageManifest: { name: "test", version: "1.0.0" },
         isolateDir: "/workspace/isolate",
+        packagesRegistry: {},
         includeDevDependencies: false,
       });
 
@@ -146,6 +148,7 @@ describe("copyPatches", () => {
         workspaceRootDir: "/workspace",
         targetPackageManifest: { name: "test", version: "1.0.0" },
         isolateDir: "/workspace/isolate",
+        packagesRegistry: {},
         includeDevDependencies: false,
       });
 
@@ -175,6 +178,7 @@ describe("copyPatches", () => {
         workspaceRootDir: "/workspace",
         targetPackageManifest: targetManifest,
         isolateDir: "/workspace/isolate",
+        packagesRegistry: {},
         includeDevDependencies: false,
       });
 
@@ -212,6 +216,7 @@ describe("copyPatches", () => {
         workspaceRootDir: "/workspace",
         targetPackageManifest: targetManifest,
         isolateDir: "/workspace/isolate",
+        packagesRegistry: {},
         includeDevDependencies: true,
       });
 
@@ -222,6 +227,7 @@ describe("copyPatches", () => {
         patchedDependencies: { "vitest@1.0.0": "patches/vitest.patch" },
         targetPackageManifest: targetManifest,
         includeDevDependencies: true,
+        reachableDependencyNames: expect.any(Set),
       });
       expect(fs.copy).toHaveBeenCalledWith(
         "/workspace/patches/vitest.patch",
@@ -252,6 +258,7 @@ describe("copyPatches", () => {
         workspaceRootDir: "/workspace",
         targetPackageManifest: targetManifest,
         isolateDir: "/workspace/isolate",
+        packagesRegistry: {},
         includeDevDependencies: false,
       });
 
@@ -282,6 +289,7 @@ describe("copyPatches", () => {
         workspaceRootDir: "/workspace",
         targetPackageManifest: targetManifest,
         isolateDir: "/workspace/isolate",
+        packagesRegistry: {},
         includeDevDependencies: false,
       });
 
@@ -315,6 +323,7 @@ describe("copyPatches", () => {
         workspaceRootDir: "/workspace",
         targetPackageManifest: targetManifest,
         isolateDir: "/workspace/isolate",
+        packagesRegistry: {},
         includeDevDependencies: false,
       });
 
@@ -357,6 +366,7 @@ describe("copyPatches", () => {
         workspaceRootDir: "/workspace",
         targetPackageManifest: targetManifest,
         isolateDir: "/workspace/isolate",
+        packagesRegistry: {},
         includeDevDependencies: false,
       });
 
@@ -401,6 +411,7 @@ describe("copyPatches", () => {
         workspaceRootDir: "/workspace",
         targetPackageManifest: targetManifest,
         isolateDir: "/workspace/isolate",
+        packagesRegistry: {},
         includeDevDependencies: false,
       });
 
@@ -447,6 +458,7 @@ describe("copyPatches", () => {
       workspaceRootDir: "/workspace",
       targetPackageManifest: targetManifest,
       isolateDir: "/workspace/isolate",
+      packagesRegistry: {},
       includeDevDependencies: false,
     });
 
@@ -457,5 +469,71 @@ describe("copyPatches", () => {
       "/workspace/patches/lodash.patch",
       "/workspace/isolate/patches/lodash.patch",
     );
+  });
+
+  it("should pass reachable transitive dep names from internal packages to the filter (regression: issue #167)", async () => {
+    /**
+     * Target `consumer` depends on internal `firebase-package`, which in turn
+     * depends on `tslib`. A patch for `tslib@2.0.0` declared at the workspace
+     * root must reach the filter with `tslib` in `reachableDependencyNames`
+     * so it can be preserved even though `consumer` doesn't list it directly.
+     */
+    const consumerManifest: PackageManifest = {
+      name: "consumer",
+      version: "1.0.0",
+      dependencies: { "firebase-package": "file:./packages/firebase-package" },
+    };
+
+    readTypedYamlSync.mockReturnValue({
+      patchedDependencies: {
+        "tslib@2.0.0": "patches/tslib@2.0.0.patch",
+      },
+    });
+    readTypedJson.mockResolvedValue({
+      name: "root",
+      version: "1.0.0",
+    } as PackageManifest);
+
+    filterPatchedDependencies.mockReturnValue({
+      "tslib@2.0.0": "patches/tslib@2.0.0.patch",
+    });
+
+    fs.existsSync.mockReturnValue(true);
+
+    usePackageManager.mockReturnValue({
+      name: "pnpm",
+      majorVersion: 9,
+      version: "9.0.0",
+      packageManagerString: "pnpm@9.0.0",
+    });
+
+    const result = await copyPatches({
+      workspaceRootDir: "/workspace",
+      targetPackageManifest: consumerManifest,
+      isolateDir: "/workspace/isolate",
+      packagesRegistry: {
+        "firebase-package": {
+          absoluteDir: "/workspace/packages/firebase-package",
+          rootRelativeDir: "packages/firebase-package",
+          manifest: {
+            name: "firebase-package",
+            version: "1.0.0",
+            dependencies: { tslib: "^2.0.0" },
+          },
+        },
+      },
+      includeDevDependencies: false,
+    });
+
+    expect(result).toEqual({
+      "tslib@2.0.0": { path: "patches/tslib@2.0.0.patch", hash: "" },
+    });
+
+    const filterCall = filterPatchedDependencies.mock.calls[0]?.[0];
+    expect(filterCall).toBeDefined();
+    const reachable = filterCall!.reachableDependencyNames;
+    expect(reachable).toBeInstanceOf(Set);
+    expect(reachable!.has("firebase-package")).toBe(true);
+    expect(reachable!.has("tslib")).toBe(true);
   });
 });

--- a/src/lib/patches/copy-patches.ts
+++ b/src/lib/patches/copy-patches.ts
@@ -4,7 +4,13 @@ import { readWantedLockfile as readWantedLockfile_v8 } from "pnpm_lockfile_file_
 import { readWantedLockfile as readWantedLockfile_v9 } from "pnpm_lockfile_file_v9";
 import { useLogger } from "~/lib/logger";
 import { usePackageManager } from "~/lib/package-manager";
-import type { PackageManifest, PatchFile, PnpmSettings } from "~/lib/types";
+import { collectReachablePackageNames } from "~/lib/registry";
+import type {
+  PackageManifest,
+  PackagesRegistry,
+  PatchFile,
+  PnpmSettings,
+} from "~/lib/types";
 import {
   filterPatchedDependencies,
   getRootRelativeLogPath,
@@ -16,11 +22,13 @@ import {
 export async function copyPatches({
   workspaceRootDir,
   targetPackageManifest,
+  packagesRegistry,
   isolateDir,
   includeDevDependencies,
 }: {
   workspaceRootDir: string;
   targetPackageManifest: PackageManifest;
+  packagesRegistry: PackagesRegistry;
   isolateDir: string;
   includeDevDependencies: boolean;
 }): Promise<Record<string, PatchFile>> {
@@ -82,10 +90,23 @@ export async function copyPatches({
     `Found ${Object.keys(patchedDependencies).length} patched dependencies in workspace`,
   );
 
+  /**
+   * Collect the set of dependency names reachable from the target (direct deps
+   * plus deps introduced by internal workspace packages). Patches for names in
+   * this set are preserved even when the target doesn't list them directly —
+   * see issue #167.
+   */
+  const reachableDependencyNames = collectReachablePackageNames({
+    targetPackageManifest,
+    packagesRegistry,
+    includeDevDependencies,
+  });
+
   const filteredPatches = filterPatchedDependencies({
     patchedDependencies,
     targetPackageManifest,
     includeDevDependencies,
+    reachableDependencyNames,
   });
 
   if (!filteredPatches) {

--- a/src/lib/registry/collect-reachable-package-names.test.ts
+++ b/src/lib/registry/collect-reachable-package-names.test.ts
@@ -152,6 +152,64 @@ describe("collectReachablePackageNames", () => {
     expect([...result].sort()).toEqual(["@scope/leaf", "pkg-a", "pkg-b"]);
   });
 
+  it("walks optionalDependencies of target and internal packages", () => {
+    const appManifest: PackageManifest = {
+      name: "app",
+      version: "1.0.0",
+      dependencies: { "pkg-a": "workspace:*" },
+      optionalDependencies: { "optional-on-target": "^1.0.0" },
+    };
+    const pkgAManifest: PackageManifest = {
+      name: "pkg-a",
+      version: "1.0.0",
+      optionalDependencies: { "optional-on-internal": "^1.0.0" },
+    };
+
+    const registry: PackagesRegistry = {
+      "pkg-a": entry(pkgAManifest),
+    };
+
+    const result = collectReachablePackageNames({
+      targetPackageManifest: appManifest,
+      packagesRegistry: registry,
+      includeDevDependencies: false,
+    });
+
+    expect(result.has("optional-on-target")).toBe(true);
+    expect(result.has("optional-on-internal")).toBe(true);
+  });
+
+  it("walks peerDependencies of target and internal packages", () => {
+    /**
+     * With pnpm's default autoInstallPeers, peer deps typically end up
+     * installed in the isolate and may carry patches.
+     */
+    const appManifest: PackageManifest = {
+      name: "app",
+      version: "1.0.0",
+      dependencies: { "pkg-a": "workspace:*" },
+      peerDependencies: { "peer-on-target": "^1.0.0" },
+    };
+    const pkgAManifest: PackageManifest = {
+      name: "pkg-a",
+      version: "1.0.0",
+      peerDependencies: { "peer-on-internal": "^1.0.0" },
+    };
+
+    const registry: PackagesRegistry = {
+      "pkg-a": entry(pkgAManifest),
+    };
+
+    const result = collectReachablePackageNames({
+      targetPackageManifest: appManifest,
+      packagesRegistry: registry,
+      includeDevDependencies: false,
+    });
+
+    expect(result.has("peer-on-target")).toBe(true);
+    expect(result.has("peer-on-internal")).toBe(true);
+  });
+
   it("tolerates cycles between internal packages", () => {
     /** Each package already visited is skipped on re-entry */
     const aManifest: PackageManifest = {

--- a/src/lib/registry/collect-reachable-package-names.test.ts
+++ b/src/lib/registry/collect-reachable-package-names.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from "vitest";
+import type { PackageManifest, PackagesRegistry } from "~/lib/types";
+import { collectReachablePackageNames } from "./collect-reachable-package-names";
+
+function entry(manifest: PackageManifest) {
+  return {
+    absoluteDir: `/workspace/packages/${manifest.name}`,
+    rootRelativeDir: `packages/${manifest.name}`,
+    manifest,
+  };
+}
+
+describe("collectReachablePackageNames", () => {
+  it("returns target direct deps", () => {
+    const manifest: PackageManifest = {
+      name: "app",
+      version: "1.0.0",
+      dependencies: { lodash: "^4.0.0", tslib: "^2.0.0" },
+    };
+
+    const result = collectReachablePackageNames({
+      targetPackageManifest: manifest,
+      packagesRegistry: {},
+      includeDevDependencies: false,
+    });
+
+    expect([...result].sort()).toEqual(["lodash", "tslib"]);
+  });
+
+  it("excludes target devDependencies when includeDevDependencies is false", () => {
+    const manifest: PackageManifest = {
+      name: "app",
+      version: "1.0.0",
+      dependencies: { lodash: "^4.0.0" },
+      devDependencies: { vitest: "^1.0.0" },
+    };
+
+    const result = collectReachablePackageNames({
+      targetPackageManifest: manifest,
+      packagesRegistry: {},
+      includeDevDependencies: false,
+    });
+
+    expect(result.has("lodash")).toBe(true);
+    expect(result.has("vitest")).toBe(false);
+  });
+
+  it("includes target devDependencies when includeDevDependencies is true", () => {
+    const manifest: PackageManifest = {
+      name: "app",
+      version: "1.0.0",
+      dependencies: { lodash: "^4.0.0" },
+      devDependencies: { vitest: "^1.0.0" },
+    };
+
+    const result = collectReachablePackageNames({
+      targetPackageManifest: manifest,
+      packagesRegistry: {},
+      includeDevDependencies: true,
+    });
+
+    expect([...result].sort()).toEqual(["lodash", "vitest"]);
+  });
+
+  it("recurses through internal workspace packages to pick up their deps", () => {
+    /** Mirrors issue #167: consumer → firebase-package (internal) → tslib */
+    const consumerManifest: PackageManifest = {
+      name: "consumer",
+      version: "1.0.0",
+      dependencies: { "firebase-package": "workspace:*" },
+    };
+    const firebaseManifest: PackageManifest = {
+      name: "firebase-package",
+      version: "1.0.0",
+      dependencies: { tslib: "^2.0.0" },
+    };
+
+    const registry: PackagesRegistry = {
+      "firebase-package": entry(firebaseManifest),
+    };
+
+    const result = collectReachablePackageNames({
+      targetPackageManifest: consumerManifest,
+      packagesRegistry: registry,
+      includeDevDependencies: false,
+    });
+
+    expect(result.has("firebase-package")).toBe(true);
+    expect(result.has("tslib")).toBe(true);
+  });
+
+  it("does not include devDependencies of internal packages", () => {
+    const consumerManifest: PackageManifest = {
+      name: "consumer",
+      version: "1.0.0",
+      dependencies: { "firebase-package": "workspace:*" },
+    };
+    const firebaseManifest: PackageManifest = {
+      name: "firebase-package",
+      version: "1.0.0",
+      dependencies: { tslib: "^2.0.0" },
+      devDependencies: { vitest: "^1.0.0" },
+    };
+
+    const registry: PackagesRegistry = {
+      "firebase-package": entry(firebaseManifest),
+    };
+
+    const result = collectReachablePackageNames({
+      targetPackageManifest: consumerManifest,
+      packagesRegistry: registry,
+      /**
+       * Even with includeDevDependencies true for the target, internal
+       * packages' devDependencies stay out — they aren't installed in the
+       * isolate.
+       */
+      includeDevDependencies: true,
+    });
+
+    expect(result.has("tslib")).toBe(true);
+    expect(result.has("vitest")).toBe(false);
+  });
+
+  it("handles multi-level internal chains", () => {
+    const appManifest: PackageManifest = {
+      name: "app",
+      version: "1.0.0",
+      dependencies: { "pkg-a": "workspace:*" },
+    };
+    const pkgAManifest: PackageManifest = {
+      name: "pkg-a",
+      version: "1.0.0",
+      dependencies: { "pkg-b": "workspace:*" },
+    };
+    const pkgBManifest: PackageManifest = {
+      name: "pkg-b",
+      version: "1.0.0",
+      dependencies: { "@scope/leaf": "^1.0.0" },
+    };
+
+    const registry: PackagesRegistry = {
+      "pkg-a": entry(pkgAManifest),
+      "pkg-b": entry(pkgBManifest),
+    };
+
+    const result = collectReachablePackageNames({
+      targetPackageManifest: appManifest,
+      packagesRegistry: registry,
+      includeDevDependencies: false,
+    });
+
+    expect([...result].sort()).toEqual(["@scope/leaf", "pkg-a", "pkg-b"]);
+  });
+
+  it("tolerates cycles between internal packages", () => {
+    /** Each package already visited is skipped on re-entry */
+    const aManifest: PackageManifest = {
+      name: "pkg-a",
+      version: "1.0.0",
+      dependencies: { "pkg-b": "workspace:*", tslib: "^2.0.0" },
+    };
+    const bManifest: PackageManifest = {
+      name: "pkg-b",
+      version: "1.0.0",
+      dependencies: { "pkg-a": "workspace:*" },
+    };
+
+    const registry: PackagesRegistry = {
+      "pkg-a": entry(aManifest),
+      "pkg-b": entry(bManifest),
+    };
+
+    const result = collectReachablePackageNames({
+      targetPackageManifest: aManifest,
+      packagesRegistry: registry,
+      includeDevDependencies: false,
+    });
+
+    expect([...result].sort()).toEqual(["pkg-a", "pkg-b", "tslib"]);
+  });
+});

--- a/src/lib/registry/collect-reachable-package-names.ts
+++ b/src/lib/registry/collect-reachable-package-names.ts
@@ -11,9 +11,11 @@ import type { PackageManifest, PackagesRegistry } from "../types";
  * `patchedDependencies` so that patches for deps introduced via internal
  * packages aren't dropped.
  *
- * devDependencies of internal packages are never followed — they aren't
- * installed in the isolate. devDependencies of the *target* are followed only
- * when `includeDevDependencies` is true.
+ * `dependencies`, `optionalDependencies`, and `peerDependencies` are all
+ * walked — any of them can lead to a package being installed in the isolate
+ * (pnpm installs peers by default via `autoInstallPeers`). devDependencies of
+ * internal packages are never followed, and devDependencies of the *target*
+ * are followed only when `includeDevDependencies` is true.
  *
  * Note: only recurses through internal packages — manifests of external deps
  * aren't available here. Deep external→external transitives therefore won't
@@ -38,6 +40,8 @@ export function collectReachablePackageNames({
   function walk(manifest: PackageManifest, isTarget: boolean) {
     const depNames = [
       ...Object.keys(manifest.dependencies ?? {}),
+      ...Object.keys(manifest.optionalDependencies ?? {}),
+      ...Object.keys(manifest.peerDependencies ?? {}),
       ...(isTarget && includeDevDependencies
         ? Object.keys(manifest.devDependencies ?? {})
         : []),

--- a/src/lib/registry/collect-reachable-package-names.ts
+++ b/src/lib/registry/collect-reachable-package-names.ts
@@ -1,0 +1,56 @@
+import type { PackageManifest, PackagesRegistry } from "../types";
+
+/**
+ * Walk the target manifest and the manifests of any internal (workspace)
+ * packages reachable from it, collecting every dependency name encountered
+ * (both internal and external).
+ *
+ * The resulting set is a superset of the target's direct dependencies: it also
+ * includes dependencies of internal workspace packages that will end up in the
+ * isolated output. This is used to filter workspace-level
+ * `patchedDependencies` so that patches for deps introduced via internal
+ * packages aren't dropped.
+ *
+ * devDependencies of internal packages are never followed — they aren't
+ * installed in the isolate. devDependencies of the *target* are followed only
+ * when `includeDevDependencies` is true.
+ *
+ * Note: only recurses through internal packages — manifests of external deps
+ * aren't available here. Deep external→external transitives therefore won't
+ * appear in the set.
+ */
+export function collectReachablePackageNames({
+  targetPackageManifest,
+  packagesRegistry,
+  includeDevDependencies,
+}: {
+  targetPackageManifest: PackageManifest;
+  packagesRegistry: PackagesRegistry;
+  includeDevDependencies: boolean;
+}): Set<string> {
+  const names = new Set<string>();
+  const visitedInternal = new Set<string>();
+
+  walk(targetPackageManifest, true);
+
+  return names;
+
+  function walk(manifest: PackageManifest, isTarget: boolean) {
+    const depNames = [
+      ...Object.keys(manifest.dependencies ?? {}),
+      ...(isTarget && includeDevDependencies
+        ? Object.keys(manifest.devDependencies ?? {})
+        : []),
+    ];
+
+    for (const name of depNames) {
+      names.add(name);
+
+      const internalPkg = packagesRegistry[name];
+      if (internalPkg && !visitedInternal.has(name)) {
+        visitedInternal.add(name);
+        walk(internalPkg.manifest, false);
+      }
+    }
+  }
+}

--- a/src/lib/registry/index.ts
+++ b/src/lib/registry/index.ts
@@ -1,2 +1,3 @@
+export * from "./collect-reachable-package-names";
 export * from "./create-packages-registry";
 export * from "./list-internal-packages";

--- a/src/lib/utils/filter-patched-dependencies.test.ts
+++ b/src/lib/utils/filter-patched-dependencies.test.ts
@@ -182,6 +182,64 @@ describe("filterPatchedDependencies", () => {
     expect(result).toBeUndefined();
   });
 
+  it("should include patches for packages reachable via internal workspace packages", () => {
+    /** Issue #167: patch targets a transitive dep via an internal package */
+    const manifest: PackageManifest = {
+      name: "consumer",
+      version: "1.0.0",
+      dependencies: { "firebase-package": "file:./packages/firebase-package" },
+    };
+
+    const result = filterPatchedDependencies({
+      patchedDependencies: { "tslib@2.0.0": "patches/tslib.patch" },
+      targetPackageManifest: manifest,
+      includeDevDependencies: false,
+      reachableDependencyNames: new Set(["firebase-package", "tslib"]),
+    });
+
+    expect(result).toEqual({ "tslib@2.0.0": "patches/tslib.patch" });
+  });
+
+  it("should exclude patches for packages not in direct deps nor the reachable set", () => {
+    const manifest: PackageManifest = {
+      name: "consumer",
+      version: "1.0.0",
+      dependencies: { "firebase-package": "file:./packages/firebase-package" },
+    };
+
+    const result = filterPatchedDependencies({
+      patchedDependencies: { "unrelated@1.0.0": "patches/unrelated.patch" },
+      targetPackageManifest: manifest,
+      includeDevDependencies: false,
+      reachableDependencyNames: new Set(["firebase-package", "tslib"]),
+    });
+
+    expect(result).toBeUndefined();
+  });
+
+  it("should prefer direct-dep match over reachable-set match", () => {
+    /** Direct deps include dev, but dev patches still respect the flag */
+    const manifest: PackageManifest = {
+      name: "app",
+      version: "1.0.0",
+      devDependencies: { vitest: "^1.0.0" },
+    };
+
+    const result = filterPatchedDependencies({
+      patchedDependencies: { "vitest@1.0.0": "patches/vitest.patch" },
+      targetPackageManifest: manifest,
+      includeDevDependencies: false,
+      /**
+       * Even if vitest is somehow in the reachable set, the direct-devDep
+       * branch runs first and excludes it when includeDevDependencies is
+       * false.
+       */
+      reachableDependencyNames: new Set(["vitest"]),
+    });
+
+    expect(result).toBeUndefined();
+  });
+
   it("should preserve patch value types", () => {
     const manifest: PackageManifest = {
       name: "test",

--- a/src/lib/utils/filter-patched-dependencies.test.ts
+++ b/src/lib/utils/filter-patched-dependencies.test.ts
@@ -217,8 +217,32 @@ describe("filterPatchedDependencies", () => {
     expect(result).toBeUndefined();
   });
 
-  it("should prefer direct-dep match over reachable-set match", () => {
-    /** Direct deps include dev, but dev patches still respect the flag */
+  it("should include a patch when a target devDep is also reachable as a prod transitive", () => {
+    /**
+     * The target lists `tslib` as a devDep and runs with
+     * includeDevDependencies=false, but `tslib` is also a prod dep of an
+     * internal workspace package that IS installed in the isolate. The
+     * patch must be preserved because tslib will be present at install
+     * time through the internal package.
+     */
+    const manifest: PackageManifest = {
+      name: "app",
+      version: "1.0.0",
+      dependencies: { "firebase-package": "file:./packages/firebase-package" },
+      devDependencies: { tslib: "^2.0.0" },
+    };
+
+    const result = filterPatchedDependencies({
+      patchedDependencies: { "tslib@2.0.0": "patches/tslib.patch" },
+      targetPackageManifest: manifest,
+      includeDevDependencies: false,
+      reachableDependencyNames: new Set(["firebase-package", "tslib"]),
+    });
+
+    expect(result).toEqual({ "tslib@2.0.0": "patches/tslib.patch" });
+  });
+
+  it("should still exclude a pure target devDep patch when not reachable and dev deps are off", () => {
     const manifest: PackageManifest = {
       name: "app",
       version: "1.0.0",
@@ -229,12 +253,7 @@ describe("filterPatchedDependencies", () => {
       patchedDependencies: { "vitest@1.0.0": "patches/vitest.patch" },
       targetPackageManifest: manifest,
       includeDevDependencies: false,
-      /**
-       * Even if vitest is somehow in the reachable set, the direct-devDep
-       * branch runs first and excludes it when includeDevDependencies is
-       * false.
-       */
-      reachableDependencyNames: new Set(["vitest"]),
+      reachableDependencyNames: new Set(),
     });
 
     expect(result).toBeUndefined();

--- a/src/lib/utils/filter-patched-dependencies.ts
+++ b/src/lib/utils/filter-patched-dependencies.ts
@@ -3,17 +3,26 @@ import type { PackageManifest } from "~/lib/types";
 import { getPackageName } from "./get-package-name";
 
 /**
- * Filters patched dependencies to only include patches for packages that are
- * present in the target package's dependencies based on dependency type.
+ * Filters patched dependencies to only include patches for packages that will
+ * be present in the isolated output, either as a direct dependency of the
+ * target or as a transitive dependency reachable through internal workspace
+ * packages.
  */
 export function filterPatchedDependencies<T>({
   patchedDependencies,
   targetPackageManifest,
   includeDevDependencies,
+  reachableDependencyNames,
 }: {
   patchedDependencies: Record<string, T> | undefined;
   targetPackageManifest: PackageManifest;
   includeDevDependencies: boolean;
+  /**
+   * Additional set of dependency names reachable from the target (e.g. via
+   * internal workspace packages). Used to preserve patches for transitive
+   * deps that are not listed directly on the target manifest.
+   */
+  reachableDependencyNames?: Set<string>;
 }): Record<string, T> | undefined {
   const log = useLogger();
   if (!patchedDependencies || typeof patchedDependencies !== "object") {
@@ -48,9 +57,21 @@ export function filterPatchedDependencies<T>({
       continue;
     }
 
-    /** Package not found in dependencies or devDependencies */
+    /**
+     * Not a direct dep. If the package is reachable via an internal workspace
+     * package, the patch should still end up in the isolated output so pnpm
+     * applies it at install time.
+     */
+    if (reachableDependencyNames?.has(packageName)) {
+      filteredPatches[packageSpec] = patchInfo;
+      includedCount++;
+      log.debug(`Including transitive dependency patch: ${packageSpec}`);
+      continue;
+    }
+
+    /** Package not reachable from the target */
     log.debug(
-      `Excluding patch: ${packageSpec} (package "${packageName}" not in target dependencies)`,
+      `Excluding patch: ${packageSpec} (package "${packageName}" not reachable from target)`,
     );
     excludedCount++;
   }

--- a/src/lib/utils/filter-patched-dependencies.ts
+++ b/src/lib/utils/filter-patched-dependencies.ts
@@ -36,7 +36,7 @@ export function filterPatchedDependencies<T>({
   for (const [packageSpec, patchInfo] of Object.entries(patchedDependencies)) {
     const packageName = getPackageName(packageSpec);
 
-    /** Check if it's a production dependency */
+    /** Direct production dependency */
     if (targetPackageManifest.dependencies?.[packageName]) {
       filteredPatches[packageSpec] = patchInfo;
       includedCount++;
@@ -44,23 +44,22 @@ export function filterPatchedDependencies<T>({
       continue;
     }
 
-    /** Check if it's a dev dependency and we should include dev dependencies */
-    if (targetPackageManifest.devDependencies?.[packageName]) {
-      if (includeDevDependencies) {
-        filteredPatches[packageSpec] = patchInfo;
-        includedCount++;
-        log.debug(`Including dev dependency patch: ${packageSpec}`);
-      } else {
-        excludedCount++;
-        log.debug(`Excluding dev dependency patch: ${packageSpec}`);
-      }
+    /** Direct dev dependency (respects the dev-deps flag) */
+    if (
+      includeDevDependencies &&
+      targetPackageManifest.devDependencies?.[packageName]
+    ) {
+      filteredPatches[packageSpec] = patchInfo;
+      includedCount++;
+      log.debug(`Including dev dependency patch: ${packageSpec}`);
       continue;
     }
 
     /**
-     * Not a direct dep. If the package is reachable via an internal workspace
-     * package, the patch should still end up in the isolated output so pnpm
-     * applies it at install time.
+     * Reachable via an internal workspace package. This fires even when the
+     * package is also listed in the target's devDependencies with
+     * `includeDevDependencies=false`, because the package is still installed
+     * in the isolate as a prod transitive.
      */
     if (reachableDependencyNames?.has(packageName)) {
       filteredPatches[packageSpec] = patchInfo;
@@ -69,10 +68,14 @@ export function filterPatchedDependencies<T>({
       continue;
     }
 
-    /** Package not reachable from the target */
-    log.debug(
-      `Excluding patch: ${packageSpec} (package "${packageName}" not reachable from target)`,
-    );
+    /** Package won't be installed in the isolate */
+    if (targetPackageManifest.devDependencies?.[packageName]) {
+      log.debug(`Excluding dev dependency patch: ${packageSpec}`);
+    } else {
+      log.debug(
+        `Excluding patch: ${packageSpec} (package "${packageName}" not reachable from target)`,
+      );
+    }
     excludedCount++;
   }
 


### PR DESCRIPTION
Fixes #167.

When a workspace declares `pnpm.patchedDependencies` for a package that is not a direct dependency of the isolate target but *is* reachable through an internal workspace package, the patch was silently dropped from the isolated output. `filterPatchedDependencies` checked only the target's own `dependencies`/`devDependencies`, so e.g. a patch on `tslib` (a dep of an internal `firebase-package`) never made it into the isolated `package.json` or the `patches/` folder.

`copyPatches` now computes the set of dependency names reachable from the target by walking the target manifest plus the manifests of every internal workspace package it can reach. That set is passed to `filterPatchedDependencies` as a third matching fallback after direct prod and direct dev deps: if the patch's package name is in the reachable set, the patch is preserved. Internal packages' `devDependencies` are intentionally not followed since they aren't installed in the isolate.

Limitation: this does not cover patches on deeper external-to-external transitives (target → externalA → externalB-patched). Addressing those requires lockfile-based pruning, which hasn't been observed as a practical need yet.

Scope: `packages (isolate-package)`
Visibility: user-facing