### PR TITLE
Rewrite pnpm-workspace.yaml to remove excluded patchedDependencies

### DIFF
--- a/src/isolate.ts
+++ b/src/isolate.ts
@@ -230,7 +230,7 @@ export function createIsolator(config?: IsolateConfig) {
       (packageManager.name === "pnpm" || packageManager.name === "bun") &&
       !config.forceNpm;
 
-    const copiedPatches = shouldCopyPatches
+    const { copiedPatches, excludedPatches } = shouldCopyPatches
       ? await copyPatches({
           workspaceRootDir,
           targetPackageManifest: outputManifest,
@@ -238,7 +238,7 @@ export function createIsolator(config?: IsolateConfig) {
           isolateDir,
           includeDevDependencies: config.includeDevDependencies,
         })
-      : {};
+      : { copiedPatches: {}, excludedPatches: {} };
 
     /** Generate an isolated lockfile based on the original one */
     const usedFallbackToNpm = await processLockfile({
@@ -324,32 +324,51 @@ export function createIsolator(config?: IsolateConfig) {
           packages,
         });
       } else {
-        /**
-         * Read the pnpm-workspace.yaml and rewrite its top-level
-         * patchedDependencies to only the patches that were actually copied
-         * into the isolate (with their relocated paths). Stale entries would
-         * point at non-existent files and break `pnpm install` in the isolate.
-         * If no patches were copied, drop the field entirely.
-         */
-        const pnpmSettings = readTypedYamlSync<PnpmSettings>(
-          path.join(workspaceRootDir, "pnpm-workspace.yaml"),
-        );
-
-        if (Object.keys(copiedPatches).length > 0) {
-          pnpmSettings.patchedDependencies = Object.fromEntries(
-            Object.entries(copiedPatches).map(([spec, patchFile]) => [
-              spec,
-              patchFile.path,
-            ]),
+        if (!Object.keys(excludedPatches).length) {
+          /**
+           * When no patches are excluded, we can simply copy the pnpm-workspace.yaml as is
+           */
+          log.debug(
+            `Copying pnpm-workspace.yaml to ${path.join(isolateDir, "pnpm-workspace.yaml")}`,
+          );
+          fs.copyFileSync(
+            path.join(workspaceRootDir, "pnpm-workspace.yaml"),
+            path.join(isolateDir, "pnpm-workspace.yaml"),
           );
         } else {
-          delete pnpmSettings.patchedDependencies;
-        }
+          /**
+           * Read the pnpm-workspace.yaml and rewrite its top-level
+           * patchedDependencies to only the patches that were actually copied
+           * into the isolate (with their relocated paths). Stale entries would
+           * point at non-existent files and break `pnpm install` in the isolate.
+           * If no patches were copied, drop the field entirely.
+           */
+          const pnpmSettings = readTypedYamlSync<PnpmSettings>(
+            path.join(workspaceRootDir, "pnpm-workspace.yaml"),
+          );
 
-        writeTypedYamlSync(
-          path.join(isolateDir, "pnpm-workspace.yaml"),
-          pnpmSettings,
-        );
+          if (Object.keys(copiedPatches).length > 0) {
+            pnpmSettings.patchedDependencies = Object.fromEntries(
+              Object.entries(copiedPatches).map(([spec, patchFile]) => [
+                spec,
+                patchFile.path,
+              ]),
+            );
+            log.debug(
+              `Copying and modifying pnpm-workspace.yaml to ${path.join(isolateDir, "pnpm-workspace.yaml")} with updated patchedDependencies field (${Object.keys(pnpmSettings.patchedDependencies).length})`,
+            );
+          } else {
+            delete pnpmSettings.patchedDependencies;
+            log.debug(
+              `Copying and modifying pnpm-workspace.yaml to ${path.join(isolateDir, "pnpm-workspace.yaml")} without patchedDependencies field`,
+            );
+          }
+
+          writeTypedYamlSync(
+            path.join(isolateDir, "pnpm-workspace.yaml"),
+            pnpmSettings,
+          );
+        }
       }
     }
 

--- a/src/isolate.ts
+++ b/src/isolate.ts
@@ -24,12 +24,13 @@ import { detectPackageManager, shouldUsePnpmPack } from "./lib/package-manager";
 import { getVersion } from "./lib/package-manager/helpers/infer-from-files";
 import { copyPatches } from "./lib/patches/copy-patches";
 import { createPackagesRegistry, listInternalPackages } from "./lib/registry";
-import type { PackageManifest } from "./lib/types";
+import type { PackageManifest, PnpmSettings } from "./lib/types";
 import {
   getDirname,
   getRootRelativeLogPath,
   isRushWorkspace,
   readTypedJson,
+  readTypedYamlSync,
   writeTypedYamlSync,
 } from "./lib/utils";
 
@@ -323,9 +324,31 @@ export function createIsolator(config?: IsolateConfig) {
           packages,
         });
       } else {
-        fs.copyFileSync(
+        /**
+         * Read the pnpm-workspace.yaml and rewrite its top-level
+         * patchedDependencies to only the patches that were actually copied
+         * into the isolate (with their relocated paths). Stale entries would
+         * point at non-existent files and break `pnpm install` in the isolate.
+         * If no patches were copied, drop the field entirely.
+         */
+        const pnpmSettings = readTypedYamlSync<PnpmSettings>(
           path.join(workspaceRootDir, "pnpm-workspace.yaml"),
+        );
+
+        if (Object.keys(copiedPatches).length > 0) {
+          pnpmSettings.patchedDependencies = Object.fromEntries(
+            Object.entries(copiedPatches).map(([spec, patchFile]) => [
+              spec,
+              patchFile.path,
+            ]),
+          );
+        } else {
+          delete pnpmSettings.patchedDependencies;
+        }
+
+        writeTypedYamlSync(
           path.join(isolateDir, "pnpm-workspace.yaml"),
+          pnpmSettings,
         );
       }
     }

--- a/src/lib/patches/copy-patches.ts
+++ b/src/lib/patches/copy-patches.ts
@@ -31,7 +31,10 @@ export async function copyPatches({
   packagesRegistry: PackagesRegistry;
   isolateDir: string;
   includeDevDependencies: boolean;
-}): Promise<Record<string, PatchFile>> {
+}): Promise<{
+  copiedPatches: Record<string, PatchFile>;
+  excludedPatches: Record<string, PatchFile>;
+}> {
   const log = useLogger();
 
   const { name: packageManagerName } = usePackageManager();
@@ -83,7 +86,10 @@ export async function copyPatches({
 
   if (!patchedDependencies || Object.keys(patchedDependencies).length === 0) {
     log.debug("No patched dependencies found in workspace root package.json");
-    return {};
+    return {
+      copiedPatches: {},
+      excludedPatches: {},
+    };
   }
 
   log.debug(
@@ -109,10 +115,6 @@ export async function copyPatches({
     reachableDependencyNames,
   });
 
-  if (!filteredPatches) {
-    return {};
-  }
-
   /**
    * Read the pnpm lockfile to get patch hashes. Bun doesn't store hashes in
    * its lockfile so we skip this for Bun.
@@ -122,9 +124,15 @@ export async function copyPatches({
       ? await readLockfilePatchedDependencies(workspaceRootDir)
       : undefined;
 
-  const copiedPatches: Record<string, PatchFile> = {};
+  const patches: {
+    copiedPatches: Record<string, PatchFile>;
+    excludedPatches: Record<string, PatchFile>;
+  } = {
+    copiedPatches: {},
+    excludedPatches: {},
+  };
 
-  for (const [packageSpec, patchPath] of Object.entries(filteredPatches)) {
+  for (const [packageSpec, patchPath] of Object.entries(patchedDependencies)) {
     const sourcePatchPath = path.resolve(workspaceRootDir, patchPath);
 
     if (!fs.existsSync(sourcePatchPath)) {
@@ -148,17 +156,26 @@ export async function copyPatches({
       log.warn(`No hash found for patch ${packageSpec} in lockfile`);
     }
 
-    copiedPatches[packageSpec] = {
-      path: patchPath,
-      hash,
-    };
+    if (filteredPatches?.[packageSpec]) {
+      patches.copiedPatches[packageSpec] = {
+        path: patchPath,
+        hash,
+      };
+    } else {
+      patches.excludedPatches[packageSpec] = {
+        path: patchPath,
+        hash,
+      };
+    }
   }
 
-  if (Object.keys(copiedPatches).length > 0) {
-    log.debug(`Copied ${Object.keys(copiedPatches).length} patch files`);
+  if (Object.keys(patches.copiedPatches).length > 0) {
+    log.debug(
+      `Copied ${Object.keys(patches.copiedPatches).length} patch files`,
+    );
   }
 
-  return copiedPatches;
+  return patches;
 }
 
 /**


### PR DESCRIPTION
Fixes #178 

I divided this into two commits. 

1. This is the simplest fix where we read the workspace file with `readTypedYamlSync`, edit the `patchedDependencies` and then write it to isolate dir with `writeTypedYamlSync`. The "downside" to this is losing comments, spacing etc even if there were no excluded patches.
2. Changed return type of `copy-patches.ts` to track `copiedPatches` and `excludedPatches` so that the existing "simple" copy of pnpm-workspace.yaml can take place when there are no excluded patches to remove.

Please feel free to revert the 2nd commit if you prefer the simplicity and single path of commit 1.