### PR TITLE
Filter patchedDependencies in isolated pnpm-workspace.yaml

### DIFF
--- a/src/isolate.ts
+++ b/src/isolate.ts
@@ -23,6 +23,7 @@ import {
 import { detectPackageManager, shouldUsePnpmPack } from "./lib/package-manager";
 import { getVersion } from "./lib/package-manager/helpers/infer-from-files";
 import { copyPatches } from "./lib/patches/copy-patches";
+import { writeIsolatePnpmWorkspace } from "./lib/patches/write-isolate-pnpm-workspace";
 import { createPackagesRegistry, listInternalPackages } from "./lib/registry";
 import type { PackageManifest } from "./lib/types";
 import {
@@ -323,10 +324,11 @@ export function createIsolator(config?: IsolateConfig) {
           packages,
         });
       } else {
-        fs.copyFileSync(
-          path.join(workspaceRootDir, "pnpm-workspace.yaml"),
-          path.join(isolateDir, "pnpm-workspace.yaml"),
-        );
+        writeIsolatePnpmWorkspace({
+          workspaceRootDir,
+          isolateDir,
+          copiedPatches,
+        });
       }
     }
 

--- a/src/lib/patches/write-isolate-pnpm-workspace.test.ts
+++ b/src/lib/patches/write-isolate-pnpm-workspace.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { PatchFile } from "~/lib/types";
+import { writeIsolatePnpmWorkspace } from "./write-isolate-pnpm-workspace";
+
+vi.mock("fs-extra", () => ({
+  default: {
+    copyFileSync: vi.fn(),
+  },
+}));
+
+vi.mock("~/lib/utils", () => ({
+  readTypedYamlSync: vi.fn(),
+  writeTypedYamlSync: vi.fn(),
+}));
+
+const fs = vi.mocked((await import("fs-extra")).default);
+const { readTypedYamlSync, writeTypedYamlSync } = vi.mocked(
+  await import("~/lib/utils"),
+);
+
+const workspaceRootDir = "/workspace";
+const isolateDir = "/workspace/isolate";
+
+describe("writeIsolatePnpmWorkspace", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("retains only the patches that were copied", () => {
+    readTypedYamlSync.mockReturnValue({
+      packages: ["packages/*"],
+      patchedDependencies: {
+        "lodash@4.17.21": "patches/lodash@4.17.21.patch",
+        "react@18.2.0": "patches/react@18.2.0.patch",
+        "axios@1.6.0": "patches/axios@1.6.0.patch",
+      },
+    });
+
+    const copiedPatches: Record<string, PatchFile> = {
+      "lodash@4.17.21": {
+        path: "patches/lodash@4.17.21.patch",
+        hash: "abc",
+      },
+    };
+
+    writeIsolatePnpmWorkspace({
+      workspaceRootDir,
+      isolateDir,
+      copiedPatches,
+    });
+
+    expect(fs.copyFileSync).not.toHaveBeenCalled();
+    expect(writeTypedYamlSync).toHaveBeenCalledTimes(1);
+    expect(writeTypedYamlSync).toHaveBeenCalledWith(
+      "/workspace/isolate/pnpm-workspace.yaml",
+      {
+        packages: ["packages/*"],
+        patchedDependencies: {
+          "lodash@4.17.21": "patches/lodash@4.17.21.patch",
+        },
+      },
+    );
+  });
+
+  it("removes the patchedDependencies field when no patches were copied", () => {
+    readTypedYamlSync.mockReturnValue({
+      packages: ["packages/*"],
+      patchedDependencies: {
+        "lodash@4.17.21": "patches/lodash@4.17.21.patch",
+      },
+    });
+
+    writeIsolatePnpmWorkspace({
+      workspaceRootDir,
+      isolateDir,
+      copiedPatches: {},
+    });
+
+    expect(fs.copyFileSync).not.toHaveBeenCalled();
+    expect(writeTypedYamlSync).toHaveBeenCalledWith(
+      "/workspace/isolate/pnpm-workspace.yaml",
+      { packages: ["packages/*"] },
+    );
+  });
+
+  it("falls back to a verbatim copy when the file has no patchedDependencies field", () => {
+    readTypedYamlSync.mockReturnValue({
+      packages: ["packages/*"],
+    });
+
+    writeIsolatePnpmWorkspace({
+      workspaceRootDir,
+      isolateDir,
+      copiedPatches: {},
+    });
+
+    expect(writeTypedYamlSync).not.toHaveBeenCalled();
+    expect(fs.copyFileSync).toHaveBeenCalledWith(
+      "/workspace/pnpm-workspace.yaml",
+      "/workspace/isolate/pnpm-workspace.yaml",
+    );
+  });
+
+  it("preserves unrelated top-level fields", () => {
+    readTypedYamlSync.mockReturnValue({
+      packages: ["packages/*"],
+      onlyBuiltDependencies: ["esbuild"],
+      overrides: { foo: "1.0.0" },
+      patchedDependencies: {
+        "lodash@4.17.21": "patches/lodash@4.17.21.patch",
+        "react@18.2.0": "patches/react@18.2.0.patch",
+      },
+    });
+
+    const copiedPatches: Record<string, PatchFile> = {
+      "react@18.2.0": { path: "patches/react@18.2.0.patch", hash: "def" },
+    };
+
+    writeIsolatePnpmWorkspace({
+      workspaceRootDir,
+      isolateDir,
+      copiedPatches,
+    });
+
+    expect(writeTypedYamlSync).toHaveBeenCalledWith(
+      "/workspace/isolate/pnpm-workspace.yaml",
+      {
+        packages: ["packages/*"],
+        onlyBuiltDependencies: ["esbuild"],
+        overrides: { foo: "1.0.0" },
+        patchedDependencies: {
+          "react@18.2.0": "patches/react@18.2.0.patch",
+        },
+      },
+    );
+  });
+
+  it("falls back to a verbatim copy when the yaml cannot be parsed", () => {
+    readTypedYamlSync.mockImplementation(() => {
+      throw new Error("bad yaml");
+    });
+
+    writeIsolatePnpmWorkspace({
+      workspaceRootDir,
+      isolateDir,
+      copiedPatches: {},
+    });
+
+    expect(writeTypedYamlSync).not.toHaveBeenCalled();
+    expect(fs.copyFileSync).toHaveBeenCalledWith(
+      "/workspace/pnpm-workspace.yaml",
+      "/workspace/isolate/pnpm-workspace.yaml",
+    );
+  });
+});

--- a/src/lib/patches/write-isolate-pnpm-workspace.test.ts
+++ b/src/lib/patches/write-isolate-pnpm-workspace.test.ts
@@ -139,6 +139,36 @@ describe("writeIsolatePnpmWorkspace", () => {
     );
   });
 
+  it("copies verbatim when every patch is kept (preserving comments and order)", () => {
+    readTypedYamlSync.mockReturnValue({
+      packages: ["packages/*"],
+      patchedDependencies: {
+        "lodash@4.17.21": "patches/lodash@4.17.21.patch",
+        "react@18.2.0": "patches/react@18.2.0.patch",
+      },
+    });
+
+    const copiedPatches: Record<string, PatchFile> = {
+      "lodash@4.17.21": {
+        path: "patches/lodash@4.17.21.patch",
+        hash: "abc",
+      },
+      "react@18.2.0": { path: "patches/react@18.2.0.patch", hash: "def" },
+    };
+
+    writeIsolatePnpmWorkspace({
+      workspaceRootDir,
+      isolateDir,
+      copiedPatches,
+    });
+
+    expect(writeTypedYamlSync).not.toHaveBeenCalled();
+    expect(fs.copyFileSync).toHaveBeenCalledWith(
+      "/workspace/pnpm-workspace.yaml",
+      "/workspace/isolate/pnpm-workspace.yaml",
+    );
+  });
+
   it("falls back to a verbatim copy when the yaml cannot be parsed", () => {
     readTypedYamlSync.mockImplementation(() => {
       throw new Error("bad yaml");

--- a/src/lib/patches/write-isolate-pnpm-workspace.ts
+++ b/src/lib/patches/write-isolate-pnpm-workspace.ts
@@ -15,7 +15,7 @@ import { readTypedYamlSync, writeTypedYamlSync } from "~/lib/utils";
  * verbatim — preserving comments, key order, and trailing whitespace — when
  * any of the following hold:
  *
- * - The source yaml cannot be parsed.
+ * - The source yaml cannot be read or parsed.
  * - The parsed settings have no `patchedDependencies` field.
  * - Every entry in `patchedDependencies` is also present in `copiedPatches`
  *   (no exclusions, so rewriting would only churn formatting).
@@ -42,7 +42,7 @@ export function writeIsolatePnpmWorkspace({
     settings = readTypedYamlSync<PnpmSettings>(sourcePath);
   } catch (error) {
     log.warn(
-      `Could not parse pnpm-workspace.yaml, falling back to verbatim copy: ${error instanceof Error ? error.message : String(error)}`,
+      `Could not read pnpm-workspace.yaml, falling back to verbatim copy: ${error instanceof Error ? error.message : String(error)}`,
     );
     fs.copyFileSync(sourcePath, targetPath);
     return;

--- a/src/lib/patches/write-isolate-pnpm-workspace.ts
+++ b/src/lib/patches/write-isolate-pnpm-workspace.ts
@@ -43,6 +43,19 @@ export function writeIsolatePnpmWorkspace({
     return;
   }
 
+  /**
+   * If every patch declared in the source yaml was kept, copy verbatim so
+   * comments, ordering, and trailing whitespace are preserved.
+   */
+  const sourceSpecs = Object.keys(settings.patchedDependencies);
+  const copiedSpecs = new Set(Object.keys(copiedPatches));
+  const hasExclusions = sourceSpecs.some((spec) => !copiedSpecs.has(spec));
+
+  if (!hasExclusions) {
+    fs.copyFileSync(sourcePath, targetPath);
+    return;
+  }
+
   const filteredEntries = Object.entries(copiedPatches).map(
     ([spec, patchFile]) => [spec, patchFile.path] as const,
   );

--- a/src/lib/patches/write-isolate-pnpm-workspace.ts
+++ b/src/lib/patches/write-isolate-pnpm-workspace.ts
@@ -11,7 +11,17 @@ import { readTypedYamlSync, writeTypedYamlSync } from "~/lib/utils";
  * isolate fails when patches that don't apply to the target package are
  * declared in the workspace root config (see issue #178).
  *
- * Falls back to a verbatim file copy when the source yaml cannot be parsed.
+ * The yaml is only rewritten when filtering is required. The file is copied
+ * verbatim — preserving comments, key order, and trailing whitespace — when
+ * any of the following hold:
+ *
+ * - The source yaml cannot be parsed.
+ * - The parsed settings have no `patchedDependencies` field.
+ * - Every entry in `patchedDependencies` is also present in `copiedPatches`
+ *   (no exclusions, so rewriting would only churn formatting).
+ *
+ * Otherwise, `patchedDependencies` is rewritten to the entries in
+ * `copiedPatches` (or removed entirely when none remain).
  */
 export function writeIsolatePnpmWorkspace({
   workspaceRootDir,

--- a/src/lib/patches/write-isolate-pnpm-workspace.ts
+++ b/src/lib/patches/write-isolate-pnpm-workspace.ts
@@ -1,0 +1,57 @@
+import fs from "fs-extra";
+import path from "node:path";
+import { useLogger } from "~/lib/logger";
+import type { PatchFile, PnpmSettings } from "~/lib/types";
+import { readTypedYamlSync, writeTypedYamlSync } from "~/lib/utils";
+
+/**
+ * Copy `pnpm-workspace.yaml` from the workspace root to the isolate directory,
+ * filtering its `patchedDependencies` field so it only references patches that
+ * were actually copied to the isolate. Without this, `pnpm install` in the
+ * isolate fails when patches that don't apply to the target package are
+ * declared in the workspace root config (see issue #178).
+ *
+ * Falls back to a verbatim file copy when the source yaml cannot be parsed.
+ */
+export function writeIsolatePnpmWorkspace({
+  workspaceRootDir,
+  isolateDir,
+  copiedPatches,
+}: {
+  workspaceRootDir: string;
+  isolateDir: string;
+  copiedPatches: Record<string, PatchFile>;
+}) {
+  const log = useLogger();
+  const sourcePath = path.join(workspaceRootDir, "pnpm-workspace.yaml");
+  const targetPath = path.join(isolateDir, "pnpm-workspace.yaml");
+
+  let settings: PnpmSettings | undefined;
+
+  try {
+    settings = readTypedYamlSync<PnpmSettings>(sourcePath);
+  } catch (error) {
+    log.warn(
+      `Could not parse pnpm-workspace.yaml, falling back to verbatim copy: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    fs.copyFileSync(sourcePath, targetPath);
+    return;
+  }
+
+  if (!settings || !settings.patchedDependencies) {
+    fs.copyFileSync(sourcePath, targetPath);
+    return;
+  }
+
+  const filteredEntries = Object.entries(copiedPatches).map(
+    ([spec, patchFile]) => [spec, patchFile.path] as const,
+  );
+
+  if (filteredEntries.length > 0) {
+    settings.patchedDependencies = Object.fromEntries(filteredEntries);
+  } else {
+    delete settings.patchedDependencies;
+  }
+
+  writeTypedYamlSync(targetPath, settings);
+}


### PR DESCRIPTION
Fixes #178.

When a pnpm workspace declares `patchedDependencies` for packages that aren't reachable from the target, `copyPatches` correctly skips those patch files but the workspace config was still copied verbatim. The resulting isolate referenced patch files that didn't exist on disk, so `pnpm install` (e.g. during a Firebase Functions deploy) failed.

`pnpm-workspace.yaml` is now parsed when written into the isolate, and its `patchedDependencies` field is rewritten to only contain the entries that were actually copied. The field is removed entirely when no patches apply. If the file has no `patchedDependencies` field or fails to parse, it falls back to a verbatim copy as before. The lockfile and target manifest were already filtered, so this brings the workspace config in line.

Scope: cli (patches)
Visibility: user-facing