### PR TITLE
Detect transitive external patches via the workspace lockfile

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "isolate-package",
-  "version": "1.32.1",
+  "version": "1.33.0-0",
   "description": "Isolate monorepo packages to form a self-contained deployable unit",
   "keywords": [
     "ci",

--- a/src/isolate.ts
+++ b/src/isolate.ts
@@ -233,8 +233,10 @@ export function createIsolator(config?: IsolateConfig) {
     const copiedPatches = shouldCopyPatches
       ? await copyPatches({
           workspaceRootDir,
+          targetPackageDir,
           targetPackageManifest: outputManifest,
           packagesRegistry,
+          internalDepPackageNames: internalPackageNames,
           isolateDir,
           includeDevDependencies: config.includeDevDependencies,
         })

--- a/src/lib/lockfile/helpers/bun-lockfile.ts
+++ b/src/lib/lockfile/helpers/bun-lockfile.ts
@@ -1,0 +1,143 @@
+/**
+ * Shared types and walker logic for the Bun workspace lockfile (`bun.lock`).
+ *
+ * Used both when generating the isolated lockfile and when computing the set
+ * of package names that will end up installed in the isolate (so that patches
+ * for deep transitive deps are preserved).
+ */
+
+export type BunWorkspaceEntry = {
+  name?: string;
+  version?: string;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+  optionalPeers?: string[];
+};
+
+export type BunLockfile = {
+  lockfileVersion: number;
+  workspaces: Record<string, BunWorkspaceEntry>;
+  packages: Record<string, unknown[]>;
+  trustedDependencies?: string[];
+  patchedDependencies?: Record<string, string>;
+  overrides?: Record<string, string>;
+};
+
+/** Extract dependency names from a workspace entry. */
+export function collectDependencyNames(
+  entry: BunWorkspaceEntry,
+  includeDevDependencies: boolean,
+): string[] {
+  const names = new Set<string>();
+
+  for (const name of Object.keys(entry.dependencies ?? {})) {
+    names.add(name);
+  }
+  for (const name of Object.keys(entry.optionalDependencies ?? {})) {
+    names.add(name);
+  }
+  for (const name of Object.keys(entry.peerDependencies ?? {})) {
+    names.add(name);
+  }
+
+  if (includeDevDependencies) {
+    for (const name of Object.keys(entry.devDependencies ?? {})) {
+      names.add(name);
+    }
+  }
+
+  return [...names];
+}
+
+/**
+ * Check whether a package entry represents a workspace package by examining
+ * its identifier string (first element in the entry array).
+ */
+export function isWorkspacePackageEntry(entry: unknown[]): boolean {
+  const ident = entry[0];
+  return typeof ident === "string" && ident.includes("@workspace:");
+}
+
+/**
+ * Extract the info object from a packages entry. The position varies by type:
+ * - npm packages: [ident, registry, info, checksum] -> index 2
+ * - workspace packages: [ident, info] -> index 1
+ * - git/github packages: [ident, info, checksum] -> index 1
+ *
+ * Detection: if the second element is a string (registry URL or checksum),
+ * the info object is deeper. Workspace entries have only 2 elements.
+ */
+export function getPackageInfoObject(
+  entry: unknown[],
+): Record<string, unknown> | undefined {
+  if (entry.length <= 1) return undefined;
+
+  /** Workspace entries: [ident, info] */
+  if (isWorkspacePackageEntry(entry)) {
+    return typeof entry[1] === "object"
+      ? (entry[1] as Record<string, unknown>)
+      : undefined;
+  }
+
+  /**
+   * npm entries with registry URL: [ident, registryUrl, info, checksum]. The
+   * second element is a string (the registry URL).
+   */
+  if (typeof entry[1] === "string") {
+    return typeof entry[2] === "object"
+      ? (entry[2] as Record<string, unknown>)
+      : undefined;
+  }
+
+  /** git/tarball entries: [ident, info, checksum] */
+  return typeof entry[1] === "object"
+    ? (entry[1] as Record<string, unknown>)
+    : undefined;
+}
+
+/**
+ * Recursively collect all package keys that are required, starting from a set
+ * of direct dependency names and walking through their transitive
+ * dependencies in the packages section.
+ */
+export function collectRequiredPackages(
+  directDependencyNames: Set<string>,
+  packages: Record<string, unknown[]>,
+): Set<string> {
+  const required = new Set<string>();
+  const queue = [...directDependencyNames];
+
+  while (queue.length > 0) {
+    const name = queue.pop()!;
+
+    if (required.has(name)) continue;
+
+    const entry = packages[name];
+    if (!entry) continue;
+
+    required.add(name);
+
+    const info = getPackageInfoObject(entry);
+    if (!info) continue;
+
+    /** Walk transitive dependencies from the info object */
+    for (const depField of [
+      "dependencies",
+      "optionalDependencies",
+      "peerDependencies",
+    ]) {
+      const deps = info[depField];
+      if (deps && typeof deps === "object") {
+        for (const depName of Object.keys(deps as Record<string, unknown>)) {
+          if (!required.has(depName)) {
+            queue.push(depName);
+          }
+        }
+      }
+    }
+  }
+
+  return required;
+}

--- a/src/lib/lockfile/helpers/generate-bun-lockfile.ts
+++ b/src/lib/lockfile/helpers/generate-bun-lockfile.ts
@@ -8,25 +8,13 @@ import {
   getPackageName,
   readTypedJsonSync,
 } from "~/lib/utils";
-
-type BunWorkspaceEntry = {
-  name?: string;
-  version?: string;
-  dependencies?: Record<string, string>;
-  devDependencies?: Record<string, string>;
-  optionalDependencies?: Record<string, string>;
-  peerDependencies?: Record<string, string>;
-  optionalPeers?: string[];
-};
-
-type BunLockfile = {
-  lockfileVersion: number;
-  workspaces: Record<string, BunWorkspaceEntry>;
-  packages: Record<string, unknown[]>;
-  trustedDependencies?: string[];
-  patchedDependencies?: Record<string, string>;
-  overrides?: Record<string, string>;
-};
+import {
+  type BunLockfile,
+  type BunWorkspaceEntry,
+  collectDependencyNames,
+  collectRequiredPackages,
+  isWorkspacePackageEntry,
+} from "./bun-lockfile";
 
 /**
  * Serialize a value to JSON with trailing commas after every array element and
@@ -52,126 +40,6 @@ export function serializeWithTrailingCommas(
   } while (result !== previous);
 
   return result;
-}
-
-/**
- * Extract dependency names from a workspace entry, optionally including
- * devDependencies.
- */
-function collectDependencyNames(
-  entry: BunWorkspaceEntry,
-  includeDevDependencies: boolean,
-): string[] {
-  const names = new Set<string>();
-
-  for (const name of Object.keys(entry.dependencies ?? {})) {
-    names.add(name);
-  }
-  for (const name of Object.keys(entry.optionalDependencies ?? {})) {
-    names.add(name);
-  }
-  for (const name of Object.keys(entry.peerDependencies ?? {})) {
-    names.add(name);
-  }
-
-  if (includeDevDependencies) {
-    for (const name of Object.keys(entry.devDependencies ?? {})) {
-      names.add(name);
-    }
-  }
-
-  return [...names];
-}
-
-/**
- * Check whether a package entry represents a workspace package by examining its
- * identifier string (first element in the entry array).
- */
-function isWorkspacePackageEntry(entry: unknown[]): boolean {
-  const ident = entry[0];
-  return typeof ident === "string" && ident.includes("@workspace:");
-}
-
-/**
- * Extract the info object from a packages entry. The position varies by type:
- * - npm packages: [ident, registry, info, checksum] -> index 2
- * - workspace packages: [ident, info] -> index 1
- * - git/github packages: [ident, info, checksum] -> index 1
- *
- * Detection: if the second element is a string (registry URL or checksum), the
- * info object is deeper. Workspace entries have only 2 elements.
- */
-function getPackageInfoObject(
-  entry: unknown[],
-): Record<string, unknown> | undefined {
-  if (entry.length <= 1) return undefined;
-
-  /** Workspace entries: [ident, info] */
-  if (isWorkspacePackageEntry(entry)) {
-    return typeof entry[1] === "object"
-      ? (entry[1] as Record<string, unknown>)
-      : undefined;
-  }
-
-  /**
-   * npm entries with registry URL: [ident, registryUrl, info, checksum].
-   * The second element is a string (the registry URL).
-   */
-  if (typeof entry[1] === "string") {
-    return typeof entry[2] === "object"
-      ? (entry[2] as Record<string, unknown>)
-      : undefined;
-  }
-
-  /** git/tarball entries: [ident, info, checksum] */
-  return typeof entry[1] === "object"
-    ? (entry[1] as Record<string, unknown>)
-    : undefined;
-}
-
-/**
- * Recursively collect all package keys that are required, starting from a set
- * of direct dependency names and walking through their transitive dependencies
- * in the packages section.
- */
-function collectRequiredPackages(
-  directDependencyNames: Set<string>,
-  packages: Record<string, unknown[]>,
-): Set<string> {
-  const required = new Set<string>();
-  const queue = [...directDependencyNames];
-
-  while (queue.length > 0) {
-    const name = queue.pop()!;
-
-    if (required.has(name)) continue;
-
-    const entry = packages[name];
-    if (!entry) continue;
-
-    required.add(name);
-
-    const info = getPackageInfoObject(entry);
-    if (!info) continue;
-
-    /** Walk transitive dependencies from the info object */
-    for (const depField of [
-      "dependencies",
-      "optionalDependencies",
-      "peerDependencies",
-    ]) {
-      const deps = info[depField];
-      if (deps && typeof deps === "object") {
-        for (const depName of Object.keys(deps as Record<string, unknown>)) {
-          if (!required.has(depName)) {
-            queue.push(depName);
-          }
-        }
-      }
-    }
-  }
-
-  return required;
 }
 
 export async function generateBunLockfile({

--- a/src/lib/patches/collect-installed-names-bun.test.ts
+++ b/src/lib/patches/collect-installed-names-bun.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { collectInstalledNamesFromBunLockfile } from "./collect-installed-names-bun";
+
+vi.mock("fs-extra", () => ({
+  default: {
+    existsSync: vi.fn(),
+  },
+}));
+
+vi.mock("~/lib/utils", () => ({
+  readTypedJsonSync: vi.fn(),
+}));
+
+const fs = vi.mocked((await import("fs-extra")).default);
+const { readTypedJsonSync } = vi.mocked(await import("~/lib/utils"));
+
+const baseArgs = {
+  workspaceRootDir: "/workspace",
+  targetPackageDir: "/workspace/packages/consumer",
+  internalDepPackageNames: [],
+  packagesRegistry: {},
+  includeDevDependencies: false,
+};
+
+describe("collectInstalledNamesFromBunLockfile", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns an empty set when bun.lock is missing", () => {
+    fs.existsSync.mockReturnValue(false);
+
+    const result = collectInstalledNamesFromBunLockfile({
+      ...baseArgs,
+    });
+
+    expect(result).toEqual(new Set());
+  });
+
+  it("walks external-to-external transitives from the target workspace entry", () => {
+    fs.existsSync.mockReturnValue(true);
+    readTypedJsonSync.mockReturnValue({
+      lockfileVersion: 1,
+      workspaces: {
+        "packages/consumer": {
+          name: "consumer",
+          dependencies: { "@react-pdf/renderer": "^4.0.0" },
+        },
+      },
+      packages: {
+        "@react-pdf/renderer": [
+          "@react-pdf/renderer@4.0.0",
+          "https://registry/...",
+          { dependencies: { "@react-pdf/render": "4.3.0" } },
+          "checksum",
+        ],
+        "@react-pdf/render": [
+          "@react-pdf/render@4.3.0",
+          "https://registry/...",
+          {},
+          "checksum",
+        ],
+      },
+    });
+
+    const result = collectInstalledNamesFromBunLockfile({
+      ...baseArgs,
+    });
+
+    expect(result.has("@react-pdf/renderer")).toBe(true);
+    expect(result.has("@react-pdf/render")).toBe(true);
+  });
+
+  it("walks transitives reachable through internal workspace entries", () => {
+    fs.existsSync.mockReturnValue(true);
+    readTypedJsonSync.mockReturnValue({
+      lockfileVersion: 1,
+      workspaces: {
+        "packages/consumer": {
+          name: "consumer",
+          dependencies: { "firebase-package": "workspace:*" },
+        },
+        "packages/firebase-package": {
+          name: "firebase-package",
+          dependencies: { tslib: "^2.0.0" },
+        },
+      },
+      packages: {
+        tslib: ["tslib@2.0.0", "https://registry/...", {}, "checksum"],
+      },
+    });
+
+    const result = collectInstalledNamesFromBunLockfile({
+      ...baseArgs,
+      internalDepPackageNames: ["firebase-package"],
+      packagesRegistry: {
+        "firebase-package": {
+          absoluteDir: "/workspace/packages/firebase-package",
+          rootRelativeDir: "packages/firebase-package",
+          manifest: { name: "firebase-package", version: "1.0.0" },
+        },
+      },
+    });
+
+    expect(result.has("tslib")).toBe(true);
+  });
+
+  it("skips devDependencies of the target when includeDevDependencies is false", () => {
+    fs.existsSync.mockReturnValue(true);
+    readTypedJsonSync.mockReturnValue({
+      lockfileVersion: 1,
+      workspaces: {
+        "packages/consumer": {
+          name: "consumer",
+          dependencies: { lodash: "^4.0.0" },
+          devDependencies: { typescript: "^5.0.0" },
+        },
+      },
+      packages: {
+        lodash: ["lodash@4.17.21", "https://registry/...", {}, "checksum"],
+        typescript: [
+          "typescript@5.5.0",
+          "https://registry/...",
+          {},
+          "checksum",
+        ],
+      },
+    });
+
+    const result = collectInstalledNamesFromBunLockfile({
+      ...baseArgs,
+    });
+
+    expect(result.has("lodash")).toBe(true);
+    expect(result.has("typescript")).toBe(false);
+  });
+
+  it("returns an empty set when the lockfile read throws", () => {
+    fs.existsSync.mockReturnValue(true);
+    readTypedJsonSync.mockImplementation(() => {
+      throw new Error("invalid json");
+    });
+
+    const result = collectInstalledNamesFromBunLockfile({
+      ...baseArgs,
+    });
+
+    expect(result).toEqual(new Set());
+  });
+});

--- a/src/lib/patches/collect-installed-names-bun.ts
+++ b/src/lib/patches/collect-installed-names-bun.ts
@@ -1,0 +1,87 @@
+import fs from "fs-extra";
+import path from "node:path";
+import {
+  type BunLockfile,
+  collectDependencyNames,
+  collectRequiredPackages,
+} from "~/lib/lockfile/helpers/bun-lockfile";
+import { useLogger } from "~/lib/logger";
+import type { PackagesRegistry } from "~/lib/types";
+import { readTypedJsonSync } from "~/lib/utils";
+
+/**
+ * Walk the workspace bun.lock starting from the target package and its
+ * internal workspace dependencies, returning the set of every package name
+ * that will end up installed in the isolate (including deep
+ * external-to-external transitives).
+ *
+ * Used by `copyPatches` to preserve patches for transitive deps that aren't
+ * directly listed on any internal manifest. Returns an empty set on any
+ * failure so the caller falls back to manifest-based reachability.
+ */
+export function collectInstalledNamesFromBunLockfile({
+  workspaceRootDir,
+  targetPackageDir,
+  internalDepPackageNames,
+  packagesRegistry,
+  includeDevDependencies,
+}: {
+  workspaceRootDir: string;
+  targetPackageDir: string;
+  internalDepPackageNames: string[];
+  packagesRegistry: PackagesRegistry;
+  includeDevDependencies: boolean;
+}): Set<string> {
+  const log = useLogger();
+
+  try {
+    const lockfilePath = path.join(workspaceRootDir, "bun.lock");
+    if (!fs.existsSync(lockfilePath)) {
+      log.debug("No bun.lock available for installed-names walk");
+      return new Set();
+    }
+
+    const lockfile = readTypedJsonSync<BunLockfile>(lockfilePath);
+
+    const targetWorkspaceKey = path
+      .relative(workspaceRootDir, targetPackageDir)
+      .split(path.sep)
+      .join(path.posix.sep);
+
+    const internalWorkspaceKeys = internalDepPackageNames
+      .map((name) => {
+        const pkg = packagesRegistry[name];
+        if (!pkg) return null;
+        return pkg.rootRelativeDir.split(path.sep).join(path.posix.sep);
+      })
+      .filter((key): key is string => Boolean(key));
+
+    const directDependencyNames = new Set<string>();
+
+    const targetEntry = lockfile.workspaces[targetWorkspaceKey];
+    if (targetEntry) {
+      for (const name of collectDependencyNames(
+        targetEntry,
+        includeDevDependencies,
+      )) {
+        directDependencyNames.add(name);
+      }
+    }
+
+    for (const workspaceKey of internalWorkspaceKeys) {
+      const entry = lockfile.workspaces[workspaceKey];
+      if (!entry) continue;
+      /** Internal workspace deps never bring in their devDependencies */
+      for (const name of collectDependencyNames(entry, false)) {
+        directDependencyNames.add(name);
+      }
+    }
+
+    return collectRequiredPackages(directDependencyNames, lockfile.packages);
+  } catch (err) {
+    log.debug(
+      `Failed to walk bun.lock for installed names: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return new Set();
+  }
+}

--- a/src/lib/patches/collect-installed-names-pnpm.test.ts
+++ b/src/lib/patches/collect-installed-names-pnpm.test.ts
@@ -1,0 +1,242 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { collectInstalledNamesFromPnpmLockfile } from "./collect-installed-names-pnpm";
+
+vi.mock("pnpm_lockfile_file_v8", () => ({
+  readWantedLockfile: vi.fn(() => Promise.resolve(null)),
+  getLockfileImporterId: vi.fn(
+    (root: string, dir: string) => dir.replace(`${root}/`, "") || ".",
+  ),
+}));
+
+vi.mock("pnpm_lockfile_file_v9", () => ({
+  readWantedLockfile: vi.fn(() => Promise.resolve(null)),
+  getLockfileImporterId: vi.fn(
+    (root: string, dir: string) => dir.replace(`${root}/`, "") || ".",
+  ),
+}));
+
+vi.mock("~/lib/utils", () => ({
+  getPackageName: vi.fn((spec: string) => {
+    if (spec.startsWith("@")) {
+      const parts = spec.split("@");
+      return `@${parts[1] ?? ""}`;
+    }
+    return spec.split("@")[0] ?? "";
+  }),
+  isRushWorkspace: vi.fn(() => false),
+}));
+
+const { readWantedLockfile: readWantedLockfile_v9 } = vi.mocked(
+  await import("pnpm_lockfile_file_v9"),
+);
+const { readWantedLockfile: readWantedLockfile_v8 } = vi.mocked(
+  await import("pnpm_lockfile_file_v8"),
+);
+
+const baseArgs = {
+  workspaceRootDir: "/workspace",
+  targetPackageDir: "/workspace/packages/consumer",
+  internalDepPackageNames: [],
+  packagesRegistry: {},
+  includeDevDependencies: false,
+};
+
+describe("collectInstalledNamesFromPnpmLockfile", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns an empty set when the lockfile is missing", async () => {
+    readWantedLockfile_v9.mockResolvedValue(null);
+
+    const result = await collectInstalledNamesFromPnpmLockfile({
+      ...baseArgs,
+      majorVersion: 9,
+    });
+
+    expect(result).toEqual(new Set());
+  });
+
+  it("walks external-to-external transitives from the target importer", async () => {
+    readWantedLockfile_v9.mockResolvedValue({
+      lockfileVersion: "9.0",
+      importers: {
+        "packages/consumer": {
+          specifiers: { "@react-pdf/renderer": "^4.0.0" },
+          dependencies: { "@react-pdf/renderer": "4.0.0" },
+        },
+      },
+      packages: {
+        "@react-pdf/renderer@4.0.0": {
+          resolution: { integrity: "sha512-x" },
+          dependencies: { "@react-pdf/render": "4.3.0" },
+        },
+        "@react-pdf/render@4.3.0": {
+          resolution: { integrity: "sha512-y" },
+        },
+      },
+    } as unknown as Awaited<ReturnType<typeof readWantedLockfile_v9>>);
+
+    const result = await collectInstalledNamesFromPnpmLockfile({
+      ...baseArgs,
+      majorVersion: 9,
+    });
+
+    expect(result.has("@react-pdf/renderer")).toBe(true);
+    expect(result.has("@react-pdf/render")).toBe(true);
+  });
+
+  it("walks transitives reachable through internal workspace importers", async () => {
+    readWantedLockfile_v9.mockResolvedValue({
+      lockfileVersion: "9.0",
+      importers: {
+        "packages/consumer": {
+          specifiers: { "firebase-package": "workspace:*" },
+          dependencies: { "firebase-package": "link:../firebase-package" },
+        },
+        "packages/firebase-package": {
+          specifiers: { tslib: "^2.0.0" },
+          dependencies: { tslib: "2.0.0" },
+        },
+      },
+      packages: {
+        "tslib@2.0.0": { resolution: { integrity: "sha512-z" } },
+      },
+    } as unknown as Awaited<ReturnType<typeof readWantedLockfile_v9>>);
+
+    const result = await collectInstalledNamesFromPnpmLockfile({
+      ...baseArgs,
+      internalDepPackageNames: ["firebase-package"],
+      packagesRegistry: {
+        "firebase-package": {
+          absoluteDir: "/workspace/packages/firebase-package",
+          rootRelativeDir: "packages/firebase-package",
+          manifest: { name: "firebase-package", version: "1.0.0" },
+        },
+      },
+      majorVersion: 9,
+    });
+
+    expect(result.has("tslib")).toBe(true);
+  });
+
+  it("does not include the target's devDependencies when includeDevDependencies is false", async () => {
+    readWantedLockfile_v9.mockResolvedValue({
+      lockfileVersion: "9.0",
+      importers: {
+        "packages/consumer": {
+          specifiers: { lodash: "^4.0.0", typescript: "^5.0.0" },
+          dependencies: { lodash: "4.17.21" },
+          devDependencies: { typescript: "5.5.0" },
+        },
+      },
+      packages: {
+        "lodash@4.17.21": { resolution: { integrity: "sha512-a" } },
+        "typescript@5.5.0": { resolution: { integrity: "sha512-b" } },
+      },
+    } as unknown as Awaited<ReturnType<typeof readWantedLockfile_v9>>);
+
+    const result = await collectInstalledNamesFromPnpmLockfile({
+      ...baseArgs,
+      majorVersion: 9,
+    });
+
+    expect(result.has("lodash")).toBe(true);
+    expect(result.has("typescript")).toBe(false);
+  });
+
+  it("includes the target's devDependencies when includeDevDependencies is true", async () => {
+    readWantedLockfile_v9.mockResolvedValue({
+      lockfileVersion: "9.0",
+      importers: {
+        "packages/consumer": {
+          specifiers: { typescript: "^5.0.0" },
+          devDependencies: { typescript: "5.5.0" },
+        },
+      },
+      packages: {
+        "typescript@5.5.0": { resolution: { integrity: "sha512-b" } },
+      },
+    } as unknown as Awaited<ReturnType<typeof readWantedLockfile_v9>>);
+
+    const result = await collectInstalledNamesFromPnpmLockfile({
+      ...baseArgs,
+      majorVersion: 9,
+      includeDevDependencies: true,
+    });
+
+    expect(result.has("typescript")).toBe(true);
+  });
+
+  it("uses the v8 reader for pnpm major < 9", async () => {
+    readWantedLockfile_v8.mockResolvedValue({
+      lockfileVersion: 6.1,
+      importers: {
+        "packages/consumer": {
+          specifiers: { foo: "^1.0.0" },
+          dependencies: { foo: "1.0.0" },
+        },
+      },
+      packages: {
+        "/foo@1.0.0": { resolution: { integrity: "sha512-c" } },
+      },
+    } as unknown as Awaited<ReturnType<typeof readWantedLockfile_v8>>);
+
+    const result = await collectInstalledNamesFromPnpmLockfile({
+      ...baseArgs,
+      majorVersion: 8,
+    });
+
+    /**
+     * The v8 reader is used; we check it was invoked (the v9 mock is left at
+     * default which would return null and produce an empty set).
+     */
+    expect(readWantedLockfile_v8).toHaveBeenCalled();
+    expect(readWantedLockfile_v9).not.toHaveBeenCalled();
+    expect(result.has("foo")).toBe(true);
+  });
+
+  it("strips peer-resolution suffixes when extracting package names", async () => {
+    readWantedLockfile_v9.mockResolvedValue({
+      lockfileVersion: "9.0",
+      importers: {
+        "packages/consumer": {
+          specifiers: { "react-dom": "^18.0.0" },
+          dependencies: {
+            "react-dom": "18.2.0(react@18.2.0)",
+          },
+        },
+      },
+      packages: {
+        "react-dom@18.2.0(react@18.2.0)": {
+          resolution: { integrity: "sha512-d" },
+          dependencies: { react: "18.2.0" },
+        },
+        "react@18.2.0": { resolution: { integrity: "sha512-e" } },
+      },
+    } as unknown as Awaited<ReturnType<typeof readWantedLockfile_v9>>);
+
+    const result = await collectInstalledNamesFromPnpmLockfile({
+      ...baseArgs,
+      majorVersion: 9,
+    });
+
+    expect(result.has("react-dom")).toBe(true);
+    expect(result.has("react")).toBe(true);
+  });
+
+  it("returns an empty set when the lockfile read throws", async () => {
+    readWantedLockfile_v9.mockRejectedValueOnce(new Error("boom"));
+
+    const result = await collectInstalledNamesFromPnpmLockfile({
+      ...baseArgs,
+      majorVersion: 9,
+    });
+
+    expect(result).toEqual(new Set());
+  });
+});

--- a/src/lib/patches/collect-installed-names-pnpm.test.ts
+++ b/src/lib/patches/collect-installed-names-pnpm.test.ts
@@ -172,17 +172,29 @@ describe("collectInstalledNamesFromPnpmLockfile", () => {
     expect(result.has("typescript")).toBe(true);
   });
 
-  it("uses the v8 reader for pnpm major < 9", async () => {
+  it("walks transitives via v8 v5-style depPath keys for pnpm major < 9", async () => {
+    /**
+     * After `readWantedLockfile_v8` normalizes a pnpm 8 lockfile (lockfile
+     * version 6.x), `lockfile.packages` is keyed in v5 form: leading slash
+     * with `/` separator between name and version, e.g. `/foo/1.0.0` and
+     * `/@scope/foo/1.0.0`.
+     */
     readWantedLockfile_v8.mockResolvedValue({
       lockfileVersion: 6.1,
       importers: {
         "packages/consumer": {
-          specifiers: { foo: "^1.0.0" },
-          dependencies: { foo: "1.0.0" },
+          specifiers: { "@react-pdf/renderer": "^4.0.0" },
+          dependencies: { "@react-pdf/renderer": "4.0.0" },
         },
       },
       packages: {
-        "/foo@1.0.0": { resolution: { integrity: "sha512-c" } },
+        "/@react-pdf/renderer/4.0.0": {
+          resolution: { integrity: "sha512-x" },
+          dependencies: { "@react-pdf/render": "4.3.0" },
+        },
+        "/@react-pdf/render/4.3.0": {
+          resolution: { integrity: "sha512-y" },
+        },
       },
     } as unknown as Awaited<ReturnType<typeof readWantedLockfile_v8>>);
 
@@ -191,13 +203,41 @@ describe("collectInstalledNamesFromPnpmLockfile", () => {
       majorVersion: 8,
     });
 
-    /**
-     * The v8 reader is used; we check it was invoked (the v9 mock is left at
-     * default which would return null and produce an empty set).
-     */
     expect(readWantedLockfile_v8).toHaveBeenCalled();
     expect(readWantedLockfile_v9).not.toHaveBeenCalled();
-    expect(result.has("foo")).toBe(true);
+    expect(result.has("@react-pdf/renderer")).toBe(true);
+    expect(result.has("@react-pdf/render")).toBe(true);
+  });
+
+  it("includes peerDependencies of package snapshots in the name set", async () => {
+    /**
+     * Peer requirement values aren't resolved depPaths, so we just collect
+     * the names. This mirrors `collectReachablePackageNames` and the bun
+     * walker, both of which include peerDependencies.
+     */
+    readWantedLockfile_v9.mockResolvedValue({
+      lockfileVersion: "9.0",
+      importers: {
+        "packages/consumer": {
+          specifiers: { "some-pkg": "^1.0.0" },
+          dependencies: { "some-pkg": "1.0.0" },
+        },
+      },
+      packages: {
+        "some-pkg@1.0.0": {
+          resolution: { integrity: "sha512-p" },
+          peerDependencies: { "peer-only-dep": ">=1" },
+        },
+      },
+    } as unknown as Awaited<ReturnType<typeof readWantedLockfile_v9>>);
+
+    const result = await collectInstalledNamesFromPnpmLockfile({
+      ...baseArgs,
+      majorVersion: 9,
+    });
+
+    expect(result.has("some-pkg")).toBe(true);
+    expect(result.has("peer-only-dep")).toBe(true);
   });
 
   it("strips peer-resolution suffixes when extracting package names", async () => {

--- a/src/lib/patches/collect-installed-names-pnpm.test.ts
+++ b/src/lib/patches/collect-installed-names-pnpm.test.ts
@@ -279,4 +279,38 @@ describe("collectInstalledNamesFromPnpmLockfile", () => {
 
     expect(result).toEqual(new Set());
   });
+
+  it("normalizes the target importer id before the isTarget check (Windows)", async () => {
+    /**
+     * Simulate Windows: getLockfileImporterId returns a backslash-separated
+     * id, but the lockfile's importer keys use POSIX separators. Without
+     * normalizing the id used in the isTarget comparison, the target's
+     * devDependencies would be skipped even with includeDevDependencies=true.
+     */
+    const { getLockfileImporterId } = vi.mocked(
+      await import("pnpm_lockfile_file_v9"),
+    );
+    getLockfileImporterId.mockReturnValueOnce("packages\\consumer");
+
+    readWantedLockfile_v9.mockResolvedValue({
+      lockfileVersion: "9.0",
+      importers: {
+        "packages/consumer": {
+          specifiers: { typescript: "^5.0.0" },
+          devDependencies: { typescript: "5.5.0" },
+        },
+      },
+      packages: {
+        "typescript@5.5.0": { resolution: { integrity: "sha512-w" } },
+      },
+    } as unknown as Awaited<ReturnType<typeof readWantedLockfile_v9>>);
+
+    const result = await collectInstalledNamesFromPnpmLockfile({
+      ...baseArgs,
+      majorVersion: 9,
+      includeDevDependencies: true,
+    });
+
+    expect(result.has("typescript")).toBe(true);
+  });
 });

--- a/src/lib/patches/collect-installed-names-pnpm.ts
+++ b/src/lib/patches/collect-installed-names-pnpm.ts
@@ -56,24 +56,26 @@ export async function collectInstalledNamesFromPnpmLockfile({
       return new Set();
     }
 
-    const targetImporterId = useVersion9
+    const rawTargetImporterId = useVersion9
       ? getLockfileImporterId_v9(workspaceRootDir, targetPackageDir)
       : getLockfileImporterId_v8(workspaceRootDir, targetPackageDir);
 
-    const internalImporterIds = internalDepPackageNames.map((name) => {
-      const pkg = packagesRegistry[name];
-      if (!pkg) return null;
-      return pkg.rootRelativeDir;
-    });
-
     /**
      * Normalize separators to POSIX so Windows callers match the lockfile's
-     * importer keys (mirrors generate-pnpm-lockfile.ts).
+     * importer keys (mirrors generate-pnpm-lockfile.ts). Applied once here so
+     * the `isTarget` equality check below compares apples-to-apples — without
+     * this, on Windows the raw id with backslashes wouldn't match the
+     * normalized id used as the importers map key.
      */
-    const importerIds = [targetImporterId, ...internalImporterIds]
-      .filter((id): id is string => Boolean(id))
-      .map((x) => x.split(path.sep).join(path.posix.sep))
-      .map((x) => (isRush ? `../../${x}` : x));
+    const targetImporterId = toLockfileImporterKey(rawTargetImporterId, isRush);
+
+    const importerIds = [
+      targetImporterId,
+      ...internalDepPackageNames
+        .map((name) => packagesRegistry[name]?.rootRelativeDir)
+        .filter((dir): dir is string => Boolean(dir))
+        .map((dir) => toLockfileImporterKey(dir, isRush)),
+    ];
 
     const packages = (lockfile as { packages?: Record<string, PnpmPackage> })
       .packages;
@@ -84,7 +86,6 @@ export async function collectInstalledNamesFromPnpmLockfile({
         lockfile.importers,
         importerIds,
         targetImporterId,
-        isRush,
         includeDevDependencies,
       );
     }
@@ -97,9 +98,7 @@ export async function collectInstalledNamesFromPnpmLockfile({
       const importer = lockfile.importers[importerId];
       if (!importer) continue;
 
-      const isTarget =
-        importerId ===
-        (isRush ? `../../${targetImporterId}` : targetImporterId);
+      const isTarget = importerId === targetImporterId;
 
       enqueueImporterDeps({
         importer,
@@ -145,6 +144,22 @@ export async function collectInstalledNamesFromPnpmLockfile({
     );
     return new Set();
   }
+}
+
+/**
+ * Convert a raw importer id (as returned by `getLockfileImporterId` or a
+ * package's rootRelativeDir) to the form actually used as a key in
+ * `lockfile.importers`: POSIX separators, with the Rush `../../` prefix when
+ * the workspace lives under `common/config/rush`. Lockfile keys are always
+ * POSIX regardless of the host OS, so backslashes are normalized
+ * unconditionally rather than relying on `path.sep`.
+ */
+function toLockfileImporterKey(importerId: string, isRush: boolean): string {
+  const posix = importerId
+    .split(path.sep)
+    .join(path.posix.sep)
+    .replace(/\\/g, "/");
+  return isRush ? `../../${posix}` : posix;
 }
 
 type ResolvedDeps = Record<string, string>;
@@ -324,15 +339,13 @@ function collectImporterDirectNames(
   importers: Record<string, PnpmImporter>,
   importerIds: string[],
   targetImporterId: string,
-  isRush: boolean,
   includeDevDependencies: boolean,
 ): Set<string> {
   const names = new Set<string>();
   for (const importerId of importerIds) {
     const importer = importers[importerId];
     if (!importer) continue;
-    const isTarget =
-      importerId === (isRush ? `../../${targetImporterId}` : targetImporterId);
+    const isTarget = importerId === targetImporterId;
     for (const name of Object.keys(importer.dependencies ?? {}))
       names.add(name);
     for (const name of Object.keys(importer.optionalDependencies ?? {})) {

--- a/src/lib/patches/collect-installed-names-pnpm.ts
+++ b/src/lib/patches/collect-installed-names-pnpm.ts
@@ -1,0 +1,268 @@
+import path from "node:path";
+import {
+  getLockfileImporterId as getLockfileImporterId_v8,
+  readWantedLockfile as readWantedLockfile_v8,
+} from "pnpm_lockfile_file_v8";
+import {
+  getLockfileImporterId as getLockfileImporterId_v9,
+  readWantedLockfile as readWantedLockfile_v9,
+} from "pnpm_lockfile_file_v9";
+import { useLogger } from "~/lib/logger";
+import type { PackagesRegistry } from "~/lib/types";
+import { getPackageName, isRushWorkspace } from "~/lib/utils";
+
+/**
+ * Walk the workspace pnpm lockfile starting from the target package and its
+ * internal workspace dependencies, returning the set of every package name
+ * that will end up installed in the isolate (including deep
+ * external-to-external transitives).
+ *
+ * Used by `copyPatches` to preserve patches for transitive deps that aren't
+ * directly listed on any internal manifest. Returns an empty set on any
+ * failure so the caller falls back to manifest-based reachability.
+ */
+export async function collectInstalledNamesFromPnpmLockfile({
+  workspaceRootDir,
+  targetPackageDir,
+  internalDepPackageNames,
+  packagesRegistry,
+  majorVersion,
+  includeDevDependencies,
+}: {
+  workspaceRootDir: string;
+  targetPackageDir: string;
+  internalDepPackageNames: string[];
+  packagesRegistry: PackagesRegistry;
+  majorVersion: number;
+  includeDevDependencies: boolean;
+}): Promise<Set<string>> {
+  const log = useLogger();
+
+  try {
+    const useVersion9 = majorVersion >= 9;
+    const isRush = isRushWorkspace(workspaceRootDir);
+    const lockfileDir = isRush
+      ? path.join(workspaceRootDir, "common/config/rush")
+      : workspaceRootDir;
+
+    const lockfile = useVersion9
+      ? await readWantedLockfile_v9(lockfileDir, { ignoreIncompatible: false })
+      : await readWantedLockfile_v8(lockfileDir, { ignoreIncompatible: false });
+
+    if (!lockfile) {
+      log.debug("No pnpm lockfile available for installed-names walk");
+      return new Set();
+    }
+
+    const targetImporterId = useVersion9
+      ? getLockfileImporterId_v9(workspaceRootDir, targetPackageDir)
+      : getLockfileImporterId_v8(workspaceRootDir, targetPackageDir);
+
+    const internalImporterIds = internalDepPackageNames.map((name) => {
+      const pkg = packagesRegistry[name];
+      if (!pkg) return null;
+      return pkg.rootRelativeDir;
+    });
+
+    /**
+     * Normalize separators to POSIX so Windows callers match the lockfile's
+     * importer keys (mirrors generate-pnpm-lockfile.ts).
+     */
+    const importerIds = [targetImporterId, ...internalImporterIds]
+      .filter((id): id is string => Boolean(id))
+      .map((x) => x.split(path.sep).join(path.posix.sep))
+      .map((x) => (isRush ? `../../${x}` : x));
+
+    const packages = (lockfile as { packages?: Record<string, PnpmPackage> })
+      .packages;
+
+    if (!packages) {
+      log.debug("Lockfile has no packages section to walk");
+      return collectImporterDirectNames(
+        lockfile.importers,
+        importerIds,
+        targetImporterId,
+        isRush,
+        includeDevDependencies,
+      );
+    }
+
+    const names = new Set<string>();
+    const seen = new Set<string>();
+    const queue: string[] = [];
+
+    for (const importerId of importerIds) {
+      const importer = lockfile.importers[importerId];
+      if (!importer) continue;
+
+      const isTarget =
+        importerId ===
+        (isRush ? `../../${targetImporterId}` : targetImporterId);
+
+      enqueueImporterDeps({
+        importer,
+        names,
+        queue,
+        includeDevDependencies: isTarget && includeDevDependencies,
+      });
+    }
+
+    while (queue.length > 0) {
+      const depPath = queue.pop()!;
+      if (seen.has(depPath)) continue;
+      seen.add(depPath);
+
+      names.add(extractPackageName(depPath));
+
+      const pkg = packages[depPath];
+      if (!pkg) continue;
+
+      enqueueResolvedDeps(pkg.dependencies, names, queue, seen);
+      enqueueResolvedDeps(pkg.optionalDependencies, names, queue, seen);
+    }
+
+    return names;
+  } catch (err) {
+    log.debug(
+      `Failed to walk pnpm lockfile for installed names: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return new Set();
+  }
+}
+
+type ResolvedDeps = Record<string, string>;
+
+type PnpmImporter = {
+  dependencies?: ResolvedDeps;
+  optionalDependencies?: ResolvedDeps;
+  devDependencies?: ResolvedDeps;
+};
+
+type PnpmPackage = {
+  dependencies?: ResolvedDeps;
+  optionalDependencies?: ResolvedDeps;
+};
+
+function enqueueImporterDeps({
+  importer,
+  names,
+  queue,
+  includeDevDependencies,
+}: {
+  importer: PnpmImporter;
+  names: Set<string>;
+  queue: string[];
+  includeDevDependencies: boolean;
+}): void {
+  enqueueResolvedDeps(importer.dependencies, names, queue);
+  enqueueResolvedDeps(importer.optionalDependencies, names, queue);
+  if (includeDevDependencies) {
+    enqueueResolvedDeps(importer.devDependencies, names, queue);
+  }
+}
+
+function enqueueResolvedDeps(
+  deps: ResolvedDeps | undefined,
+  names: Set<string>,
+  queue: string[],
+  seen?: Set<string>,
+): void {
+  if (!deps) return;
+
+  for (const [alias, ref] of Object.entries(deps)) {
+    /**
+     * The alias is the name as listed in the parent's dependencies map. For
+     * non-aliased installs this is also the resolved package name. We add it
+     * to the set as a candidate name; visiting the actual depPath below
+     * refines this with the true installed name.
+     */
+    names.add(alias);
+
+    const depPath = refToRelative(ref, alias);
+    if (depPath && !seen?.has(depPath)) {
+      queue.push(depPath);
+    }
+  }
+}
+
+/**
+ * Mirrors `@pnpm/dependency-path`'s `refToRelative`, which we don't expose as
+ * a direct dep. Returns the depPath used as a key in `lockfile.packages`, or
+ * null if the ref points to a workspace link / non-resolved entry.
+ */
+function refToRelative(reference: string, pkgName: string): string | null {
+  if (!reference) return null;
+  if (reference.startsWith("link:")) return null;
+  if (reference.startsWith("@")) return reference;
+  const atIndex = reference.indexOf("@");
+  if (atIndex === -1) return `${pkgName}@${reference}`;
+  const colonIndex = reference.indexOf(":");
+  const bracketIndex = reference.indexOf("(");
+  if (
+    (colonIndex === -1 || atIndex < colonIndex) &&
+    (bracketIndex === -1 || atIndex < bracketIndex)
+  ) {
+    return reference;
+  }
+  return `${pkgName}@${reference}`;
+}
+
+/**
+ * Extract the bare package name from a pnpm depPath. Strips the optional
+ * peer-resolution suffix (e.g. `(react@18.0.0)`) before parsing the name.
+ */
+function extractPackageName(depPath: string): string {
+  const peerStart = indexOfPeersSuffix(depPath);
+  const trimmed = peerStart === -1 ? depPath : depPath.substring(0, peerStart);
+  return getPackageName(trimmed);
+}
+
+/**
+ * Mirrors `@pnpm/dependency-path`'s `indexOfPeersSuffix`. Returns the index
+ * where the peer-resolution suffix starts, or -1 if there is none.
+ */
+function indexOfPeersSuffix(depPath: string): number {
+  if (!depPath.endsWith(")")) return -1;
+  let open = 1;
+  for (let i = depPath.length - 2; i >= 0; i--) {
+    if (depPath[i] === "(") {
+      open--;
+    } else if (depPath[i] === ")") {
+      open++;
+    } else if (!open) {
+      return i + 1;
+    }
+  }
+  return -1;
+}
+
+/**
+ * Fallback when the lockfile is missing `packages`: just return importer
+ * direct dep names so we at least cover some of the graph.
+ */
+function collectImporterDirectNames(
+  importers: Record<string, PnpmImporter>,
+  importerIds: string[],
+  targetImporterId: string,
+  isRush: boolean,
+  includeDevDependencies: boolean,
+): Set<string> {
+  const names = new Set<string>();
+  for (const importerId of importerIds) {
+    const importer = importers[importerId];
+    if (!importer) continue;
+    const isTarget =
+      importerId === (isRush ? `../../${targetImporterId}` : targetImporterId);
+    for (const name of Object.keys(importer.dependencies ?? {}))
+      names.add(name);
+    for (const name of Object.keys(importer.optionalDependencies ?? {})) {
+      names.add(name);
+    }
+    if (isTarget && includeDevDependencies) {
+      for (const name of Object.keys(importer.devDependencies ?? {})) {
+        names.add(name);
+      }
+    }
+  }
+  return names;
+}

--- a/src/lib/patches/collect-installed-names-pnpm.ts
+++ b/src/lib/patches/collect-installed-names-pnpm.ts
@@ -19,7 +19,9 @@ import { getPackageName, isRushWorkspace } from "~/lib/utils";
  *
  * Used by `copyPatches` to preserve patches for transitive deps that aren't
  * directly listed on any internal manifest. Returns an empty set on any
- * failure so the caller falls back to manifest-based reachability.
+ * failure so the caller falls back to manifest-based reachability. When the
+ * lockfile is present but lacks a `packages` section, returns just the
+ * direct importer dep names.
  */
 export async function collectInstalledNamesFromPnpmLockfile({
   workspaceRootDir,
@@ -103,6 +105,7 @@ export async function collectInstalledNamesFromPnpmLockfile({
         importer,
         names,
         queue,
+        useVersion9,
         includeDevDependencies: isTarget && includeDevDependencies,
       });
     }
@@ -117,8 +120,22 @@ export async function collectInstalledNamesFromPnpmLockfile({
       const pkg = packages[depPath];
       if (!pkg) continue;
 
-      enqueueResolvedDeps(pkg.dependencies, names, queue, seen);
-      enqueueResolvedDeps(pkg.optionalDependencies, names, queue, seen);
+      enqueueResolvedDeps(pkg.dependencies, names, queue, useVersion9, seen);
+      enqueueResolvedDeps(
+        pkg.optionalDependencies,
+        names,
+        queue,
+        useVersion9,
+        seen,
+      );
+
+      /**
+       * Peer requirement values are name → semver-range, not resolved depPaths.
+       * Just record the names so a patch on a peer-only external transitive
+       * survives filtering (mirrors the bun walker and the sister manifest
+       * walker, which both include peerDependencies).
+       */
+      collectNames(pkg.peerDependencies, names);
     }
 
     return names;
@@ -136,35 +153,46 @@ type PnpmImporter = {
   dependencies?: ResolvedDeps;
   optionalDependencies?: ResolvedDeps;
   devDependencies?: ResolvedDeps;
+  peerDependencies?: ResolvedDeps;
 };
 
 type PnpmPackage = {
   dependencies?: ResolvedDeps;
   optionalDependencies?: ResolvedDeps;
+  peerDependencies?: ResolvedDeps;
 };
 
 function enqueueImporterDeps({
   importer,
   names,
   queue,
+  useVersion9,
   includeDevDependencies,
 }: {
   importer: PnpmImporter;
   names: Set<string>;
   queue: string[];
+  useVersion9: boolean;
   includeDevDependencies: boolean;
 }): void {
-  enqueueResolvedDeps(importer.dependencies, names, queue);
-  enqueueResolvedDeps(importer.optionalDependencies, names, queue);
+  enqueueResolvedDeps(importer.dependencies, names, queue, useVersion9);
+  enqueueResolvedDeps(importer.optionalDependencies, names, queue, useVersion9);
   if (includeDevDependencies) {
-    enqueueResolvedDeps(importer.devDependencies, names, queue);
+    enqueueResolvedDeps(importer.devDependencies, names, queue, useVersion9);
   }
+  /**
+   * Importer peerDependencies usually aren't a separate map in the lockfile
+   * (autoInstallPeers folds them into `dependencies`), but record names if
+   * they happen to be present.
+   */
+  collectNames(importer.peerDependencies, names);
 }
 
 function enqueueResolvedDeps(
   deps: ResolvedDeps | undefined,
   names: Set<string>,
   queue: string[],
+  useVersion9: boolean,
   seen?: Set<string>,
 ): void {
   if (!deps) return;
@@ -178,21 +206,42 @@ function enqueueResolvedDeps(
      */
     names.add(alias);
 
-    const depPath = refToRelative(ref, alias);
+    const depPath = refToRelative(ref, alias, useVersion9);
     if (depPath && !seen?.has(depPath)) {
       queue.push(depPath);
     }
   }
 }
 
+function collectNames(
+  deps: ResolvedDeps | undefined,
+  names: Set<string>,
+): void {
+  if (!deps) return;
+  for (const name of Object.keys(deps)) {
+    names.add(name);
+  }
+}
+
 /**
- * Mirrors `@pnpm/dependency-path`'s `refToRelative`, which we don't expose as
- * a direct dep. Returns the depPath used as a key in `lockfile.packages`, or
- * null if the ref points to a workspace link / non-resolved entry.
+ * Mirrors `@pnpm/dependency-path`'s `refToRelative`. The depPath shape differs
+ * between pnpm 8 (lockfile v6, normalized to v5 keys like `/foo/1.0.0`) and
+ * pnpm 9 (lockfile v9 keys like `foo@1.0.0`). Returns the depPath used as a
+ * key in `lockfile.packages`, or null if the ref points to a workspace link.
  */
-function refToRelative(reference: string, pkgName: string): string | null {
+function refToRelative(
+  reference: string,
+  pkgName: string,
+  useVersion9: boolean,
+): string | null {
   if (!reference) return null;
   if (reference.startsWith("link:")) return null;
+  return useVersion9
+    ? refToRelativeV9(reference, pkgName)
+    : refToRelativeV8(reference, pkgName);
+}
+
+function refToRelativeV9(reference: string, pkgName: string): string | null {
   if (reference.startsWith("@")) return reference;
   const atIndex = reference.indexOf("@");
   if (atIndex === -1) return `${pkgName}@${reference}`;
@@ -208,12 +257,43 @@ function refToRelative(reference: string, pkgName: string): string | null {
 }
 
 /**
+ * v8 form: pnpm 8 (lockfile v6) is normalized on read to v5-style depPaths
+ * with leading slash and `/` separator between name and version. Plain
+ * version refs build that key; refs already containing a `/` (peer-suffixed
+ * or pre-formed) are returned verbatim. Mirrors `@pnpm/dependency-path@2.x`.
+ */
+function refToRelativeV8(reference: string, pkgName: string): string | null {
+  if (reference.startsWith("file:")) return reference;
+  const slashIndex = reference.indexOf("/");
+  const bracketIndex = reference.indexOf("(");
+  const noSlashBeforeBracket =
+    bracketIndex !== -1 && reference.lastIndexOf("/", bracketIndex) === -1;
+  if (slashIndex === -1 || noSlashBeforeBracket) {
+    return `/${pkgName}/${reference}`;
+  }
+  return reference;
+}
+
+/**
  * Extract the bare package name from a pnpm depPath. Strips the optional
- * peer-resolution suffix (e.g. `(react@18.0.0)`) before parsing the name.
+ * peer-resolution suffix (e.g. `(react@18.0.0)`) before parsing. Handles
+ * both v9 (`@scope/foo@1.0.0`) and v8 (`/@scope/foo/1.0.0`) shapes.
  */
 function extractPackageName(depPath: string): string {
   const peerStart = indexOfPeersSuffix(depPath);
   const trimmed = peerStart === -1 ? depPath : depPath.substring(0, peerStart);
+
+  if (trimmed.startsWith("/")) {
+    /** v8 v5-style: `/<name>/<version>` */
+    const stripped = trimmed.slice(1);
+    if (stripped.startsWith("@")) {
+      const secondSlash = stripped.indexOf("/", stripped.indexOf("/") + 1);
+      return secondSlash === -1 ? stripped : stripped.slice(0, secondSlash);
+    }
+    const firstSlash = stripped.indexOf("/");
+    return firstSlash === -1 ? stripped : stripped.slice(0, firstSlash);
+  }
+
   return getPackageName(trimmed);
 }
 
@@ -256,6 +336,9 @@ function collectImporterDirectNames(
     for (const name of Object.keys(importer.dependencies ?? {}))
       names.add(name);
     for (const name of Object.keys(importer.optionalDependencies ?? {})) {
+      names.add(name);
+    }
+    for (const name of Object.keys(importer.peerDependencies ?? {})) {
       names.add(name);
     }
     if (isTarget && includeDevDependencies) {

--- a/src/lib/patches/copy-patches.test.ts
+++ b/src/lib/patches/copy-patches.test.ts
@@ -15,9 +15,17 @@ vi.mock("fs-extra", () => ({
 vi.mock("~/lib/utils", () => ({
   filterPatchedDependencies: vi.fn(),
   getIsolateRelativeLogPath: vi.fn((p: string) => p),
+  getPackageName: vi.fn((spec: string) => {
+    if (spec.startsWith("@")) {
+      const parts = spec.split("@");
+      return `@${parts[1] ?? ""}`;
+    }
+    return spec.split("@")[0] ?? "";
+  }),
   getRootRelativeLogPath: vi.fn((p: string) => p),
   isRushWorkspace: vi.fn(() => false),
   readTypedJson: vi.fn(),
+  readTypedJsonSync: vi.fn(),
   readTypedYamlSync: vi.fn(),
 }));
 
@@ -29,16 +37,25 @@ vi.mock("~/lib/package-manager", () => ({
 /** Mock the pnpm lockfile readers */
 vi.mock("pnpm_lockfile_file_v8", () => ({
   readWantedLockfile: vi.fn(() => Promise.resolve(null)),
+  getLockfileImporterId: vi.fn(
+    (root: string, dir: string) => dir.replace(`${root}/`, "") || ".",
+  ),
 }));
 
 vi.mock("pnpm_lockfile_file_v9", () => ({
   readWantedLockfile: vi.fn(() => Promise.resolve(null)),
+  getLockfileImporterId: vi.fn(
+    (root: string, dir: string) => dir.replace(`${root}/`, "") || ".",
+  ),
 }));
 
 const fs = vi.mocked((await import("fs-extra")).default);
 const { filterPatchedDependencies, readTypedJson, readTypedYamlSync } =
   vi.mocked(await import("~/lib/utils"));
 const { usePackageManager } = vi.mocked(await import("~/lib/package-manager"));
+const { readWantedLockfile: readWantedLockfile_v9 } = vi.mocked(
+  await import("pnpm_lockfile_file_v9"),
+);
 
 describe("copyPatches", () => {
   beforeEach(() => {
@@ -65,6 +82,8 @@ describe("copyPatches", () => {
 
     const result = await copyPatches({
       workspaceRootDir: "/workspace",
+      targetPackageDir: "/workspace/packages/test",
+      internalDepPackageNames: [],
       targetPackageManifest: { name: "test", version: "1.0.0" },
       isolateDir: "/workspace/isolate",
       packagesRegistry: {},
@@ -126,6 +145,8 @@ describe("copyPatches", () => {
 
       const result = await copyPatches({
         workspaceRootDir: "/workspace",
+        targetPackageDir: "/workspace/packages/test",
+        internalDepPackageNames: [],
         targetPackageManifest: { name: "test", version: "1.0.0" },
         isolateDir: "/workspace/isolate",
         packagesRegistry: {},
@@ -146,6 +167,8 @@ describe("copyPatches", () => {
 
       const result = await copyPatches({
         workspaceRootDir: "/workspace",
+        targetPackageDir: "/workspace/packages/test",
+        internalDepPackageNames: [],
         targetPackageManifest: { name: "test", version: "1.0.0" },
         isolateDir: "/workspace/isolate",
         packagesRegistry: {},
@@ -176,6 +199,8 @@ describe("copyPatches", () => {
 
       const result = await copyPatches({
         workspaceRootDir: "/workspace",
+        targetPackageDir: "/workspace/packages/test",
+        internalDepPackageNames: [],
         targetPackageManifest: targetManifest,
         isolateDir: "/workspace/isolate",
         packagesRegistry: {},
@@ -214,6 +239,8 @@ describe("copyPatches", () => {
 
       const result = await copyPatches({
         workspaceRootDir: "/workspace",
+        targetPackageDir: "/workspace/packages/test",
+        internalDepPackageNames: [],
         targetPackageManifest: targetManifest,
         isolateDir: "/workspace/isolate",
         packagesRegistry: {},
@@ -256,6 +283,8 @@ describe("copyPatches", () => {
 
       const result = await copyPatches({
         workspaceRootDir: "/workspace",
+        targetPackageDir: "/workspace/packages/test",
+        internalDepPackageNames: [],
         targetPackageManifest: targetManifest,
         isolateDir: "/workspace/isolate",
         packagesRegistry: {},
@@ -287,6 +316,8 @@ describe("copyPatches", () => {
 
       const result = await copyPatches({
         workspaceRootDir: "/workspace",
+        targetPackageDir: "/workspace/packages/test",
+        internalDepPackageNames: [],
         targetPackageManifest: targetManifest,
         isolateDir: "/workspace/isolate",
         packagesRegistry: {},
@@ -321,6 +352,8 @@ describe("copyPatches", () => {
 
       const result = await copyPatches({
         workspaceRootDir: "/workspace",
+        targetPackageDir: "/workspace/packages/test",
+        internalDepPackageNames: [],
         targetPackageManifest: targetManifest,
         isolateDir: "/workspace/isolate",
         packagesRegistry: {},
@@ -364,6 +397,8 @@ describe("copyPatches", () => {
 
       const result = await copyPatches({
         workspaceRootDir: "/workspace",
+        targetPackageDir: "/workspace/packages/test",
+        internalDepPackageNames: [],
         targetPackageManifest: targetManifest,
         isolateDir: "/workspace/isolate",
         packagesRegistry: {},
@@ -409,6 +444,8 @@ describe("copyPatches", () => {
 
       const result = await copyPatches({
         workspaceRootDir: "/workspace",
+        targetPackageDir: "/workspace/packages/test",
+        internalDepPackageNames: [],
         targetPackageManifest: targetManifest,
         isolateDir: "/workspace/isolate",
         packagesRegistry: {},
@@ -456,6 +493,8 @@ describe("copyPatches", () => {
 
     const result = await copyPatches({
       workspaceRootDir: "/workspace",
+      targetPackageDir: "/workspace/packages/test",
+      internalDepPackageNames: [],
       targetPackageManifest: targetManifest,
       isolateDir: "/workspace/isolate",
       packagesRegistry: {},
@@ -509,6 +548,8 @@ describe("copyPatches", () => {
 
     const result = await copyPatches({
       workspaceRootDir: "/workspace",
+      targetPackageDir: "/workspace/packages/test",
+      internalDepPackageNames: [],
       targetPackageManifest: consumerManifest,
       isolateDir: "/workspace/isolate",
       packagesRegistry: {
@@ -535,5 +576,89 @@ describe("copyPatches", () => {
     expect(reachable).toBeInstanceOf(Set);
     expect(reachable!.has("firebase-package")).toBe(true);
     expect(reachable!.has("tslib")).toBe(true);
+  });
+
+  it("should pick up deep external-to-external transitives from the pnpm lockfile (regression: issue #167 follow-up)", async () => {
+    /**
+     * Target depends on `@react-pdf/renderer` (external). The patched
+     * `@react-pdf/render` is only a transitive of `@react-pdf/renderer`. The
+     * manifest walker can't see it because it can't open external manifests,
+     * so the lockfile walker has to surface it.
+     */
+    const targetManifest: PackageManifest = {
+      name: "consumer",
+      version: "1.0.0",
+      dependencies: { "@react-pdf/renderer": "^4.0.0" },
+    };
+
+    readTypedYamlSync.mockReturnValue({
+      patchedDependencies: {
+        "@react-pdf/render@4.3.0": "patches/@react-pdf__render@4.3.0.patch",
+      },
+    });
+    readTypedJson.mockResolvedValue({
+      name: "root",
+      version: "1.0.0",
+    } as PackageManifest);
+
+    filterPatchedDependencies.mockReturnValue({
+      "@react-pdf/render@4.3.0": "patches/@react-pdf__render@4.3.0.patch",
+    });
+
+    fs.existsSync.mockReturnValue(true);
+
+    usePackageManager.mockReturnValue({
+      name: "pnpm",
+      majorVersion: 9,
+      version: "9.0.0",
+      packageManagerString: "pnpm@9.0.0",
+    });
+
+    /**
+     * Fake v9 lockfile: target importer depends on @react-pdf/renderer, which
+     * has @react-pdf/render as its only resolved dep.
+     */
+    readWantedLockfile_v9.mockResolvedValue({
+      lockfileVersion: "9.0",
+      importers: {
+        "packages/consumer": {
+          specifiers: { "@react-pdf/renderer": "^4.0.0" },
+          dependencies: { "@react-pdf/renderer": "4.0.0" },
+        },
+      },
+      packages: {
+        "@react-pdf/renderer@4.0.0": {
+          resolution: { integrity: "sha512-x" },
+          dependencies: { "@react-pdf/render": "4.3.0" },
+        },
+        "@react-pdf/render@4.3.0": {
+          resolution: { integrity: "sha512-y" },
+        },
+      },
+    } as unknown as Awaited<ReturnType<typeof readWantedLockfile_v9>>);
+
+    const result = await copyPatches({
+      workspaceRootDir: "/workspace",
+      targetPackageDir: "/workspace/packages/consumer",
+      internalDepPackageNames: [],
+      targetPackageManifest: targetManifest,
+      isolateDir: "/workspace/isolate",
+      packagesRegistry: {},
+      includeDevDependencies: false,
+    });
+
+    expect(result).toEqual({
+      "@react-pdf/render@4.3.0": {
+        path: "patches/@react-pdf__render@4.3.0.patch",
+        hash: "",
+      },
+    });
+
+    const filterCall = filterPatchedDependencies.mock.calls[0]?.[0];
+    expect(filterCall).toBeDefined();
+    const reachable = filterCall!.reachableDependencyNames;
+    expect(reachable).toBeInstanceOf(Set);
+    expect(reachable!.has("@react-pdf/renderer")).toBe(true);
+    expect(reachable!.has("@react-pdf/render")).toBe(true);
   });
 });

--- a/src/lib/patches/copy-patches.ts
+++ b/src/lib/patches/copy-patches.ts
@@ -18,23 +18,29 @@ import {
   readTypedJson,
   readTypedYamlSync,
 } from "~/lib/utils";
+import { collectInstalledNamesFromBunLockfile } from "./collect-installed-names-bun";
+import { collectInstalledNamesFromPnpmLockfile } from "./collect-installed-names-pnpm";
 
 export async function copyPatches({
   workspaceRootDir,
+  targetPackageDir,
   targetPackageManifest,
   packagesRegistry,
+  internalDepPackageNames,
   isolateDir,
   includeDevDependencies,
 }: {
   workspaceRootDir: string;
+  targetPackageDir: string;
   targetPackageManifest: PackageManifest;
   packagesRegistry: PackagesRegistry;
+  internalDepPackageNames: string[];
   isolateDir: string;
   includeDevDependencies: boolean;
 }): Promise<Record<string, PatchFile>> {
   const log = useLogger();
 
-  const { name: packageManagerName } = usePackageManager();
+  const { name: packageManagerName, majorVersion } = usePackageManager();
 
   let patchedDependencies: Record<string, string> | undefined;
 
@@ -101,6 +107,37 @@ export async function copyPatches({
     packagesRegistry,
     includeDevDependencies,
   });
+
+  /**
+   * Manifest-based reachability misses external→external transitives because
+   * external manifests aren't loaded here. Walk the package-manager's
+   * lockfile to also pick up those names, so a patch for a deeply-nested
+   * external dep (e.g. `@react-pdf/render` reached via `@react-pdf/renderer`)
+   * survives isolation.
+   */
+  const lockfileInstalledNames =
+    packageManagerName === "pnpm"
+      ? await collectInstalledNamesFromPnpmLockfile({
+          workspaceRootDir,
+          targetPackageDir,
+          internalDepPackageNames,
+          packagesRegistry,
+          majorVersion,
+          includeDevDependencies,
+        })
+      : packageManagerName === "bun"
+        ? collectInstalledNamesFromBunLockfile({
+            workspaceRootDir,
+            targetPackageDir,
+            internalDepPackageNames,
+            packagesRegistry,
+            includeDevDependencies,
+          })
+        : new Set<string>();
+
+  for (const name of lockfileInstalledNames) {
+    reachableDependencyNames.add(name);
+  }
 
   const filteredPatches = filterPatchedDependencies({
     patchedDependencies,


### PR DESCRIPTION
## Problem

`pnpm.patchedDependencies` and `bun`'s `patchedDependencies` are dropped during isolation when the patched package is reachable only through an external transitive dep. The follow-up case from issue #167 shows the shape: target depends on `@react-pdf/renderer`, which depends on the patched `@react-pdf/render`. Since `@react-pdf/render` is not listed on any internal manifest, `collectReachablePackageNames` (which only walks workspace manifests) doesn't see it, `filterPatchedDependencies` excludes it, the patch file is not copied, and the isolated install runs with an unpatched copy.

## Solution

Walk the workspace lockfile from the target plus its internal importers and union the resulting set of installed package names into the existing `reachableDependencyNames` argument that `filterPatchedDependencies` consumes. The three current tiers (direct prod, direct dev, internal-reachable) are unchanged; the lockfile-derived set is added on top so the filter already handles it via its existing reachable check.

For pnpm, the new helper reads `pnpm-lock.yaml` (v8 or v9, Rush-aware), seeds a BFS frontier from each importer's `dependencies`/`optionalDependencies` (plus the target's `devDependencies` when `includeDevDependencies` is true), and walks `lockfile.packages`, mirroring `@pnpm/dependency-path`'s `refToRelative` and `indexOfPeersSuffix` inline so the package set stays a strict subset of what pnpm will install. For bun, the BFS that already exists in `generateBunLockfile` is extracted into a shared module so both lockfile generation and patch detection use the same walker.

Walk failures (missing lockfile, parse error, unknown pnpm version) return an empty set so the existing manifest-based tiers still apply as a fallback.

NPM is unaffected: `copyPatches` is still gated to pnpm/bun via `isolate.ts` and skipped entirely under `forceNpm`.

Scope: packages (isolate-package)
Visibility: user-facing