### PR TITLE
Fix intermittent "unexpected end of file" during unpack

### DIFF
--- a/src/lib/output/process-build-output-files.ts
+++ b/src/lib/output/process-build-output-files.ts
@@ -1,9 +1,6 @@
 import fs from "fs-extra";
 import path from "node:path";
-import { useLogger } from "../logger";
 import { pack, unpack } from "../utils";
-
-const TIMEOUT_MS = 5000;
 
 export async function processBuildOutputFiles({
   targetPackageDir,
@@ -14,22 +11,13 @@ export async function processBuildOutputFiles({
   tmpDir: string;
   isolateDir: string;
 }) {
-  const log = useLogger();
-
   const packedFilePath = await pack(targetPackageDir, tmpDir);
   const unpackDir = path.join(tmpDir, "target");
 
-  const now = Date.now();
-  let isWaitingYet = false;
-
-  while (!fs.existsSync(packedFilePath) && Date.now() - now < TIMEOUT_MS) {
-    if (!isWaitingYet) {
-      log.debug(`Waiting for ${packedFilePath} to become available...`);
-    }
-    isWaitingYet = true;
-    await new Promise((resolve) => setTimeout(resolve, 100));
-  }
-
+  /**
+   * `pack` already waits for the tarball to be fully written before returning,
+   * so it is safe to unpack immediately.
+   */
   await unpack(packedFilePath, unpackDir);
   await fs.copy(path.join(unpackDir, "package"), isolateDir);
 }

--- a/src/lib/utils/pack.ts
+++ b/src/lib/utils/pack.ts
@@ -6,6 +6,13 @@ import { useLogger } from "../logger";
 import { shouldUsePnpmPack } from "../package-manager";
 import { getErrorMessage } from "./get-error-message";
 
+/**
+ * How long to wait for the packed tarball to appear and stop growing on disk
+ * after `pnpm pack` / `npm pack` has exited.
+ */
+const PACK_FILE_READY_TIMEOUT_MS = 5000;
+const PACK_FILE_READY_POLL_MS = 50;
+
 export async function pack(srcDir: string, dstDir: string) {
   const log = useLogger();
 
@@ -59,20 +66,59 @@ export async function pack(srcDir: string, dstDir: string) {
 
   const filePath = path.join(dstDir, fileName);
 
-  if (!fs.existsSync(filePath)) {
-    log.error(
-      `The response from pack could not be resolved to an existing file: ${filePath}`,
-    );
-  } else {
-    log.debug(`Packed (temp)/${fileName}`);
-  }
-
   process.chdir(previousCwd);
 
   /**
-   * Return the path anyway even if it doesn't validate. A later stage will wait
-   * for the file to occur still. Not sure if this makes sense. Maybe we should
-   * stop at the validation error...
+   * `pnpm pack` (and occasionally `npm pack`) can return before the tarball is
+   * fully visible/flushed to disk. A naive `existsSync` check is not enough:
+   * the directory entry can appear before the file's data has been written,
+   * which causes downstream consumers (gunzip + tar) to fail with
+   * "unexpected end of file". Wait until the file exists and it's size has
+   * stopped changing across two consecutive polls before returning.
    */
+  await waitForCompleteFile(filePath, {
+    timeoutMs: PACK_FILE_READY_TIMEOUT_MS,
+    pollMs: PACK_FILE_READY_POLL_MS,
+  });
+
+  log.debug(`Packed (temp)/${fileName}`);
+
   return filePath;
+}
+
+async function waitForCompleteFile(
+  filePath: string,
+  { timeoutMs, pollMs }: { timeoutMs: number; pollMs: number },
+) {
+  const deadline = Date.now() + timeoutMs;
+  let lastSize = -1;
+
+  while (Date.now() < deadline) {
+    try {
+      const { size } = await fs.promises.stat(filePath);
+
+      /**
+       * Consider the file ready once it has non-zero size and that size has
+       * not changed since the previous poll. This is a cheap proxy for "the
+       * writer has finished flushing" without needing to inspect file
+       * contents or rely on platform-specific signals.
+       */
+      if (size > 0 && size === lastSize) {
+        return;
+      }
+
+      lastSize = size;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw err;
+      }
+      /** File not visible yet; keep polling. */
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, pollMs));
+  }
+
+  throw new Error(
+    `Timed out after ${timeoutMs}ms waiting for packed file to be written: ${filePath}`,
+  );
 }

--- a/src/lib/utils/pack.ts
+++ b/src/lib/utils/pack.ts
@@ -73,7 +73,7 @@ export async function pack(srcDir: string, dstDir: string) {
    * fully visible/flushed to disk. A naive `existsSync` check is not enough:
    * the directory entry can appear before the file's data has been written,
    * which causes downstream consumers (gunzip + tar) to fail with
-   * "unexpected end of file". Wait until the file exists and it's size has
+   * "unexpected end of file". Wait until the file exists and its size has
    * stopped changing across two consecutive polls before returning.
    */
   await waitForCompleteFile(filePath, {

--- a/src/lib/utils/unpack.ts
+++ b/src/lib/utils/unpack.ts
@@ -1,13 +1,19 @@
-import fs from "fs-extra";
-import tar from "tar-fs";
-import { createGunzip } from "zlib";
+import { createReadStream } from "node:fs";
+import { pipeline } from "node:stream/promises";
+import { createGunzip } from "node:zlib";
+import { extract as extractTar } from "tar-fs";
 
+/**
+ * Extract a gzipped tar archive into the given directory.
+ *
+ * Uses `stream/promises.pipeline` so that errors at any stage (file read,
+ * gunzip, tar extract) propagate as a rejected promise rather than crashing
+ * the process as unhandled stream errors.
+ */
 export async function unpack(filePath: string, unpackDir: string) {
-  await new Promise<void>((resolve, reject) => {
-    fs.createReadStream(filePath)
-      .pipe(createGunzip())
-      .pipe(tar.extract(unpackDir))
-      .on("finish", () => resolve())
-      .on("error", (err) => reject(err));
-  });
+  await pipeline(
+    createReadStream(filePath),
+    createGunzip(),
+    extractTar(unpackDir),
+  );
 }


### PR DESCRIPTION
## Commit messages

Add a wait for pack to complete using size polling
Use better pipeline for error handling
Cleanup and remove naive wait for file exists checks

Fixes #183

## AI Summary

 Two independent bugs combined to produce the intermittent zlib crash described in the issue: `pnpm pack` could return before its tarball was fully flushed to disk, and `unpack` silently dropped errors from the read and gunzip stages of its pipe chain. This PR fixes both.

 ## Changes

 - **pack.ts** — After `pnpm pack` / `npm pack` exits, wait until the tarball both exists and has a stable size across two consecutive 50 ms polls (5 s timeout) before returning. Throws a clear error on timeout instead of returning a path that may not yet be fully written. Removes the existing "return path anyway, a later stage will wait" branch and its log line, which papered over this case incompletely.
 - **unpack.ts** — Replace the hand-rolled `createReadStream().pipe(createGunzip()).pipe(tar.extract())` chain with `node:stream/promises` `pipeline`. `.pipe()` does not forward `error` events, so the previous code only caught errors from `tar-fs`; errors from the read stream or `gunzip` (which is exactly where #183 originates) became unhandled and crashed the process with a stack trace containing no `isolate-package` frames. `pipeline` surfaces errors from every stage as a rejected promise.
 - **process-build-output-files.ts** — Removed the now-redundant `while (!fs.existsSync(...))` polling loop and its `TIMEOUT_MS` / `useLogger` usage. The wait lives inside `pack()` now, so `packDependencies` (which had no equivalent wait at all, and whose parallel `unpack` calls had the same latent race) benefits without duplicated logic.

 ## Behaviour

 - Happy path is unchanged.
 - If a tarball is ever truncated in future, the failure now surfaces as a rejected promise from `unpack` with a real stack trace, rather than a bare `Zlib.zlibOnError` crash.

 ## Tests

 `pnpm check-types` and `pnpm test` (218 tests across 19 files) both pass.