### PR TITLE
Fix `ENOTEMPTY` race when resetting the isolate output directory

### DIFF
--- a/src/isolate.ts
+++ b/src/isolate.ts
@@ -31,6 +31,7 @@ import {
   getRootRelativeLogPath,
   isRushWorkspace,
   readTypedJson,
+  resetIsolateDir,
   writeTypedYamlSync,
 } from "./lib/utils";
 
@@ -77,12 +78,7 @@ export function createIsolator(config?: IsolateConfig) {
       getRootRelativeLogPath(isolateDir, workspaceRootDir),
     );
 
-    if (fs.existsSync(isolateDir)) {
-      await fs.remove(isolateDir);
-      log.debug("Cleaned the existing isolate output directory");
-    }
-
-    await fs.ensureDir(isolateDir);
+    await resetIsolateDir(isolateDir);
 
     const tmpDir = path.join(isolateDir, "__tmp");
     await fs.ensureDir(tmpDir);

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -9,5 +9,6 @@ export * from "./is-rush-workspace";
 export * from "./json";
 export * from "./log-paths";
 export * from "./pack";
+export * from "./reset-isolate-dir";
 export * from "./unpack";
 export * from "./yaml";

--- a/src/lib/utils/reset-isolate-dir.ts
+++ b/src/lib/utils/reset-isolate-dir.ts
@@ -1,0 +1,107 @@
+import { randomBytes } from "node:crypto";
+import fs from "fs-extra";
+import path from "node:path";
+import { useLogger } from "../logger";
+
+/**
+ * Prefix used for trash directories created when resetting the isolate output
+ * directory. The leading dot keeps it hidden in file explorers and `ls`
+ * without `-a`, so users don't see a flash of two folders while the old
+ * contents are being reaped in the background.
+ */
+const TRASH_PREFIX = ".";
+const TRASH_INFIX = ".trash-";
+
+/**
+ * Reset the isolate output directory to a fresh empty directory, avoiding the
+ * `ENOTEMPTY` race that occurs when another process (e.g. the Firebase
+ * functions emulator, a file watcher) writes into the directory while it is
+ * being recursively deleted.
+ *
+ * Strategy:
+ *
+ * 1. Sweep any leftover trash directories from previous runs that may have
+ *    been killed mid-cleanup. Best-effort: ignore errors.
+ * 2. If the isolate directory exists, atomically `rename` it to a hidden
+ *    sibling (`.${basename}.trash-<pid>-<rnd>`) on the same filesystem. The
+ *    rename is atomic, so the moment it returns the original path is free for
+ *    a fresh empty directory and nothing a concurrent writer does inside the
+ *    old tree can affect the new one.
+ * 3. Kick off the recursive delete of the trash directory in the background.
+ *    We don't await it: it is the slowest part of an isolate run, and any
+ *    failure (e.g. another process still holding files open) is harmless
+ *    because the logical state is already correct. Stale trash dirs are
+ *    reaped by the next run's sweep in step 1.
+ * 4. Ensure the (now-vacant) isolate directory exists.
+ */
+export async function resetIsolateDir(isolateDir: string): Promise<void> {
+  const log = useLogger();
+  const parentDir = path.dirname(isolateDir);
+  const baseName = path.basename(isolateDir);
+  const trashGlobPrefix = `${TRASH_PREFIX}${baseName}${TRASH_INFIX}`;
+
+  /** Best-effort sweep of leftover trash from previously killed runs. */
+  await sweepStaleTrash(parentDir, trashGlobPrefix);
+
+  if (fs.existsSync(isolateDir)) {
+    const trashDir = path.join(
+      parentDir,
+      `${trashGlobPrefix}${process.pid}-${randomBytes(4).toString("hex")}`,
+    );
+
+    try {
+      await fs.rename(isolateDir, trashDir);
+      log.debug("Moved existing isolate output directory to trash for cleanup");
+
+      /**
+       * Fire-and-forget. A concurrent writer can cause `ENOTEMPTY` or
+       * `EBUSY` here, but the logical state is already correct: the real
+       * `isolateDir` is gone. Any debris left behind will be swept on the
+       * next run.
+       */
+      void fs.remove(trashDir).catch((err: unknown) => {
+        log.debug(
+          "Background cleanup of trashed isolate directory did not complete:",
+          err instanceof Error ? err.message : String(err),
+        );
+      });
+    } catch (err) {
+      /**
+       * `rename` can fail with `EXDEV` if for some reason the parent dir and
+       * the isolate dir end up on different filesystems (it shouldn't, since
+       * they share a parent), or with `EPERM` on platforms that disallow
+       * renaming busy directories. Fall back to the original behaviour: a
+       * straight recursive delete. This preserves correctness at the cost of
+       * the race the rename was meant to avoid.
+       */
+      log.debug(
+        "Could not rename existing isolate output directory, falling back to recursive delete:",
+        err instanceof Error ? err.message : String(err),
+      );
+
+      await fs.remove(isolateDir);
+    }
+  }
+
+  await fs.ensureDir(isolateDir);
+}
+
+async function sweepStaleTrash(parentDir: string, trashGlobPrefix: string) {
+  let entries: string[];
+  try {
+    entries = await fs.readdir(parentDir);
+  } catch {
+    /** Parent doesn't exist yet; nothing to sweep. */
+    return;
+  }
+
+  await Promise.all(
+    entries
+      .filter((entry) => entry.startsWith(trashGlobPrefix))
+      .map((entry) =>
+        fs.remove(path.join(parentDir, entry)).catch(() => {
+          /** Best-effort. */
+        }),
+      ),
+  );
+}


### PR DESCRIPTION
Fixes #185 

 ## Summary

 Side-steps the recursive-delete race entirely by atomically renaming the existing `isolateDir` out of the way before deleting it, instead of trying to recursively delete it in place while another process may still be writing into it.

 ## Approach

 1. **Atomic rename, not in-place delete.** If `isolateDir` exists, `rename` it to a hidden sibling in the same parent (`.${basename}.trash-<pid-<rnd`). Same parent → same filesystem → the rename is atomic and never `EXDEV`. As soon as it returns, the original path is free for a fresh empty directory, and anything a concurrent writer does inside the renamed tree can no longer affect the new one.
 2. **Fire-and-forget cleanup.** The recursive delete of the renamed tree runs in the background, unawaited. If it loses a race with a concurrent writer (`ENOTEMPTY`/`EBUSY`), the error is logged at debug level but not thrown — the logical state is already correct, and `isolate` has no later step that depends on the trash being gone. Awaiting it would simply move the original race onto the renamed path.
 3. **Startup sweep.** Each run begins by removing any leftover `.${basename}.trash-*` siblings in the parent, so a process killed mid-cleanup never leaves debris behind for long. The sweep is also best-effort.
 4. **Hidden by convention.** The leading dot keeps the trash invisible in file explorers, VS Code's tree, and `ls` without `-a`, so users don't see a flash of two folders during a build.
 5. **Safe fallback.** If `rename` fails for any reason (e.g. `EXDEV` on a weird mount layout, `EPERM` on Windows when the directory is busy), fall back to the original `await fs.remove(isolateDir)` path so correctness is preserved at the cost of re-exposing the race in that edge case.

 ## Changes

 - **reset-isolate-dir.ts** (new) — Implements `resetIsolateDir(isolateDir)`: startup sweep → rename to trash → background delete → `ensureDir`. Exported via index.ts.
 - **isolate.ts** — Replaced the `fs.existsSync` + `fs.remove` + `fs.ensureDir` block at the top of `createIsolator` with a single `await resetIsolateDir(isolateDir)` call.

 ## Behaviour

 - Happy path is unchanged. The output directory is reset to empty before `isolate` proceeds, just as before.
 - Under a concurrent reader/writer (Firebase functions emulator, file watcher, etc.), `isolate` no longer fails with `ENOTEMPTY` during the initial cleanup.
 - In the unlikely event that a build is killed mid-cleanup, the next run's sweep reaps the leftover `.${basename}.trash-*` automatically.

 ## Note on .gitignore

 The trash directory lives next to `isolateDir` (e.g. `functions/.isolate.trash-12345-ab12cd34`). It's hidden and short-lived, but projects that explicitly list `isolate/` in .gitignore may want to add `.isolate.trash-*` alongside it for completeness. Happy to add a note to the README in this PR if you'd like — left it out for now to keep the diff focused.

 ## Tests

 `pnpm check-types` and `pnpm test` (218 tests across 19 files) both pass. No new tests added yet; happy to add unit coverage for `resetIsolateDir` (verifying the rename, the sweep, and the fallback path against a real tmp dir) if you'd like that in this PR.