### PR TITLE
Restore isolate bin alongside isolate-package

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "url": "git+https://github.com/0x80/isolate-package.git"
   },
   "bin": {
+    "isolate": "./dist/isolate-bin.mjs",
     "isolate-package": "./dist/isolate-bin.mjs"
   },
   "files": [


### PR DESCRIPTION
A recent change renamed the CLI bin from `isolate` to `isolate-package`, which is a breaking change for anyone invoking the bin directly (scripts, CI, Dockerfiles, `npx isolate`, etc.). Restore the original `isolate` bin so it is exposed in parallel with `isolate-package`, both pointing at the same entry. This avoids breaking existing users on a minor version bump.

Scope: packages (isolate-package)
Visibility: user-facing