### PR TITLE
Avoid ENOTEMPTY race when resetting the isolate output directory

### DIFF
--- a/src/isolate.ts
+++ b/src/isolate.ts
@@ -78,7 +78,16 @@ export function createIsolator(config?: IsolateConfig) {
       getRootRelativeLogPath(isolateDir, workspaceRootDir),
     );
 
-    await resetIsolateDir(isolateDir);
+    /**
+     * Place the trash sibling outside `targetPackageDir`, since that directory
+     * is later packed by `processBuildOutputFiles`. Keeping the trash next to
+     * the target package (still on the same filesystem) preserves the atomic
+     * rename without risking that the trash gets picked up by `npm pack` or
+     * races with that step.
+     */
+    await resetIsolateDir(isolateDir, {
+      trashParentDir: path.dirname(targetPackageDir),
+    });
 
     const tmpDir = path.join(isolateDir, "__tmp");
     await fs.ensureDir(tmpDir);

--- a/src/isolate.ts
+++ b/src/isolate.ts
@@ -31,6 +31,7 @@ import {
   getRootRelativeLogPath,
   isRushWorkspace,
   readTypedJson,
+  resetIsolateDir,
   writeTypedYamlSync,
 } from "./lib/utils";
 
@@ -77,12 +78,7 @@ export function createIsolator(config?: IsolateConfig) {
       getRootRelativeLogPath(isolateDir, workspaceRootDir),
     );
 
-    if (fs.existsSync(isolateDir)) {
-      await fs.remove(isolateDir);
-      log.debug("Cleaned the existing isolate output directory");
-    }
-
-    await fs.ensureDir(isolateDir);
+    await resetIsolateDir(isolateDir);
 
     const tmpDir = path.join(isolateDir, "__tmp");
     await fs.ensureDir(tmpDir);

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -9,5 +9,6 @@ export * from "./is-rush-workspace";
 export * from "./json";
 export * from "./log-paths";
 export * from "./pack";
+export * from "./reset-isolate-dir";
 export * from "./unpack";
 export * from "./yaml";

--- a/src/lib/utils/reset-isolate-dir.test.ts
+++ b/src/lib/utils/reset-isolate-dir.test.ts
@@ -69,9 +69,9 @@ describe("resetIsolateDir", () => {
     await fs.writeFile(path.join(isolateDir, "stale.txt"), "stale");
 
     /**
-     * Block the background delete by holding the trash dir open. We grab the
-     * snapshot immediately after the call so we can assert where the trash
-     * landed before the background `fs.remove` runs.
+     * Wrap `fs.rename` so we can read back the destination path the function
+     * picked — the trash dir name is randomised, so capturing the spy's
+     * arguments is the only way to assert where the rename targeted.
      */
     const renameSpy = vi.spyOn(fs, "rename");
 

--- a/src/lib/utils/reset-isolate-dir.test.ts
+++ b/src/lib/utils/reset-isolate-dir.test.ts
@@ -1,0 +1,163 @@
+import fs from "fs-extra";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resetIsolateDir } from "./reset-isolate-dir";
+
+/**
+ * Wait until `predicate` returns true or the timeout elapses. Used for the
+ * fire-and-forget background delete, which we can't await directly.
+ */
+async function waitFor(
+  predicate: () => boolean | Promise<boolean>,
+  {
+    timeoutMs = 2000,
+    intervalMs = 20,
+  }: { timeoutMs?: number; intervalMs?: number } = {},
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+  throw new Error(`Timed out after ${timeoutMs}ms waiting for predicate`);
+}
+
+describe("resetIsolateDir", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "reset-isolate-dir-"));
+  });
+
+  afterEach(async () => {
+    await fs.remove(tempDir).catch(() => {
+      /** Best-effort. */
+    });
+  });
+
+  it("creates an empty isolate dir when none exists", async () => {
+    const isolateDir = path.join(tempDir, "package", "isolate");
+
+    await resetIsolateDir(isolateDir);
+
+    expect(fs.existsSync(isolateDir)).toBe(true);
+    expect(await fs.readdir(isolateDir)).toEqual([]);
+  });
+
+  it("empties an existing isolate dir and creates the trash sibling next to it by default", async () => {
+    const isolateDir = path.join(tempDir, "package", "isolate");
+    await fs.ensureDir(isolateDir);
+    await fs.writeFile(path.join(isolateDir, "stale.txt"), "stale");
+
+    await resetIsolateDir(isolateDir);
+
+    expect(fs.existsSync(isolateDir)).toBe(true);
+    expect(await fs.readdir(isolateDir)).toEqual([]);
+
+    /** Background delete eventually removes the trash sibling. */
+    await waitFor(async () => {
+      const entries = await fs.readdir(path.dirname(isolateDir));
+      return entries.every((entry) => !entry.includes(".trash-"));
+    });
+  });
+
+  it("places trash in the provided trashParentDir instead of next to isolateDir", async () => {
+    const packageParent = path.join(tempDir, "packages");
+    const isolateDir = path.join(packageParent, "api", "isolate");
+    await fs.ensureDir(isolateDir);
+    await fs.writeFile(path.join(isolateDir, "stale.txt"), "stale");
+
+    /**
+     * Block the background delete by holding the trash dir open. We grab the
+     * snapshot immediately after the call so we can assert where the trash
+     * landed before the background `fs.remove` runs.
+     */
+    const renameSpy = vi.spyOn(fs, "rename");
+
+    await resetIsolateDir(isolateDir, { trashParentDir: packageParent });
+
+    expect(renameSpy).toHaveBeenCalledTimes(1);
+    const [, renamedTo] = renameSpy.mock.calls[0]!;
+    expect(path.dirname(renamedTo as string)).toBe(packageParent);
+    expect(path.basename(renamedTo as string)).toMatch(
+      /^\.api-isolate\.trash-/,
+    );
+
+    /** The original target package dir contains nothing but a fresh empty isolate dir. */
+    expect(await fs.readdir(path.dirname(isolateDir))).toEqual(["isolate"]);
+    expect(await fs.readdir(isolateDir)).toEqual([]);
+
+    renameSpy.mockRestore();
+
+    await waitFor(async () => {
+      const entries = await fs.readdir(packageParent);
+      return entries.every((entry) => !entry.includes(".trash-"));
+    });
+  });
+
+  it("sweeps leftover trash from previous runs", async () => {
+    const packageParent = path.join(tempDir, "packages");
+    const isolateDir = path.join(packageParent, "api", "isolate");
+    await fs.ensureDir(isolateDir);
+
+    /** Simulate debris left behind by a previously killed run. */
+    const stale1 = path.join(packageParent, ".api-isolate.trash-9999-aabbccdd");
+    const stale2 = path.join(packageParent, ".api-isolate.trash-9998-eeff0011");
+    await fs.ensureDir(stale1);
+    await fs.ensureDir(stale2);
+    await fs.writeFile(path.join(stale1, "junk"), "junk");
+
+    /** Unrelated sibling that must be left alone. */
+    const sibling = path.join(packageParent, "web");
+    await fs.ensureDir(sibling);
+
+    await resetIsolateDir(isolateDir, { trashParentDir: packageParent });
+
+    /** Eventually both the stale entries and any new trash are gone. */
+    await waitFor(async () => {
+      const entries = await fs.readdir(packageParent);
+      return entries.every((entry) => !entry.includes(".trash-"));
+    });
+
+    expect(fs.existsSync(sibling)).toBe(true);
+  });
+
+  it("only sweeps trash matching this isolateDir's stem", async () => {
+    const packageParent = path.join(tempDir, "packages");
+    const isolateDir = path.join(packageParent, "api", "isolate");
+    await fs.ensureDir(isolateDir);
+
+    /** Trash from a different package's isolate run. */
+    const otherTrash = path.join(
+      packageParent,
+      ".web-isolate.trash-1234-deadbeef",
+    );
+    await fs.ensureDir(otherTrash);
+
+    await resetIsolateDir(isolateDir, { trashParentDir: packageParent });
+
+    /** The sweep filter is keyed on the stem, so other packages' trash stays. */
+    expect(fs.existsSync(otherTrash)).toBe(true);
+  });
+
+  it("falls back to recursive delete when rename fails", async () => {
+    const isolateDir = path.join(tempDir, "package", "isolate");
+    await fs.ensureDir(isolateDir);
+    await fs.writeFile(path.join(isolateDir, "stale.txt"), "stale");
+
+    const renameSpy = vi
+      .spyOn(fs, "rename")
+      .mockRejectedValueOnce(
+        Object.assign(new Error("EXDEV"), { code: "EXDEV" }),
+      );
+
+    await resetIsolateDir(isolateDir);
+
+    expect(renameSpy).toHaveBeenCalledTimes(1);
+    expect(fs.existsSync(isolateDir)).toBe(true);
+    expect(await fs.readdir(isolateDir)).toEqual([]);
+
+    renameSpy.mockRestore();
+  });
+});

--- a/src/lib/utils/reset-isolate-dir.ts
+++ b/src/lib/utils/reset-isolate-dir.ts
@@ -121,6 +121,11 @@ function buildTrashStem(trashParentDir: string, isolateDir: string): string {
   return relative.split(path.sep).filter(Boolean).join("-");
 }
 
+/**
+ * Best-effort sweep of leftover trash directories matching this isolate dir's
+ * stem. Failures are swallowed: stale trash is debris, not state, and a
+ * subsequent run will get another chance to reap it.
+ */
 async function sweepStaleTrash(parentDir: string, trashGlobPrefix: string) {
   let entries: string[];
   try {

--- a/src/lib/utils/reset-isolate-dir.ts
+++ b/src/lib/utils/reset-isolate-dir.ts
@@ -12,6 +12,21 @@ import { useLogger } from "../logger";
 const TRASH_PREFIX = ".";
 const TRASH_INFIX = ".trash-";
 
+export type ResetIsolateDirOptions = {
+  /**
+   * Directory in which to place the temporary "trash" sibling that
+   * `isolateDir` is renamed to before being deleted in the background.
+   * Defaults to `path.dirname(isolateDir)`.
+   *
+   * Callers that pack the parent of `isolateDir` (e.g. `isolate.ts`, which
+   * later runs `npm pack` on `targetPackageDir`) should point this at a
+   * location outside of what gets packed, so the trash can't leak into the
+   * packed output and so the background delete can't race with the pack
+   * step.
+   */
+  trashParentDir?: string;
+};
+
 /**
  * Reset the isolate output directory to a fresh empty directory, avoiding the
  * `ENOTEMPTY` race that occurs when another process (e.g. the Firebase
@@ -23,10 +38,10 @@ const TRASH_INFIX = ".trash-";
  * 1. Sweep any leftover trash directories from previous runs that may have
  *    been killed mid-cleanup. Best-effort: ignore errors.
  * 2. If the isolate directory exists, atomically `rename` it to a hidden
- *    sibling (`.${basename}.trash-<pid>-<rnd>`) on the same filesystem. The
- *    rename is atomic, so the moment it returns the original path is free for
- *    a fresh empty directory and nothing a concurrent writer does inside the
- *    old tree can affect the new one.
+ *    sibling on the same filesystem. The rename is atomic, so the moment it
+ *    returns the original path is free for a fresh empty directory and
+ *    nothing a concurrent writer does inside the old tree can affect the
+ *    new one.
  * 3. Kick off the recursive delete of the trash directory in the background.
  *    We don't await it: it is the slowest part of an isolate run, and any
  *    failure (e.g. another process still holding files open) is harmless
@@ -34,22 +49,26 @@ const TRASH_INFIX = ".trash-";
  *    reaped by the next run's sweep in step 1.
  * 4. Ensure the (now-vacant) isolate directory exists.
  */
-export async function resetIsolateDir(isolateDir: string): Promise<void> {
+export async function resetIsolateDir(
+  isolateDir: string,
+  options: ResetIsolateDirOptions = {},
+): Promise<void> {
   const log = useLogger();
-  const parentDir = path.dirname(isolateDir);
-  const baseName = path.basename(isolateDir);
-  const trashGlobPrefix = `${TRASH_PREFIX}${baseName}${TRASH_INFIX}`;
+  const trashParentDir = options.trashParentDir ?? path.dirname(isolateDir);
+  const trashStem = buildTrashStem(trashParentDir, isolateDir);
+  const trashGlobPrefix = `${TRASH_PREFIX}${trashStem}${TRASH_INFIX}`;
 
   /** Best-effort sweep of leftover trash from previously killed runs. */
-  await sweepStaleTrash(parentDir, trashGlobPrefix);
+  await sweepStaleTrash(trashParentDir, trashGlobPrefix);
 
   if (fs.existsSync(isolateDir)) {
     const trashDir = path.join(
-      parentDir,
+      trashParentDir,
       `${trashGlobPrefix}${process.pid}-${randomBytes(4).toString("hex")}`,
     );
 
     try {
+      await fs.ensureDir(trashParentDir);
       await fs.rename(isolateDir, trashDir);
       log.debug("Moved existing isolate output directory to trash for cleanup");
 
@@ -67,12 +86,11 @@ export async function resetIsolateDir(isolateDir: string): Promise<void> {
       });
     } catch (err) {
       /**
-       * `rename` can fail with `EXDEV` if for some reason the parent dir and
-       * the isolate dir end up on different filesystems (it shouldn't, since
-       * they share a parent), or with `EPERM` on platforms that disallow
-       * renaming busy directories. Fall back to the original behaviour: a
-       * straight recursive delete. This preserves correctness at the cost of
-       * the race the rename was meant to avoid.
+       * `rename` can fail with `EXDEV` if `trashParentDir` ends up on a
+       * different filesystem from `isolateDir`, or with `EPERM` on platforms
+       * that disallow renaming busy directories. Fall back to the original
+       * behaviour: a straight recursive delete. This preserves correctness
+       * at the cost of the race the rename was meant to avoid.
        */
       log.debug(
         "Could not rename existing isolate output directory, falling back to recursive delete:",
@@ -84,6 +102,23 @@ export async function resetIsolateDir(isolateDir: string): Promise<void> {
   }
 
   await fs.ensureDir(isolateDir);
+}
+
+/**
+ * Build a stable name stem for the trash directory. When `trashParentDir` is
+ * the direct parent of `isolateDir` (the default), this is just the isolate
+ * dir's basename. When it isn't (e.g. callers placing trash outside the
+ * packed dir), include the relative path so multiple isolate dirs sharing
+ * the same trash parent don't collide in the sweep filter.
+ */
+function buildTrashStem(trashParentDir: string, isolateDir: string): string {
+  const relative = path.relative(trashParentDir, isolateDir);
+
+  if (!relative || relative.startsWith("..") || path.isAbsolute(relative)) {
+    return path.basename(isolateDir);
+  }
+
+  return relative.split(path.sep).filter(Boolean).join("-");
 }
 
 async function sweepStaleTrash(parentDir: string, trashGlobPrefix: string) {

--- a/src/lib/utils/reset-isolate-dir.ts
+++ b/src/lib/utils/reset-isolate-dir.ts
@@ -1,0 +1,107 @@
+import { randomBytes } from "node:crypto";
+import fs from "fs-extra";
+import path from "node:path";
+import { useLogger } from "../logger";
+
+/**
+ * Prefix used for trash directories created when resetting the isolate output
+ * directory. The leading dot keeps it hidden in file explorers and `ls`
+ * without `-a`, so users don't see a flash of two folders while the old
+ * contents are being reaped in the background.
+ */
+const TRASH_PREFIX = ".";
+const TRASH_INFIX = ".trash-";
+
+/**
+ * Reset the isolate output directory to a fresh empty directory, avoiding the
+ * `ENOTEMPTY` race that occurs when another process (e.g. the Firebase
+ * functions emulator, a file watcher) writes into the directory while it is
+ * being recursively deleted.
+ *
+ * Strategy:
+ *
+ * 1. Sweep any leftover trash directories from previous runs that may have
+ *    been killed mid-cleanup. Best-effort: ignore errors.
+ * 2. If the isolate directory exists, atomically `rename` it to a hidden
+ *    sibling (`.${basename}.trash-<pid>-<rnd>`) on the same filesystem. The
+ *    rename is atomic, so the moment it returns the original path is free for
+ *    a fresh empty directory and nothing a concurrent writer does inside the
+ *    old tree can affect the new one.
+ * 3. Kick off the recursive delete of the trash directory in the background.
+ *    We don't await it: it is the slowest part of an isolate run, and any
+ *    failure (e.g. another process still holding files open) is harmless
+ *    because the logical state is already correct. Stale trash dirs are
+ *    reaped by the next run's sweep in step 1.
+ * 4. Ensure the (now-vacant) isolate directory exists.
+ */
+export async function resetIsolateDir(isolateDir: string): Promise<void> {
+  const log = useLogger();
+  const parentDir = path.dirname(isolateDir);
+  const baseName = path.basename(isolateDir);
+  const trashGlobPrefix = `${TRASH_PREFIX}${baseName}${TRASH_INFIX}`;
+
+  /** Best-effort sweep of leftover trash from previously killed runs. */
+  await sweepStaleTrash(parentDir, trashGlobPrefix);
+
+  if (fs.existsSync(isolateDir)) {
+    const trashDir = path.join(
+      parentDir,
+      `${trashGlobPrefix}${process.pid}-${randomBytes(4).toString("hex")}`,
+    );
+
+    try {
+      await fs.rename(isolateDir, trashDir);
+      log.debug("Moved existing isolate output directory to trash for cleanup");
+
+      /**
+       * Fire-and-forget. A concurrent writer can cause `ENOTEMPTY` or
+       * `EBUSY` here, but the logical state is already correct: the real
+       * `isolateDir` is gone. Any debris left behind will be swept on the
+       * next run.
+       */
+      void fs.remove(trashDir).catch((err: unknown) => {
+        log.debug(
+          "Background cleanup of trashed isolate directory did not complete:",
+          err instanceof Error ? err.message : String(err),
+        );
+      });
+    } catch (err) {
+      /**
+       * `rename` can fail with `EXDEV` if for some reason the parent dir and
+       * the isolate dir end up on different filesystems (it shouldn't, since
+       * they share a parent), or with `EPERM` on platforms that disallow
+       * renaming busy directories. Fall back to the original behaviour: a
+       * straight recursive delete. This preserves correctness at the cost of
+       * the race the rename was meant to avoid.
+       */
+      log.debug(
+        "Could not rename existing isolate output directory, falling back to recursive delete:",
+        err instanceof Error ? err.message : String(err),
+      );
+
+      await fs.remove(isolateDir);
+    }
+  }
+
+  await fs.ensureDir(isolateDir);
+}
+
+async function sweepStaleTrash(parentDir: string, trashGlobPrefix: string) {
+  let entries: string[];
+  try {
+    entries = await fs.readdir(parentDir);
+  } catch {
+    /** Parent doesn't exist yet; nothing to sweep. */
+    return;
+  }
+
+  await Promise.all(
+    entries
+      .filter((entry) => entry.startsWith(trashGlobPrefix))
+      .map((entry) =>
+        fs.remove(path.join(parentDir, entry)).catch(() => {
+          /** Best-effort. */
+        }),
+      ),
+  );
+}


### PR DESCRIPTION
Builds on the work in #186 (credit to @ChromeQ for the original commit) and addresses the review feedback that surfaced there.

## Problem

When `isolate` ran while another process (e.g. the Firebase Functions emulator, a file watcher) was reading or writing inside `isolateDir`, the recursive `fs.remove(isolateDir)` at the start of a run could race with the concurrent writer and fail with `ENOTEMPTY` (or `EBUSY` on Windows).

## Solution

Replace the in-place recursive delete with an atomic rename to a hidden sibling, followed by a fire-and-forget background delete:

1. Sweep any leftover trash from previously killed runs.
2. Rename `isolateDir` to a hidden sibling. Atomic, so the original path is immediately free for a fresh empty directory and a concurrent writer can no longer affect what lands there.
3. Delete the renamed tree in the background, unawaited. Failures are logged at debug level only; the logical state is already correct.
4. `ensureDir(isolateDir)`.
5. If `rename` fails (e.g. `EXDEV` on a cross-filesystem layout), fall back to the original recursive delete so correctness is preserved.

## Differences from #186

The original PR placed the trash sibling next to `isolateDir`, which lives inside `targetPackageDir`. Later in the same run, `processBuildOutputFiles` runs `npm pack` / `pnpm pack` on `targetPackageDir`, so an unawaited `.isolate.trash-*` tree could be picked up by the pack step (or race with it) unless the package's `files` field explicitly excluded it.

This PR:

- Adds a `trashParentDir` option to `resetIsolateDir`. The caller in `isolate.ts` passes `path.dirname(targetPackageDir)` so trash always ends up outside the packed directory but still on the same filesystem, preserving the atomic-rename guarantee.
- Disambiguates the trash name when `trashParentDir` is not the direct parent, by encoding the relative path into the stem (e.g. `.api-isolate.trash-<pid>-<rnd>`). This keeps the startup sweep scoped to this isolate dir's own debris, so concurrent isolations of sibling packages don't trample each other's trash.
- Adds unit tests for `resetIsolateDir` covering empty parent, rename-to-trash with default and custom `trashParentDir`, stale-trash sweep, stem-scoped sweep isolation, and the rename-fallback path.

Closes #185

Scope: cli (isolate-package)
Visibility: user-facing