### PR TITLE
Fix intermittent "unexpected end of file" during unpack

### DIFF
--- a/src/lib/output/process-build-output-files.ts
+++ b/src/lib/output/process-build-output-files.ts
@@ -1,9 +1,6 @@
 import fs from "fs-extra";
 import path from "node:path";
-import { useLogger } from "../logger";
 import { pack, unpack } from "../utils";
-
-const TIMEOUT_MS = 5000;
 
 export async function processBuildOutputFiles({
   targetPackageDir,
@@ -14,22 +11,13 @@ export async function processBuildOutputFiles({
   tmpDir: string;
   isolateDir: string;
 }) {
-  const log = useLogger();
-
   const packedFilePath = await pack(targetPackageDir, tmpDir);
   const unpackDir = path.join(tmpDir, "target");
 
-  const now = Date.now();
-  let isWaitingYet = false;
-
-  while (!fs.existsSync(packedFilePath) && Date.now() - now < TIMEOUT_MS) {
-    if (!isWaitingYet) {
-      log.debug(`Waiting for ${packedFilePath} to become available...`);
-    }
-    isWaitingYet = true;
-    await new Promise((resolve) => setTimeout(resolve, 100));
-  }
-
+  /**
+   * `pack` already waits for the tarball to be fully written before returning,
+   * so it is safe to unpack immediately.
+   */
   await unpack(packedFilePath, unpackDir);
   await fs.copy(path.join(unpackDir, "package"), isolateDir);
 }

--- a/src/lib/utils/pack.ts
+++ b/src/lib/utils/pack.ts
@@ -6,6 +6,13 @@ import { useLogger } from "../logger";
 import { shouldUsePnpmPack } from "../package-manager";
 import { getErrorMessage } from "./get-error-message";
 
+/**
+ * How long to wait for the packed tarball to appear and stop growing on disk
+ * after `pnpm pack` / `npm pack` has exited.
+ */
+const PACK_FILE_READY_TIMEOUT_MS = 5000;
+const PACK_FILE_READY_POLL_MS = 50;
+
 export async function pack(srcDir: string, dstDir: string) {
   const log = useLogger();
 
@@ -59,20 +66,59 @@ export async function pack(srcDir: string, dstDir: string) {
 
   const filePath = path.join(dstDir, fileName);
 
-  if (!fs.existsSync(filePath)) {
-    log.error(
-      `The response from pack could not be resolved to an existing file: ${filePath}`,
-    );
-  } else {
-    log.debug(`Packed (temp)/${fileName}`);
-  }
-
   process.chdir(previousCwd);
 
   /**
-   * Return the path anyway even if it doesn't validate. A later stage will wait
-   * for the file to occur still. Not sure if this makes sense. Maybe we should
-   * stop at the validation error...
+   * `pnpm pack` (and occasionally `npm pack`) can return before the tarball is
+   * fully visible/flushed to disk. A naive `existsSync` check is not enough:
+   * the directory entry can appear before the file's data has been written,
+   * which causes downstream consumers (gunzip + tar) to fail with
+   * "unexpected end of file". Wait until the file exists and it's size has
+   * stopped changing across two consecutive polls before returning.
    */
+  await waitForCompleteFile(filePath, {
+    timeoutMs: PACK_FILE_READY_TIMEOUT_MS,
+    pollMs: PACK_FILE_READY_POLL_MS,
+  });
+
+  log.debug(`Packed (temp)/${fileName}`);
+
   return filePath;
+}
+
+async function waitForCompleteFile(
+  filePath: string,
+  { timeoutMs, pollMs }: { timeoutMs: number; pollMs: number },
+) {
+  const deadline = Date.now() + timeoutMs;
+  let lastSize = -1;
+
+  while (Date.now() < deadline) {
+    try {
+      const { size } = await fs.promises.stat(filePath);
+
+      /**
+       * Consider the file ready once it has non-zero size and that size has
+       * not changed since the previous poll. This is a cheap proxy for "the
+       * writer has finished flushing" without needing to inspect file
+       * contents or rely on platform-specific signals.
+       */
+      if (size > 0 && size === lastSize) {
+        return;
+      }
+
+      lastSize = size;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw err;
+      }
+      /** File not visible yet; keep polling. */
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, pollMs));
+  }
+
+  throw new Error(
+    `Timed out after ${timeoutMs}ms waiting for packed file to be written: ${filePath}`,
+  );
 }

--- a/src/lib/utils/pack.ts
+++ b/src/lib/utils/pack.ts
@@ -1,10 +1,10 @@
 import assert from "node:assert";
 import { exec } from "node:child_process";
-import fs from "node:fs";
 import path from "node:path";
 import { useLogger } from "../logger";
 import { shouldUsePnpmPack } from "../package-manager";
 import { getErrorMessage } from "./get-error-message";
+import { waitForCompleteFile } from "./wait-for-complete-file";
 
 /**
  * How long to wait for the packed tarball to appear and stop growing on disk
@@ -84,41 +84,4 @@ export async function pack(srcDir: string, dstDir: string) {
   log.debug(`Packed (temp)/${fileName}`);
 
   return filePath;
-}
-
-async function waitForCompleteFile(
-  filePath: string,
-  { timeoutMs, pollMs }: { timeoutMs: number; pollMs: number },
-) {
-  const deadline = Date.now() + timeoutMs;
-  let lastSize = -1;
-
-  while (Date.now() < deadline) {
-    try {
-      const { size } = await fs.promises.stat(filePath);
-
-      /**
-       * Consider the file ready once it has non-zero size and that size has
-       * not changed since the previous poll. This is a cheap proxy for "the
-       * writer has finished flushing" without needing to inspect file
-       * contents or rely on platform-specific signals.
-       */
-      if (size > 0 && size === lastSize) {
-        return;
-      }
-
-      lastSize = size;
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
-        throw err;
-      }
-      /** File not visible yet; keep polling. */
-    }
-
-    await new Promise((resolve) => setTimeout(resolve, pollMs));
-  }
-
-  throw new Error(
-    `Timed out after ${timeoutMs}ms waiting for packed file to be written: ${filePath}`,
-  );
 }

--- a/src/lib/utils/pack.ts
+++ b/src/lib/utils/pack.ts
@@ -73,7 +73,7 @@ export async function pack(srcDir: string, dstDir: string) {
    * fully visible/flushed to disk. A naive `existsSync` check is not enough:
    * the directory entry can appear before the file's data has been written,
    * which causes downstream consumers (gunzip + tar) to fail with
-   * "unexpected end of file". Wait until the file exists and it's size has
+   * "unexpected end of file". Wait until the file exists and its size has
    * stopped changing across two consecutive polls before returning.
    */
   await waitForCompleteFile(filePath, {

--- a/src/lib/utils/unpack.test.ts
+++ b/src/lib/utils/unpack.test.ts
@@ -1,0 +1,76 @@
+import fs from "fs-extra";
+import { createWriteStream } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { pipeline } from "node:stream/promises";
+import { createGzip } from "node:zlib";
+import { pack as packTar } from "tar-fs";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { unpack } from "./unpack";
+
+async function createTarball(srcDir: string, tarballPath: string) {
+  await pipeline(packTar(srcDir), createGzip(), createWriteStream(tarballPath));
+}
+
+describe("unpack", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "isolate-unpack-test-"));
+  });
+
+  afterEach(async () => {
+    await fs.remove(tempDir);
+  });
+
+  it("extracts a valid gzipped tarball into the destination directory", async () => {
+    const srcDir = path.join(tempDir, "src");
+    await fs.ensureDir(path.join(srcDir, "nested"));
+    await fs.writeFile(path.join(srcDir, "root.txt"), "hello");
+    await fs.writeFile(path.join(srcDir, "nested", "leaf.txt"), "world");
+
+    const tarballPath = path.join(tempDir, "archive.tgz");
+    await createTarball(srcDir, tarballPath);
+
+    const unpackDir = path.join(tempDir, "out");
+    await unpack(tarballPath, unpackDir);
+
+    expect(await fs.readFile(path.join(unpackDir, "root.txt"), "utf8")).toBe(
+      "hello",
+    );
+    expect(
+      await fs.readFile(path.join(unpackDir, "nested", "leaf.txt"), "utf8"),
+    ).toBe("world");
+  });
+
+  it("rejects with an error when the tarball is truncated", async () => {
+    const srcDir = path.join(tempDir, "src");
+    await fs.ensureDir(srcDir);
+    await fs.writeFile(path.join(srcDir, "file.txt"), "a".repeat(8192));
+
+    const tarballPath = path.join(tempDir, "archive.tgz");
+    await createTarball(srcDir, tarballPath);
+
+    const truncatedPath = path.join(tempDir, "truncated.tgz");
+    const fullData = await fs.readFile(tarballPath);
+    await fs.writeFile(truncatedPath, fullData.subarray(0, 32));
+
+    const unpackDir = path.join(tempDir, "out");
+
+    /**
+     * Pre-fix, the gunzip error from a truncated archive surfaced as an
+     * unhandled stream error and crashed the process. With `pipeline` the
+     * same scenario must reject the returned promise so callers can handle
+     * it.
+     */
+    await expect(unpack(truncatedPath, unpackDir)).rejects.toThrow();
+  });
+
+  it("rejects when the source path does not exist", async () => {
+    const unpackDir = path.join(tempDir, "out");
+
+    await expect(
+      unpack(path.join(tempDir, "does-not-exist.tgz"), unpackDir),
+    ).rejects.toThrow();
+  });
+});

--- a/src/lib/utils/unpack.ts
+++ b/src/lib/utils/unpack.ts
@@ -1,13 +1,19 @@
-import fs from "fs-extra";
-import tar from "tar-fs";
-import { createGunzip } from "zlib";
+import { createReadStream } from "node:fs";
+import { pipeline } from "node:stream/promises";
+import { createGunzip } from "node:zlib";
+import { extract as extractTar } from "tar-fs";
 
+/**
+ * Extract a gzipped tar archive into the given directory.
+ *
+ * Uses `stream/promises.pipeline` so that errors at any stage (file read,
+ * gunzip, tar extract) propagate as a rejected promise rather than crashing
+ * the process as unhandled stream errors.
+ */
 export async function unpack(filePath: string, unpackDir: string) {
-  await new Promise<void>((resolve, reject) => {
-    fs.createReadStream(filePath)
-      .pipe(createGunzip())
-      .pipe(tar.extract(unpackDir))
-      .on("finish", () => resolve())
-      .on("error", (err) => reject(err));
-  });
+  await pipeline(
+    createReadStream(filePath),
+    createGunzip(),
+    extractTar(unpackDir),
+  );
 }

--- a/src/lib/utils/wait-for-complete-file.test.ts
+++ b/src/lib/utils/wait-for-complete-file.test.ts
@@ -29,25 +29,31 @@ describe("waitForCompleteFile", () => {
   it("waits until a file that appears late is written", async () => {
     const filePath = path.join(tempDir, "late.bin");
 
-    setTimeout(() => {
+    const write = setTimeout(() => {
       void fs.writeFile(filePath, Buffer.alloc(512, 0x01));
     }, 60);
 
-    await expect(
-      waitForCompleteFile(filePath, { timeoutMs: 1000, pollMs: 20 }),
-    ).resolves.toBeUndefined();
+    try {
+      await expect(
+        waitForCompleteFile(filePath, { timeoutMs: 1000, pollMs: 20 }),
+      ).resolves.toBeUndefined();
 
-    const { size } = await fs.stat(filePath);
-    expect(size).toBe(512);
+      const { size } = await fs.stat(filePath);
+      expect(size).toBe(512);
+    } finally {
+      clearTimeout(write);
+    }
   });
 
   it("waits for size to stabilize when a file grows in chunks", async () => {
     const filePath = path.join(tempDir, "growing.bin");
     const pollMs = 100;
     /**
-     * Each chunk arrives well within a single poll interval, so the wait
-     * cannot see two consecutive equal sizes until growth stops. With a
-     * 100ms poll, 30ms between chunks safely satisfies that.
+     * The total write window (`chunkIntervalMs * chunkCount` = 150ms) is
+     * shorter than two poll intervals, so the wait cannot observe two
+     * consecutive equal sizes until after the final chunk has landed. That
+     * is what guards against a false-positive return at a partial size, not
+     * the per-chunk spacing.
      */
     const chunkIntervalMs = 30;
     const chunkCount = 5;

--- a/src/lib/utils/wait-for-complete-file.test.ts
+++ b/src/lib/utils/wait-for-complete-file.test.ts
@@ -1,0 +1,99 @@
+import fs from "fs-extra";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { waitForCompleteFile } from "./wait-for-complete-file";
+
+describe("waitForCompleteFile", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "isolate-wait-for-file-"),
+    );
+  });
+
+  afterEach(async () => {
+    await fs.remove(tempDir);
+  });
+
+  it("resolves for a file that already exists with stable size", async () => {
+    const filePath = path.join(tempDir, "ready.bin");
+    await fs.writeFile(filePath, Buffer.alloc(1024, 0x42));
+
+    await expect(
+      waitForCompleteFile(filePath, { timeoutMs: 1000, pollMs: 20 }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("waits until a file that appears late is written", async () => {
+    const filePath = path.join(tempDir, "late.bin");
+
+    setTimeout(() => {
+      void fs.writeFile(filePath, Buffer.alloc(512, 0x01));
+    }, 60);
+
+    await expect(
+      waitForCompleteFile(filePath, { timeoutMs: 1000, pollMs: 20 }),
+    ).resolves.toBeUndefined();
+
+    const { size } = await fs.stat(filePath);
+    expect(size).toBe(512);
+  });
+
+  it("waits for size to stabilize when a file grows in chunks", async () => {
+    const filePath = path.join(tempDir, "growing.bin");
+    const pollMs = 100;
+    /**
+     * Each chunk arrives well within a single poll interval, so the wait
+     * cannot see two consecutive equal sizes until growth stops. With a
+     * 100ms poll, 30ms between chunks safely satisfies that.
+     */
+    const chunkIntervalMs = 30;
+    const chunkCount = 5;
+
+    const writes = Array.from({ length: chunkCount }, (_, i) =>
+      setTimeout(
+        () => {
+          const op =
+            i === 0
+              ? fs.writeFile(filePath, Buffer.alloc(100, i + 1))
+              : fs.appendFile(filePath, Buffer.alloc(100, i + 1));
+          void op;
+        },
+        chunkIntervalMs * (i + 1),
+      ),
+    );
+
+    try {
+      await waitForCompleteFile(filePath, { timeoutMs: 2000, pollMs });
+
+      /**
+       * Returning before the file finished growing would leave size below
+       * chunkCount * 100. Observing the full size confirms the wait did not
+       * exit mid-write.
+       */
+      const { size } = await fs.stat(filePath);
+      expect(size).toBe(chunkCount * 100);
+    } finally {
+      writes.forEach((t) => clearTimeout(t));
+    }
+  });
+
+  it("rejects with a timeout error when the file never appears", async () => {
+    const filePath = path.join(tempDir, "missing.bin");
+
+    await expect(
+      waitForCompleteFile(filePath, { timeoutMs: 150, pollMs: 20 }),
+    ).rejects.toThrow(/Timed out after 150ms/);
+  });
+
+  it("rejects with a timeout error when the file stays empty", async () => {
+    const filePath = path.join(tempDir, "empty.bin");
+    await fs.writeFile(filePath, "");
+
+    await expect(
+      waitForCompleteFile(filePath, { timeoutMs: 150, pollMs: 20 }),
+    ).rejects.toThrow(/Timed out/);
+  });
+});

--- a/src/lib/utils/wait-for-complete-file.ts
+++ b/src/lib/utils/wait-for-complete-file.ts
@@ -1,0 +1,42 @@
+import fs from "node:fs";
+
+/**
+ * Wait until the given file exists and its size has stopped changing across
+ * two consecutive polls. Resolves once the file is considered fully written,
+ * rejects with a timeout error otherwise.
+ *
+ * This is a cheap proxy for "the writer has finished flushing" without
+ * inspecting file contents or relying on platform-specific signals. It is
+ * intended for cases where an external process (e.g. `pnpm pack`) may report
+ * completion before its output is fully visible on disk.
+ */
+export async function waitForCompleteFile(
+  filePath: string,
+  { timeoutMs, pollMs }: { timeoutMs: number; pollMs: number },
+) {
+  const deadline = Date.now() + timeoutMs;
+  let lastSize = -1;
+
+  while (Date.now() < deadline) {
+    try {
+      const { size } = await fs.promises.stat(filePath);
+
+      if (size > 0 && size === lastSize) {
+        return;
+      }
+
+      lastSize = size;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw err;
+      }
+      /** File not visible yet; keep polling. */
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, pollMs));
+  }
+
+  throw new Error(
+    `Timed out after ${timeoutMs}ms waiting for file to be written: ${filePath}`,
+  );
+}


### PR DESCRIPTION
Two independent bugs combined to produce the intermittent zlib crash described in #183:

- `pnpm pack` could return before its tarball was fully flushed to disk. The directory entry would appear before the data was written, so the existing `fs.existsSync` wait in `processBuildOutputFiles` was not sufficient — downstream gunzip could read past end-of-data and fail.
- `unpack` used a hand-rolled `.pipe()` chain that only forwarded errors from the final stage. Errors from the read stream or `gunzip` (where #183 originates) became unhandled stream errors and crashed the process with a bare zlib stack trace containing no isolate-package frames.

`pack` now waits until the tarball exists and its size has been stable across two consecutive polls before returning, with a 5s timeout that surfaces as a real error. `unpack` uses `node:stream/promises` `pipeline`, which propagates errors from every stage as a rejected promise. The redundant `fs.existsSync` polling in `processBuildOutputFiles` is removed since the wait now lives inside `pack`.

Builds on @ChromeQ's work in #184 — first two commits are cherry-picked from that PR. The follow-up commit extracts `waitForCompleteFile` into its own module and adds unit tests covering stable-size detection, the timeout path, valid extraction, and error propagation from a truncated tarball.

Closes #183

Scope: lib (pack/unpack)
Visibility: user-facing