### PR TITLE
Resolve catalog dependencies from pnpm-workspace.yaml

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"9c609b91-defe-41e8-8841-d5ae5a1fe00b","pid":22842,"procStart":"Thu May 21 09:50:06 2026","acquiredAt":1779357670341}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"9c609b91-defe-41e8-8841-d5ae5a1fe00b","pid":22842,"procStart":"Thu May 21 09:50:06 2026","acquiredAt":1779357670341}

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ docs/.vitepress/dist
 
 # Claude Code local settings
 .claude/settings.local.json
+.claude/scheduled_tasks.lock

--- a/src/lib/manifest/helpers/resolve-catalog-dependencies.test.ts
+++ b/src/lib/manifest/helpers/resolve-catalog-dependencies.test.ts
@@ -2,13 +2,15 @@ import os from "node:os";
 import path from "node:path";
 import fs from "fs-extra";
 import yaml from "yaml";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mockLogger = {
+  debug: vi.fn(),
+  warn: vi.fn(),
+};
 
 vi.mock("~/lib/logger", () => ({
-  useLogger: vi.fn(() => ({
-    debug: vi.fn(),
-    warn: vi.fn(),
-  })),
+  useLogger: vi.fn(() => mockLogger),
 }));
 
 const { resolveCatalogDependencies } = await import(
@@ -21,9 +23,11 @@ const { resolveCatalogDependencies } = await import(
  */
 async function createTempWorkspace({
   workspaceYaml,
+  workspaceYamlRaw,
   packageJson,
 }: {
   workspaceYaml?: object;
+  workspaceYamlRaw?: string;
   packageJson?: object;
 }): Promise<string> {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), "isolate-test-"));
@@ -32,6 +36,12 @@ async function createTempWorkspace({
     await fs.writeFile(
       path.join(dir, "pnpm-workspace.yaml"),
       yaml.stringify(workspaceYaml),
+      "utf-8",
+    );
+  } else if (workspaceYamlRaw !== undefined) {
+    await fs.writeFile(
+      path.join(dir, "pnpm-workspace.yaml"),
+      workspaceYamlRaw,
       "utf-8",
     );
   }
@@ -198,6 +208,89 @@ describe("resolveCatalogDependencies", () => {
       );
 
       expect(result).toEqual({ typescript: "^5.4.0" });
+    });
+
+    it("resolves named catalog: from root-level catalogs field in package.json", async () => {
+      tmpDir = await createTempWorkspace({
+        packageJson: {
+          name: "root",
+          version: "0.0.0",
+          catalogs: {
+            react18: {
+              react: "^18.3.1",
+              "react-dom": "^18.3.1",
+            },
+          },
+        },
+      });
+
+      const result = await resolveCatalogDependencies(
+        {
+          react: "catalog:react18",
+          "react-dom": "catalog:react18",
+        },
+        tmpDir,
+      );
+
+      expect(result).toEqual({
+        react: "^18.3.1",
+        "react-dom": "^18.3.1",
+      });
+    });
+
+    it("resolves named catalog: from workspaces.catalogs in package.json", async () => {
+      tmpDir = await createTempWorkspace({
+        packageJson: {
+          name: "root",
+          version: "0.0.0",
+          workspaces: {
+            packages: ["packages/*"],
+            catalogs: {
+              tools: {
+                typescript: "^5.4.0",
+                eslint: "^8.0.0",
+              },
+            },
+          },
+        },
+      });
+
+      const result = await resolveCatalogDependencies(
+        { typescript: "catalog:tools", eslint: "catalog:tools" },
+        tmpDir,
+      );
+
+      expect(result).toEqual({
+        typescript: "^5.4.0",
+        eslint: "^8.0.0",
+      });
+    });
+  });
+
+  describe("pnpm-workspace.yaml with invalid YAML", () => {
+    it("warns about invalid YAML and falls back to package.json", async () => {
+      tmpDir = await createTempWorkspace({
+        workspaceYamlRaw: "catalog:\n  react: ^18.3.1\n  - invalid format",
+        packageJson: {
+          name: "root",
+          version: "0.0.0",
+          catalog: { react: "^18.0.0" },
+        },
+      });
+
+
+      const result = await resolveCatalogDependencies(
+        { react: "catalog:" },
+        tmpDir,
+      );
+
+      // Verify it fell back to package.json correctly
+      expect(result).toEqual({ react: "^18.0.0" });
+      
+      // Verify a warning was logged
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining(`Failed to parse ${path.join(tmpDir, "pnpm-workspace.yaml")}:`),
+      );
     });
   });
 

--- a/src/lib/manifest/helpers/resolve-catalog-dependencies.test.ts
+++ b/src/lib/manifest/helpers/resolve-catalog-dependencies.test.ts
@@ -1,0 +1,268 @@
+import os from "node:os";
+import path from "node:path";
+import fs from "fs-extra";
+import yaml from "yaml";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("~/lib/logger", () => ({
+  useLogger: vi.fn(() => ({
+    debug: vi.fn(),
+    warn: vi.fn(),
+  })),
+}));
+
+const { resolveCatalogDependencies } = await import(
+  "./resolve-catalog-dependencies"
+);
+
+/**
+ * Creates a temporary directory with optional pnpm-workspace.yaml and
+ * package.json for testing catalog resolution.
+ */
+async function createTempWorkspace({
+  workspaceYaml,
+  packageJson,
+}: {
+  workspaceYaml?: object;
+  packageJson?: object;
+}): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "isolate-test-"));
+
+  if (workspaceYaml !== undefined) {
+    await fs.writeFile(
+      path.join(dir, "pnpm-workspace.yaml"),
+      yaml.stringify(workspaceYaml),
+      "utf-8",
+    );
+  }
+
+  // Always write a minimal package.json so the fallback doesn't throw
+  const manifest = packageJson ?? { name: "root", version: "0.0.0" };
+  await fs.writeJson(path.join(dir, "package.json"), manifest);
+
+  return dir;
+}
+
+describe("resolveCatalogDependencies", () => {
+  let tmpDir: string;
+
+  afterEach(async () => {
+    if (tmpDir) {
+      await fs.remove(tmpDir);
+    }
+  });
+
+  describe("with no dependencies", () => {
+    it("returns undefined when dependencies is undefined", async () => {
+      tmpDir = await createTempWorkspace({});
+      const result = await resolveCatalogDependencies(undefined, tmpDir);
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe("pnpm-workspace.yaml: default catalog (catalog:)", () => {
+    it("resolves catalog: specifiers from pnpm-workspace.yaml", async () => {
+      tmpDir = await createTempWorkspace({
+        workspaceYaml: {
+          packages: ["packages/*"],
+          catalog: {
+            react: "^18.3.1",
+            typescript: "^5.0.0",
+          },
+        },
+      });
+
+      const result = await resolveCatalogDependencies(
+        { react: "catalog:", typescript: "catalog:", lodash: "^4.0.0" },
+        tmpDir,
+      );
+
+      expect(result).toEqual({
+        react: "^18.3.1",
+        typescript: "^5.0.0",
+        lodash: "^4.0.0",
+      });
+    });
+
+    it("also handles catalog:default as the default catalog name", async () => {
+      tmpDir = await createTempWorkspace({
+        workspaceYaml: {
+          packages: ["packages/*"],
+          catalogs: {
+            default: {
+              react: "^18.3.1",
+            },
+          },
+        },
+      });
+
+      const result = await resolveCatalogDependencies(
+        { react: "catalog:default" },
+        tmpDir,
+      );
+
+      expect(result).toEqual({ react: "^18.3.1" });
+    });
+  });
+
+  describe("pnpm-workspace.yaml: named catalogs (catalog:<name>)", () => {
+    it("resolves named catalog specifiers from pnpm-workspace.yaml", async () => {
+      tmpDir = await createTempWorkspace({
+        workspaceYaml: {
+          packages: ["packages/*"],
+          catalogs: {
+            react18: {
+              react: "^18.3.1",
+              "react-dom": "^18.3.1",
+            },
+            react19: {
+              react: "^19.0.0",
+            },
+          },
+        },
+      });
+
+      const result = await resolveCatalogDependencies(
+        {
+          react: "catalog:react18",
+          "react-dom": "catalog:react18",
+        },
+        tmpDir,
+      );
+
+      expect(result).toEqual({
+        react: "^18.3.1",
+        "react-dom": "^18.3.1",
+      });
+    });
+  });
+
+  describe("pnpm-workspace.yaml: missing package in catalog", () => {
+    it("keeps original specifier and warns when package not found in catalog", async () => {
+      tmpDir = await createTempWorkspace({
+        workspaceYaml: {
+          packages: ["packages/*"],
+          catalog: { react: "^18.0.0" },
+        },
+      });
+
+      const result = await resolveCatalogDependencies(
+        { react: "catalog:", "missing-pkg": "catalog:" },
+        tmpDir,
+      );
+
+      expect(result).toEqual({
+        react: "^18.0.0",
+        "missing-pkg": "catalog:", // kept as-is with a warning
+      });
+    });
+  });
+
+  describe("package.json fallback (Bun format)", () => {
+    it("resolves catalog: from root-level catalog field in package.json", async () => {
+      tmpDir = await createTempWorkspace({
+        packageJson: {
+          name: "root",
+          version: "0.0.0",
+          catalog: {
+            react: "^18.3.1",
+          },
+        },
+      });
+
+      const result = await resolveCatalogDependencies(
+        { react: "catalog:" },
+        tmpDir,
+      );
+
+      expect(result).toEqual({ react: "^18.3.1" });
+    });
+
+    it("resolves catalog: from workspaces.catalog in package.json", async () => {
+      tmpDir = await createTempWorkspace({
+        packageJson: {
+          name: "root",
+          version: "0.0.0",
+          workspaces: {
+            packages: ["packages/*"],
+            catalog: {
+              typescript: "^5.4.0",
+            },
+          },
+        },
+      });
+
+      const result = await resolveCatalogDependencies(
+        { typescript: "catalog:" },
+        tmpDir,
+      );
+
+      expect(result).toEqual({ typescript: "^5.4.0" });
+    });
+  });
+
+  describe("pnpm-workspace.yaml without catalog fields", () => {
+    it("falls back to package.json when pnpm-workspace.yaml has no catalog", async () => {
+      tmpDir = await createTempWorkspace({
+        workspaceYaml: {
+          // No catalog or catalogs field - just packages
+          packages: ["packages/*"],
+        },
+        packageJson: {
+          name: "root",
+          version: "0.0.0",
+          catalog: { react: "^18.0.0" },
+        },
+      });
+
+      const result = await resolveCatalogDependencies(
+        { react: "catalog:" },
+        tmpDir,
+      );
+
+      expect(result).toEqual({ react: "^18.0.0" });
+    });
+  });
+
+  describe("no catalog defined anywhere", () => {
+    it("returns dependencies as-is when no catalog is found", async () => {
+      tmpDir = await createTempWorkspace({});
+
+      const result = await resolveCatalogDependencies(
+        { react: "^18.0.0", typescript: "^5.0.0" },
+        tmpDir,
+      );
+
+      expect(result).toEqual({
+        react: "^18.0.0",
+        typescript: "^5.0.0",
+      });
+    });
+  });
+
+  describe("non-catalog specifiers", () => {
+    it("leaves non-catalog specifiers unchanged", async () => {
+      tmpDir = await createTempWorkspace({
+        workspaceYaml: {
+          packages: ["packages/*"],
+          catalog: { react: "^18.0.0" },
+        },
+      });
+
+      const result = await resolveCatalogDependencies(
+        {
+          react: "catalog:",
+          lodash: "^4.0.0",
+          typescript: "workspace:*",
+        },
+        tmpDir,
+      );
+
+      expect(result).toEqual({
+        react: "^18.0.0",
+        lodash: "^4.0.0",
+        typescript: "workspace:*",
+      });
+    });
+  });
+});

--- a/src/lib/manifest/helpers/resolve-catalog-dependencies.test.ts
+++ b/src/lib/manifest/helpers/resolve-catalog-dependencies.test.ts
@@ -13,9 +13,8 @@ vi.mock("~/lib/logger", () => ({
   useLogger: vi.fn(() => mockLogger),
 }));
 
-const { resolveCatalogDependencies } = await import(
-  "./resolve-catalog-dependencies"
-);
+const { resolveCatalogDependencies } =
+  await import("./resolve-catalog-dependencies");
 
 /**
  * Creates a temporary directory with optional pnpm-workspace.yaml and
@@ -278,7 +277,6 @@ describe("resolveCatalogDependencies", () => {
         },
       });
 
-
       const result = await resolveCatalogDependencies(
         { react: "catalog:" },
         tmpDir,
@@ -286,10 +284,12 @@ describe("resolveCatalogDependencies", () => {
 
       // Verify it fell back to package.json correctly
       expect(result).toEqual({ react: "^18.0.0" });
-      
+
       // Verify a warning was logged
       expect(mockLogger.warn).toHaveBeenCalledWith(
-        expect.stringContaining(`Failed to parse ${path.join(tmpDir, "pnpm-workspace.yaml")}:`),
+        expect.stringContaining(
+          `Failed to parse ${path.join(tmpDir, "pnpm-workspace.yaml")}:`,
+        ),
       );
     });
   });

--- a/src/lib/manifest/helpers/resolve-catalog-dependencies.test.ts
+++ b/src/lib/manifest/helpers/resolve-catalog-dependencies.test.ts
@@ -45,7 +45,7 @@ async function createTempWorkspace({
     );
   }
 
-  // Always write a minimal package.json so the fallback doesn't throw
+  /** Always write a minimal package.json so the fallback doesn't throw. */
   const manifest = packageJson ?? { name: "root", version: "0.0.0" };
   await fs.writeJson(path.join(dir, "package.json"), manifest);
 
@@ -313,10 +313,10 @@ describe("resolveCatalogDependencies", () => {
         tmpDir,
       );
 
-      // Verify it fell back to package.json correctly
+      /** Verify it fell back to package.json correctly. */
       expect(result).toEqual({ react: "^18.0.0" });
 
-      // Verify a warning was logged
+      /** Verify a warning was logged. */
       expect(mockLogger.warn).toHaveBeenCalledWith(
         expect.stringContaining(
           `Failed to parse ${path.join(tmpDir, "pnpm-workspace.yaml")}:`,
@@ -329,7 +329,7 @@ describe("resolveCatalogDependencies", () => {
     it("falls back to package.json when pnpm-workspace.yaml has no catalog", async () => {
       tmpDir = await createTempWorkspace({
         workspaceYaml: {
-          // No catalog or catalogs field - just packages
+          /** No catalog or catalogs field - just packages. */
           packages: ["packages/*"],
         },
         packageJson: {

--- a/src/lib/manifest/helpers/resolve-catalog-dependencies.test.ts
+++ b/src/lib/manifest/helpers/resolve-catalog-dependencies.test.ts
@@ -2,7 +2,7 @@ import os from "node:os";
 import path from "node:path";
 import fs from "fs-extra";
 import yaml from "yaml";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockLogger = {
   debug: vi.fn(),
@@ -54,6 +54,10 @@ async function createTempWorkspace({
 
 describe("resolveCatalogDependencies", () => {
   let tmpDir: string;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
 
   afterEach(async () => {
     if (tmpDir) {
@@ -263,6 +267,33 @@ describe("resolveCatalogDependencies", () => {
         typescript: "^5.4.0",
         eslint: "^8.0.0",
       });
+    });
+  });
+
+  describe("precedence", () => {
+    it("prefers pnpm-workspace.yaml over package.json when both define the same catalog dependency", async () => {
+      tmpDir = await createTempWorkspace({
+        workspaceYaml: {
+          packages: ["packages/*"],
+          catalog: {
+            react: "^18.3.1",
+          },
+        },
+        packageJson: {
+          name: "root",
+          version: "0.0.0",
+          catalog: {
+            react: "^18.2.0",
+          },
+        },
+      });
+
+      const result = await resolveCatalogDependencies(
+        { react: "catalog:" },
+        tmpDir,
+      );
+
+      expect(result).toEqual({ react: "^18.3.1" });
     });
   });
 

--- a/src/lib/manifest/helpers/resolve-catalog-dependencies.test.ts
+++ b/src/lib/manifest/helpers/resolve-catalog-dependencies.test.ts
@@ -116,6 +116,24 @@ describe("resolveCatalogDependencies", () => {
 
       expect(result).toEqual({ react: "^18.3.1" });
     });
+
+    it("resolves catalog:default from the top-level catalog field", async () => {
+      tmpDir = await createTempWorkspace({
+        workspaceYaml: {
+          packages: ["packages/*"],
+          catalog: {
+            react: "^18.3.1",
+          },
+        },
+      });
+
+      const result = await resolveCatalogDependencies(
+        { react: "catalog:default" },
+        tmpDir,
+      );
+
+      expect(result).toEqual({ react: "^18.3.1" });
+    });
   });
 
   describe("pnpm-workspace.yaml: named catalogs (catalog:<name>)", () => {

--- a/src/lib/manifest/helpers/resolve-catalog-dependencies.ts
+++ b/src/lib/manifest/helpers/resolve-catalog-dependencies.ts
@@ -13,6 +13,8 @@ interface CatalogSource {
   catalogs?: CatalogsMap;
 }
 
+const catalogSourceCache = new Map<string, Promise<CatalogSource>>();
+
 /**
  * Loads catalog definitions by checking pnpm-workspace.yaml first (pnpm
  * format), then falling back to the root package.json (Bun format).
@@ -32,41 +34,58 @@ interface CatalogSource {
 async function loadCatalogSource(
   workspaceRootDir: string,
 ): Promise<CatalogSource> {
-  // Try pnpm-workspace.yaml first
-  const workspaceYamlPath = path.join(
-    workspaceRootDir,
-    "pnpm-workspace.yaml",
-  );
-
-  if (await fs.pathExists(workspaceYamlPath)) {
-    const rawContent = await fs.readFile(workspaceYamlPath, "utf-8");
-    const yamlConfig = yaml.parse(rawContent) as CatalogSource | null;
-
-    if (yamlConfig?.catalog || yamlConfig?.catalogs) {
-      return {
-        catalog: yamlConfig.catalog,
-        catalogs: yamlConfig.catalogs,
-      };
-    }
+  if (catalogSourceCache.has(workspaceRootDir)) {
+    return catalogSourceCache.get(workspaceRootDir)!;
   }
 
-  // Fall back to package.json (Bun format)
-  const rootManifestPath = path.join(workspaceRootDir, "package.json");
-  const rootManifest = await readTypedJson<
-    PackageManifest & {
-      catalog?: CatalogMap;
-      catalogs?: CatalogsMap;
-      workspaces?: {
+  const loadPromise = (async () => {
+    const log = useLogger();
+
+    // Try pnpm-workspace.yaml first
+    const workspaceYamlPath = path.join(
+      workspaceRootDir,
+      "pnpm-workspace.yaml",
+    );
+
+    if (await fs.pathExists(workspaceYamlPath)) {
+      try {
+        const rawContent = await fs.readFile(workspaceYamlPath, "utf-8");
+        const yamlConfig = yaml.parse(rawContent) as CatalogSource | null;
+
+        if (yamlConfig?.catalog || yamlConfig?.catalogs) {
+          return {
+            catalog: yamlConfig.catalog,
+            catalogs: yamlConfig.catalogs,
+          };
+        }
+      } catch (err) {
+        log.warn(
+          `Failed to parse ${workspaceYamlPath}: ${err instanceof Error ? err.message : String(err)}. Falling back to package.json for catalog definitions.`,
+        );
+      }
+    }
+
+    // Fall back to package.json (Bun format)
+    const rootManifestPath = path.join(workspaceRootDir, "package.json");
+    const rootManifest = await readTypedJson<
+      PackageManifest & {
         catalog?: CatalogMap;
         catalogs?: CatalogsMap;
-      };
-    }
-  >(rootManifestPath);
+        workspaces?: {
+          catalog?: CatalogMap;
+          catalogs?: CatalogsMap;
+        };
+      }
+    >(rootManifestPath);
 
-  return {
-    catalog: rootManifest.catalog ?? rootManifest.workspaces?.catalog,
-    catalogs: rootManifest.catalogs ?? rootManifest.workspaces?.catalogs,
-  };
+    return {
+      catalog: rootManifest.catalog ?? rootManifest.workspaces?.catalog,
+      catalogs: rootManifest.catalogs ?? rootManifest.workspaces?.catalogs,
+    };
+  })();
+
+  catalogSourceCache.set(workspaceRootDir, loadPromise);
+  return loadPromise;
 }
 
 /**

--- a/src/lib/manifest/helpers/resolve-catalog-dependencies.ts
+++ b/src/lib/manifest/helpers/resolve-catalog-dependencies.ts
@@ -1,16 +1,83 @@
+import fs from "fs-extra";
 import path from "node:path";
 import { useLogger } from "~/lib/logger";
 import type { PackageManifest } from "~/lib/types";
 import { readTypedJson } from "~/lib/utils";
+import yaml from "yaml";
+
+type CatalogMap = Record<string, string>;
+type CatalogsMap = Record<string, CatalogMap>;
+
+interface CatalogSource {
+  catalog?: CatalogMap;
+  catalogs?: CatalogsMap;
+}
+
+/**
+ * Loads catalog definitions by checking pnpm-workspace.yaml first (pnpm
+ * format), then falling back to the root package.json (Bun format).
+ *
+ * Pnpm defines catalogs in pnpm-workspace.yaml:
+ *
+ * ```yaml
+ * catalog:
+ *   react: ^18.3.1
+ * catalogs:
+ *   react18:
+ *     react: ^18.3.1
+ * ```
+ *
+ * Bun defines catalogs in package.json (at root level or under workspaces).
+ */
+async function loadCatalogSource(
+  workspaceRootDir: string,
+): Promise<CatalogSource> {
+  // Try pnpm-workspace.yaml first
+  const workspaceYamlPath = path.join(
+    workspaceRootDir,
+    "pnpm-workspace.yaml",
+  );
+
+  if (await fs.pathExists(workspaceYamlPath)) {
+    const rawContent = await fs.readFile(workspaceYamlPath, "utf-8");
+    const yamlConfig = yaml.parse(rawContent) as CatalogSource | null;
+
+    if (yamlConfig?.catalog || yamlConfig?.catalogs) {
+      return {
+        catalog: yamlConfig.catalog,
+        catalogs: yamlConfig.catalogs,
+      };
+    }
+  }
+
+  // Fall back to package.json (Bun format)
+  const rootManifestPath = path.join(workspaceRootDir, "package.json");
+  const rootManifest = await readTypedJson<
+    PackageManifest & {
+      catalog?: CatalogMap;
+      catalogs?: CatalogsMap;
+      workspaces?: {
+        catalog?: CatalogMap;
+        catalogs?: CatalogsMap;
+      };
+    }
+  >(rootManifestPath);
+
+  return {
+    catalog: rootManifest.catalog ?? rootManifest.workspaces?.catalog,
+    catalogs: rootManifest.catalogs ?? rootManifest.workspaces?.catalogs,
+  };
+}
 
 /**
  * Resolves catalog dependencies by replacing "catalog:" specifiers with their
- * actual versions from the root package.json catalog field.
+ * actual versions.
  *
  * Supports both pnpm and Bun catalog formats:
  *
- * - Pnpm: catalog at root level
- * - Bun: catalog or catalogs at root level, or workspaces.catalog
+ * - Pnpm: catalog/catalogs defined in pnpm-workspace.yaml
+ * - Bun: catalog or catalogs at root level, or workspaces.catalog in
+ *   package.json
  */
 export async function resolveCatalogDependencies(
   dependencies: Record<string, string> | undefined,
@@ -21,22 +88,8 @@ export async function resolveCatalogDependencies(
   }
 
   const log = useLogger();
-  const rootManifestPath = path.join(workspaceRootDir, "package.json");
-  const rootManifest = await readTypedJson<
-    PackageManifest & {
-      catalog?: Record<string, string>;
-      catalogs?: Record<string, Record<string, string>>;
-      workspaces?: {
-        catalog?: Record<string, string>;
-        catalogs?: Record<string, Record<string, string>>;
-      };
-    }
-  >(rootManifestPath);
-
-  // Try to find catalog in various locations (pnpm and Bun formats)
-  const flatCatalog = rootManifest.catalog || rootManifest.workspaces?.catalog;
-  const nestedCatalogs =
-    rootManifest.catalogs || rootManifest.workspaces?.catalogs;
+  const { catalog: flatCatalog, catalogs: nestedCatalogs } =
+    await loadCatalogSource(workspaceRootDir);
 
   if (!flatCatalog && !nestedCatalogs) {
     // No catalog found, return dependencies as-is

--- a/src/lib/manifest/helpers/resolve-catalog-dependencies.ts
+++ b/src/lib/manifest/helpers/resolve-catalog-dependencies.ts
@@ -84,8 +84,17 @@ async function loadCatalogSource(
     };
   })();
 
-  catalogSourceCache.set(workspaceRootDir, loadPromise);
-  return loadPromise;
+  /**
+   * Drop the cache entry if loading fails so a subsequent call can retry
+   * instead of immediately rethrowing the same rejection.
+   */
+  const cachedLoadPromise = loadPromise.catch((err) => {
+    catalogSourceCache.delete(workspaceRootDir);
+    throw err;
+  });
+
+  catalogSourceCache.set(workspaceRootDir, cachedLoadPromise);
+  return cachedLoadPromise;
 }
 
 /**

--- a/src/lib/manifest/helpers/resolve-catalog-dependencies.ts
+++ b/src/lib/manifest/helpers/resolve-catalog-dependencies.ts
@@ -41,7 +41,7 @@ async function loadCatalogSource(
   const loadPromise = (async () => {
     const log = useLogger();
 
-    // Try pnpm-workspace.yaml first
+    /** Try pnpm-workspace.yaml first. */
     const workspaceYamlPath = path.join(
       workspaceRootDir,
       "pnpm-workspace.yaml",
@@ -65,7 +65,7 @@ async function loadCatalogSource(
       }
     }
 
-    // Fall back to package.json (Bun format)
+    /** Fall back to package.json (Bun format). */
     const rootManifestPath = path.join(workspaceRootDir, "package.json");
     const rootManifest = await readTypedJson<
       PackageManifest & {

--- a/src/lib/manifest/helpers/resolve-catalog-dependencies.ts
+++ b/src/lib/manifest/helpers/resolve-catalog-dependencies.ts
@@ -131,12 +131,18 @@ export async function resolveCatalogDependencies(
     if (specifier === "catalog:" || specifier.startsWith("catalog:")) {
       let catalogVersion: string | undefined;
 
-      if (specifier === "catalog:") {
-        // Simple catalog reference - use package name as key
-        catalogVersion = flatCatalog?.[packageName];
+      const groupName =
+        specifier === "catalog:" ? "default" : specifier.slice(8);
+
+      if (groupName === "default") {
+        /**
+         * Per pnpm semantics, `catalog:` and `catalog:default` are
+         * equivalent: the default catalog can live under the top-level
+         * `catalog` field or under `catalogs.default`, so check both.
+         */
+        catalogVersion =
+          flatCatalog?.[packageName] ?? nestedCatalogs?.default?.[packageName];
       } else {
-        // Catalog group reference (e.g., "catalog:group1")
-        const groupName = specifier.slice(8);
         catalogVersion = nestedCatalogs?.[groupName]?.[packageName];
       }
 


### PR DESCRIPTION
Finishes the work from #168 by @royalty37 (cherry-picked to preserve attribution) and addresses the remaining Copilot review feedback.

When using `forceNpm` inside a pnpm workspace, `resolveCatalogDependencies` only inspected the root `package.json` for `catalog` definitions and failed to resolve `catalog:` specifiers that pnpm stores in `pnpm-workspace.yaml`. The new `loadCatalogSource` helper reads the YAML first and falls back to `package.json` (Bun format), with the parsed source cached per workspace root.

On top of the cherry-picked commits:

- The cache entry is dropped if the load promise rejects so a later call can retry instead of immediately rethrowing the cached failure.
- Vitest mocks are reset between tests to keep logger assertions independent of test order.
- A precedence test verifies `pnpm-workspace.yaml` wins over `package.json` when both define the same catalog dependency.
- `catalog:default` is now treated as equivalent to `catalog:` per pnpm semantics: both resolve from the top-level `catalog` field or `catalogs.default`, whichever defines the package.

Scope: packages (isolate-package)
Visibility: user-facing