### PR TITLE
Lock in pnpm 11 allowBuilds propagation via workspace yaml copy

### DIFF
--- a/src/lib/patches/write-isolate-pnpm-workspace.test.ts
+++ b/src/lib/patches/write-isolate-pnpm-workspace.test.ts
@@ -139,6 +139,86 @@ describe("writeIsolatePnpmWorkspace", () => {
     );
   });
 
+  /**
+   * Regression test for issue #189: pnpm 11 expresses the build-script policy
+   * via `allowBuilds` in pnpm-workspace.yaml (and removes the older
+   * `pnpm.onlyBuiltDependencies` / `ignoredBuiltDependencies` fields from
+   * package.json). The verbatim copy must carry that field — along with other
+   * workspace-level settings like `minimumReleaseAge` — into the isolate
+   * output so downstream `pnpm install` honors the same policy.
+   */
+  it("preserves pnpm 11 workspace settings (allowBuilds, minimumReleaseAge) when no patches are involved", () => {
+    readTypedYamlSync.mockReturnValue({
+      packages: ["apps/*", "packages/*"],
+      allowBuilds: {
+        puppeteer: true,
+        esbuild: true,
+      },
+      minimumReleaseAge: 10080,
+    });
+
+    writeIsolatePnpmWorkspace({
+      workspaceRootDir,
+      isolateDir,
+      copiedPatches: {},
+    });
+
+    /**
+     * With no patchedDependencies in the source yaml, the file is copied
+     * verbatim — preserving `allowBuilds` and any other top-level settings.
+     */
+    expect(writeTypedYamlSync).not.toHaveBeenCalled();
+    expect(fs.copyFileSync).toHaveBeenCalledWith(
+      "/workspace/pnpm-workspace.yaml",
+      "/workspace/isolate/pnpm-workspace.yaml",
+    );
+  });
+
+  /**
+   * When patches are being filtered, the rewrite path must still carry
+   * `allowBuilds` into the output yaml — otherwise pnpm 11's build-script
+   * policy is silently dropped.
+   */
+  it("preserves allowBuilds when rewriting to filter patchedDependencies", () => {
+    readTypedYamlSync.mockReturnValue({
+      packages: ["apps/*", "packages/*"],
+      allowBuilds: {
+        puppeteer: true,
+      },
+      patchedDependencies: {
+        "lodash@4.17.21": "patches/lodash@4.17.21.patch",
+        "axios@1.6.0": "patches/axios@1.6.0.patch",
+      },
+    });
+
+    const copiedPatches: Record<string, PatchFile> = {
+      "lodash@4.17.21": {
+        path: "patches/lodash@4.17.21.patch",
+        hash: "abc",
+      },
+    };
+
+    writeIsolatePnpmWorkspace({
+      workspaceRootDir,
+      isolateDir,
+      copiedPatches,
+    });
+
+    expect(fs.copyFileSync).not.toHaveBeenCalled();
+    expect(writeTypedYamlSync).toHaveBeenCalledWith(
+      "/workspace/isolate/pnpm-workspace.yaml",
+      {
+        packages: ["apps/*", "packages/*"],
+        allowBuilds: {
+          puppeteer: true,
+        },
+        patchedDependencies: {
+          "lodash@4.17.21": "patches/lodash@4.17.21.patch",
+        },
+      },
+    );
+  });
+
   it("copies verbatim when every patch is kept (preserving comments and order)", () => {
     readTypedYamlSync.mockReturnValue({
       packages: ["packages/*"],


### PR DESCRIPTION
Issue #189 reports that pnpm 11's `allowBuilds` (the replacement for `pnpm.onlyBuiltDependencies` / `ignoredBuiltDependencies`, which were removed in pnpm 11) is not propagated into the isolate output, so the downstream `pnpm install` runs in default-deny mode and drops every dependency `postinstall`.

The verbatim copy of `pnpm-workspace.yaml` introduced in #180 already carries `allowBuilds` — and other top-level workspace settings like `minimumReleaseAge`, `overrides`, `catalog(s)` — into the isolate, both on the no-patch path and through the patch-filter rewrite path. This change adds explicit regression tests that pin that behavior so a future patch-filter refactor cannot silently drop pnpm-11-only fields.

Closes #189.

Scope: packages (isolate-package)
Visibility: user-facing