### PR TITLE
Adopt stricter oxlint config

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,18 +1,120 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
-  "plugins": ["typescript"],
+  "plugins": ["import", "typescript", "unicorn", "promise", "node"],
   "categories": {
     "correctness": "error",
     "suspicious": "warn",
-    "perf": "warn"
+    "perf": "warn",
+    "pedantic": "warn",
+    "style": "off",
+    "restriction": "off"
   },
   "rules": {
+    "import/no-cycle": "warn",
+    "import/no-duplicates": "warn",
+    "import/no-self-import": "error",
+    "import/no-unassigned-import": "off",
+    "import/no-named-as-default-member": "off",
+    "import/no-named-as-default": "off",
+
+    "typescript/no-unused-vars": [
+      "warn",
+      { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }
+    ],
+    "typescript/no-non-null-assertion": "error",
+    "typescript/no-explicit-any": "error",
     "typescript/no-floating-promises": "error",
     "typescript/no-misused-promises": "error",
     "typescript/await-thenable": "error",
-    "typescript/no-unused-vars": ["warn", { "argsIgnorePattern": "^_" }],
+    "typescript/no-unsafe-argument": "error",
+    "typescript/no-unsafe-assignment": "error",
+    "typescript/no-unsafe-call": "error",
+    "typescript/no-unsafe-member-access": "error",
+    "typescript/no-unsafe-return": "error",
     "typescript/no-unsafe-type-assertion": "off",
+    "typescript/no-deprecated": "error",
+    "typescript/prefer-nullish-coalescing": "error",
+    "typescript/no-confusing-void-expression": "error",
+    "typescript/strict-void-return": "error",
+    "typescript/consistent-type-definitions": ["error", "type"],
+    "typescript/consistent-type-imports": "error",
+    "typescript/consistent-type-exports": "error",
+    "typescript/array-type": ["error", { "default": "array" }],
+    "typescript/promise-function-async": "error",
+    "typescript/return-await": "error",
+    "typescript/restrict-template-expressions": "off",
+    "typescript/prefer-readonly-parameter-types": "off",
+    "typescript/strict-boolean-expressions": "off",
+    "typescript/require-array-sort-compare": "off",
+
+    "unicorn/prefer-node-protocol": "error",
+    "unicorn/catch-error-name": "error",
+    "unicorn/numeric-separators-style": "error",
+    "unicorn/no-await-expression-member": "error",
+    "unicorn/no-useless-undefined": "error",
+    "unicorn/prefer-string-replace-all": "off",
+    "unicorn/consistent-assert": "off",
+    "unicorn/no-array-sort": "off",
+    "unicorn/prefer-set-has": "off",
+    "unicorn/no-negated-condition": "off",
+    "unicorn/prefer-top-level-await": "off",
+    "unicorn/prefer-math-trunc": "off",
+
+    "eslint/require-await": "off",
+    "typescript/require-await": "off",
+    "eslint/no-underscore-dangle": "off",
+    "eslint/no-inline-comments": "off",
+    "eslint/no-negated-condition": "off",
+    "eslint/no-else-return": "off",
+    "eslint/max-lines-per-function": "off",
+    "eslint/max-lines": "off",
+    "eslint/require-unicode-regexp": "off",
+    "import/max-dependencies": "off",
+
+    "no-console": "warn",
     "no-await-in-loop": "off"
   },
-  "ignorePatterns": ["*.d.ts", "*.d.mts"]
+  "ignorePatterns": ["*.d.ts", "*.d.mts"],
+  "overrides": [
+    {
+      "files": [
+        "**/*.test.ts",
+        "**/*.spec.ts",
+        "**/test/**/*.ts",
+        "src/testing/**/*.ts"
+      ],
+      "rules": {
+        "typescript/no-explicit-any": "off",
+        "typescript/no-non-null-assertion": "off",
+        "typescript/no-unsafe-argument": "off",
+        "typescript/no-unsafe-assignment": "off",
+        "typescript/no-unsafe-call": "off",
+        "typescript/no-unsafe-member-access": "off",
+        "typescript/no-unsafe-return": "off",
+        "typescript/promise-function-async": "off",
+        "typescript/no-confusing-void-expression": "off",
+        "typescript/strict-void-return": "off",
+        "typescript/consistent-type-imports": "off",
+        "unicorn/no-await-expression-member": "off",
+        "unicorn/no-useless-undefined": "off",
+        "unicorn/consistent-function-scoping": "off"
+      }
+    },
+    {
+      "files": ["src/lib/lockfile/helpers/**/*.ts"],
+      "rules": {
+        "typescript/no-unsafe-argument": "off",
+        "typescript/no-unsafe-assignment": "off",
+        "typescript/no-unsafe-call": "off",
+        "typescript/no-unsafe-member-access": "off",
+        "typescript/no-unsafe-return": "off"
+      }
+    },
+    {
+      "files": ["src/isolate-bin.ts"],
+      "rules": {
+        "no-console": "off"
+      }
+    }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "url": "git+https://github.com/0x80/isolate-package.git"
   },
   "bin": {
-    "isolate": "./dist/isolate-bin.mjs",
     "isolate-package": "./dist/isolate-bin.mjs"
   },
   "files": [
@@ -42,7 +41,7 @@
     "dev": "tsdown --watch",
     "test": "vitest run",
     "format": "oxfmt",
-    "lint": "oxlint -c .oxlintrc.json --type-aware",
+    "lint": "oxlint -c .oxlintrc.json --import-plugin --type-aware",
     "check-format": "oxfmt --check",
     "check-types": "tsc --noEmit",
     "prepare": "(husky || true) && pnpm check-types && pnpm build",
@@ -94,7 +93,7 @@
   "lint-staged": {
     "*.{ts,tsx,js,mjs,cjs}": [
       "oxfmt",
-      "oxlint -c .oxlintrc.json --type-aware"
+      "oxlint -c .oxlintrc.json --import-plugin --type-aware"
     ]
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "url": "git+https://github.com/0x80/isolate-package.git"
   },
   "bin": {
+    "isolate": "./dist/isolate-bin.mjs",
     "isolate-package": "./dist/isolate-bin.mjs"
   },
   "files": [

--- a/src/isolate-bin.ts
+++ b/src/isolate-bin.ts
@@ -100,8 +100,8 @@ async function run() {
 run().catch((error) => {
   if (error instanceof Error) {
     console.error(error.stack);
-    process.exit(1);
   } else {
     console.error(error);
   }
+  process.exit(1);
 });

--- a/src/isolate-bin.ts
+++ b/src/isolate-bin.ts
@@ -97,11 +97,11 @@ async function run() {
   await isolate(mergedConfig);
 }
 
-run().catch((err) => {
-  if (err instanceof Error) {
-    console.error(err.stack);
+run().catch((error) => {
+  if (error instanceof Error) {
+    console.error(error.stack);
     process.exit(1);
   } else {
-    console.error(err);
+    console.error(error);
   }
 });

--- a/src/isolate.ts
+++ b/src/isolate.ts
@@ -54,7 +54,7 @@ export function createIsolator(config?: IsolateConfig) {
     const { targetPackageDir, workspaceRootDir } =
       resolveWorkspacePaths(config);
 
-    const buildOutputDir = await getBuildOutputDir({
+    const buildOutputDir = getBuildOutputDir({
       targetPackageDir,
       buildDirName: config.buildDirName,
       tsconfigPath: config.tsconfigPath,
@@ -283,9 +283,7 @@ export function createIsolator(config?: IsolateConfig) {
         if (packageManager.name === "bun") {
           manifest.patchedDependencies = patchEntries;
         } else {
-          if (!manifest.pnpm) {
-            manifest.pnpm = {};
-          }
+          manifest.pnpm ??= {};
           manifest.pnpm.patchedDependencies = patchEntries;
         }
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -93,7 +93,7 @@ function loadModuleConfig(filePath: string): IsolateConfig {
       throw new Error("Failed to extract config JSON from subprocess output");
     }
 
-    const parsed = JSON.parse(jsonMatch);
+    const parsed = JSON.parse(jsonMatch) as unknown;
 
     if (
       typeof parsed !== "object" ||
@@ -105,7 +105,7 @@ function loadModuleConfig(filePath: string): IsolateConfig {
       );
     }
 
-    return parsed;
+    return parsed as IsolateConfig;
   } catch (error) {
     const stderr =
       error instanceof Error && "stderr" in error

--- a/src/lib/lockfile/helpers/bun-lockfile.ts
+++ b/src/lib/lockfile/helpers/bun-lockfile.ts
@@ -109,9 +109,8 @@ export function collectRequiredPackages(
   const required = new Set<string>();
   const queue = [...directDependencyNames];
 
-  while (queue.length > 0) {
-    const name = queue.pop()!;
-
+  let name: string | undefined;
+  while ((name = queue.pop()) !== undefined) {
     if (required.has(name)) continue;
 
     const entry = packages[name];

--- a/src/lib/lockfile/helpers/generate-bun-lockfile.ts
+++ b/src/lib/lockfile/helpers/generate-bun-lockfile.ts
@@ -215,8 +215,8 @@ export async function generateBunLockfile({
     );
 
     log.debug("Created lockfile at", outputPath);
-  } catch (err) {
-    log.error(`Failed to generate lockfile: ${getErrorMessage(err)}`);
-    throw err;
+  } catch (error) {
+    log.error(`Failed to generate lockfile: ${getErrorMessage(error)}`);
+    throw error;
   }
 }

--- a/src/lib/lockfile/helpers/generate-npm-lockfile.ts
+++ b/src/lib/lockfile/helpers/generate-npm-lockfile.ts
@@ -114,9 +114,9 @@ export async function generateNpmLockfile({
       "Created lockfile at",
       path.join(isolateDir, "package-lock.json"),
     );
-  } catch (err) {
-    log.error(`Failed to generate lockfile: ${getErrorMessage(err)}`);
-    throw err;
+  } catch (error) {
+    log.error(`Failed to generate lockfile: ${getErrorMessage(error)}`);
+    throw error;
   }
 }
 

--- a/src/lib/lockfile/helpers/generate-pnpm-lockfile.ts
+++ b/src/lib/lockfile/helpers/generate-pnpm-lockfile.ts
@@ -185,8 +185,8 @@ export async function generatePnpmLockfile({
     }
 
     log.debug("Created lockfile at", path.join(isolateDir, "pnpm-lock.yaml"));
-  } catch (err) {
-    log.error(`Failed to generate lockfile: ${getErrorMessage(err)}`);
-    throw err;
+  } catch (error) {
+    log.error(`Failed to generate lockfile: ${getErrorMessage(error)}`);
+    throw error;
   }
 }

--- a/src/lib/lockfile/helpers/generate-yarn-lockfile.ts
+++ b/src/lib/lockfile/helpers/generate-yarn-lockfile.ts
@@ -43,8 +43,8 @@ export async function generateYarnLockfile({
     execSync(`yarn install --cwd ${isolateDir}`);
 
     log.debug("Generated lockfile at", newLockfilePath);
-  } catch (err) {
-    log.error(`Failed to generate lockfile: ${getErrorMessage(err)}`);
-    throw err;
+  } catch (error) {
+    log.error(`Failed to generate lockfile: ${getErrorMessage(error)}`);
+    throw error;
   }
 }

--- a/src/lib/manifest/helpers/adopt-pnpm-fields-from-root.ts
+++ b/src/lib/manifest/helpers/adopt-pnpm-fields-from-root.ts
@@ -1,5 +1,5 @@
 import type { ProjectManifest, PnpmSettings } from "@pnpm/types";
-import path from "path";
+import path from "node:path";
 import { usePackageManager } from "~/lib/package-manager";
 import type { PackageManifest } from "~/lib/types";
 import { isRushWorkspace, readTypedJson } from "~/lib/utils";
@@ -60,7 +60,7 @@ function adoptPnpmFieldsOnly(
   rootPackageManifest: ProjectManifest,
 ): PackageManifest {
   const { overrides, onlyBuiltDependencies, ignoredBuiltDependencies } =
-    rootPackageManifest.pnpm || {};
+    rootPackageManifest.pnpm ?? {};
 
   /** If no pnpm fields are present, return the original manifest */
   if (!overrides && !onlyBuiltDependencies && !ignoredBuiltDependencies) {

--- a/src/lib/manifest/helpers/resolve-catalog-dependencies.ts
+++ b/src/lib/manifest/helpers/resolve-catalog-dependencies.ts
@@ -8,10 +8,10 @@ import yaml from "yaml";
 type CatalogMap = Record<string, string>;
 type CatalogsMap = Record<string, CatalogMap>;
 
-interface CatalogSource {
+type CatalogSource = {
   catalog?: CatalogMap;
   catalogs?: CatalogsMap;
-}
+};
 
 const catalogSourceCache = new Map<string, Promise<CatalogSource>>();
 
@@ -34,8 +34,9 @@ const catalogSourceCache = new Map<string, Promise<CatalogSource>>();
 async function loadCatalogSource(
   workspaceRootDir: string,
 ): Promise<CatalogSource> {
-  if (catalogSourceCache.has(workspaceRootDir)) {
-    return catalogSourceCache.get(workspaceRootDir)!;
+  const cached = catalogSourceCache.get(workspaceRootDir);
+  if (cached) {
+    return cached;
   }
 
   const loadPromise = (async () => {
@@ -58,9 +59,9 @@ async function loadCatalogSource(
             catalogs: yamlConfig.catalogs,
           };
         }
-      } catch (err) {
+      } catch (error) {
         log.warn(
-          `Failed to parse ${workspaceYamlPath}: ${err instanceof Error ? err.message : String(err)}. Falling back to package.json for catalog definitions.`,
+          `Failed to parse ${workspaceYamlPath}: ${error instanceof Error ? error.message : String(error)}. Falling back to package.json for catalog definitions.`,
         );
       }
     }
@@ -88,9 +89,9 @@ async function loadCatalogSource(
    * Drop the cache entry if loading fails so a subsequent call can retry
    * instead of immediately rethrowing the same rejection.
    */
-  const cachedLoadPromise = loadPromise.catch((err) => {
+  const cachedLoadPromise = loadPromise.catch((error) => {
     catalogSourceCache.delete(workspaceRootDir);
-    throw err;
+    throw error;
   });
 
   catalogSourceCache.set(workspaceRootDir, cachedLoadPromise);

--- a/src/lib/manifest/validate-manifest.ts
+++ b/src/lib/manifest/validate-manifest.ts
@@ -45,8 +45,8 @@ export function validateManifestMandatoryFields(
     missingFields.push("files");
   }
 
-  if (missingFields.length > 0) {
-    const field = missingFields[0]!;
+  const [field] = missingFields;
+  if (field) {
     const errorMessage =
       missingFields.length === 1
         ? `Package at ${packagePath} is missing the "${field}" field in its package.json. See ${fieldDocUrls[field] ?? "https://isolate-package.codecompose.dev/getting-started#prerequisites"}`

--- a/src/lib/output/get-build-output-dir.ts
+++ b/src/lib/output/get-build-output-dir.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import outdent from "outdent";
 import { useLogger } from "../logger";
 
-export async function getBuildOutputDir({
+export function getBuildOutputDir({
   targetPackageDir,
   buildDirName,
   tsconfigPath,

--- a/src/lib/package-manager/helpers/infer-from-files.ts
+++ b/src/lib/package-manager/helpers/infer-from-files.ts
@@ -15,10 +15,10 @@ export function inferFromFiles(workspaceRoot: string): PackageManager {
         const version = getVersion(name);
 
         return { name, version, majorVersion: getMajorVersion(version) };
-      } catch (err) {
+      } catch (error) {
         throw new Error(
-          `Failed to find package manager version for ${name}: ${getErrorMessage(err)}`,
-          { cause: err },
+          `Failed to find package manager version for ${name}: ${getErrorMessage(error)}`,
+          { cause: error },
         );
       }
     }

--- a/src/lib/patches/collect-installed-names-bun.ts
+++ b/src/lib/patches/collect-installed-names-bun.ts
@@ -78,9 +78,9 @@ export function collectInstalledNamesFromBunLockfile({
     }
 
     return collectRequiredPackages(directDependencyNames, lockfile.packages);
-  } catch (err) {
+  } catch (error) {
     log.debug(
-      `Failed to walk bun.lock for installed names: ${err instanceof Error ? err.message : String(err)}`,
+      `Failed to walk bun.lock for installed names: ${error instanceof Error ? error.message : String(error)}`,
     );
     return new Set();
   }

--- a/src/lib/patches/collect-installed-names-pnpm.ts
+++ b/src/lib/patches/collect-installed-names-pnpm.ts
@@ -109,8 +109,8 @@ export async function collectInstalledNamesFromPnpmLockfile({
       });
     }
 
-    while (queue.length > 0) {
-      const depPath = queue.pop()!;
+    let depPath: string | undefined;
+    while ((depPath = queue.pop()) !== undefined) {
       if (seen.has(depPath)) continue;
       seen.add(depPath);
 
@@ -138,9 +138,9 @@ export async function collectInstalledNamesFromPnpmLockfile({
     }
 
     return names;
-  } catch (err) {
+  } catch (error) {
     log.debug(
-      `Failed to walk pnpm lockfile for installed names: ${err instanceof Error ? err.message : String(err)}`,
+      `Failed to walk pnpm lockfile for installed names: ${error instanceof Error ? error.message : String(error)}`,
     );
     return new Set();
   }

--- a/src/lib/patches/copy-patches.test.ts
+++ b/src/lib/patches/copy-patches.test.ts
@@ -66,14 +66,6 @@ describe("copyPatches", () => {
     vi.restoreAllMocks();
   });
 
-  const mockJsonSettings = (settings: PnpmSettings | undefined) => {
-    readTypedJson.mockResolvedValue({
-      name: "root",
-      version: "1.0.0",
-      pnpm: settings,
-    });
-  };
-
   it("should return empty object when workspace root package.json cannot be read", async () => {
     readTypedYamlSync.mockImplementation(() => {
       throw new Error("File not found");

--- a/src/lib/patches/write-isolate-pnpm-workspace.test.ts
+++ b/src/lib/patches/write-isolate-pnpm-workspace.test.ts
@@ -154,7 +154,7 @@ describe("writeIsolatePnpmWorkspace", () => {
         puppeteer: true,
         esbuild: true,
       },
-      minimumReleaseAge: 10080,
+      minimumReleaseAge: 10_080,
     });
 
     writeIsolatePnpmWorkspace({

--- a/src/lib/registry/create-packages-registry.ts
+++ b/src/lib/registry/create-packages-registry.ts
@@ -28,38 +28,41 @@ export async function createPackagesRegistry(
     workspaceRootDir,
   );
 
-  const registry: PackagesRegistry = (
-    await Promise.all(
-      allPackages.map(async (rootRelativeDir) => {
-        const absoluteDir = path.join(workspaceRootDir, rootRelativeDir);
-        const manifestPath = path.join(absoluteDir, "package.json");
+  const entries = await Promise.all(
+    allPackages.map(async (rootRelativeDir) => {
+      const absoluteDir = path.join(workspaceRootDir, rootRelativeDir);
+      const manifestPath = path.join(absoluteDir, "package.json");
 
-        if (!fs.existsSync(manifestPath)) {
-          log.warn(
-            `Ignoring directory ${rootRelativeDir} because it does not contain a package.json file`,
-          );
-          return;
-        } else {
-          log.debug(`Registering package ${rootRelativeDir}`);
+      if (!fs.existsSync(manifestPath)) {
+        log.warn(
+          `Ignoring directory ${rootRelativeDir} because it does not contain a package.json file`,
+        );
+        return;
+      }
 
-          const manifest = await readTypedJson<PackageManifest>(
-            path.join(absoluteDir, "package.json"),
-          );
+      log.debug(`Registering package ${rootRelativeDir}`);
 
-          return {
-            manifest,
-            rootRelativeDir,
-            absoluteDir,
-          };
-        }
-      }),
-    )
-  ).reduce<PackagesRegistry>((acc, info) => {
-    if (info) {
-      acc[info.manifest.name] = info;
-    }
-    return acc;
-  }, {});
+      const manifest = await readTypedJson<PackageManifest>(
+        path.join(absoluteDir, "package.json"),
+      );
+
+      return {
+        manifest,
+        rootRelativeDir,
+        absoluteDir,
+      };
+    }),
+  );
+
+  const registry: PackagesRegistry = entries.reduce<PackagesRegistry>(
+    (acc, info) => {
+      if (info) {
+        acc[info.manifest.name] = info;
+      }
+      return acc;
+    },
+    {},
+  );
 
   return registry;
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -6,10 +6,10 @@ export type { PnpmSettings } from "@pnpm/types";
  * Represents a patch file entry in the pnpm lockfile. Contains the path to the
  * patch file and its content hash.
  */
-export interface PatchFile {
+export type PatchFile = {
   path: string;
   hash: string;
-}
+};
 
 export type PackageManifest = PnpmPackageManifest & {
   packageManager?: string;

--- a/src/lib/utils/get-dirname.ts
+++ b/src/lib/utils/get-dirname.ts
@@ -1,4 +1,4 @@
-import { fileURLToPath } from "url";
+import { fileURLToPath } from "node:url";
 
 /**
  * Calling context should pass in import.meta.url and the function will return

--- a/src/lib/utils/json.ts
+++ b/src/lib/utils/json.ts
@@ -10,10 +10,10 @@ export function readTypedJsonSync<T>(filePath: string) {
       stripJsonComments(rawContent, { trailingCommas: true }),
     ) as T;
     return data;
-  } catch (err) {
+  } catch (error) {
     throw new Error(
-      `Failed to read JSON from ${filePath}: ${getErrorMessage(err)}`,
-      { cause: err },
+      `Failed to read JSON from ${filePath}: ${getErrorMessage(error)}`,
+      { cause: error },
     );
   }
 }
@@ -25,10 +25,10 @@ export async function readTypedJson<T>(filePath: string) {
       stripJsonComments(rawContent, { trailingCommas: true }),
     ) as T;
     return data;
-  } catch (err) {
+  } catch (error) {
     throw new Error(
-      `Failed to read JSON from ${filePath}: ${getErrorMessage(err)}`,
-      { cause: err },
+      `Failed to read JSON from ${filePath}: ${getErrorMessage(error)}`,
+      { cause: error },
     );
   }
 }

--- a/src/lib/utils/pack.ts
+++ b/src/lib/utils/pack.ts
@@ -35,7 +35,8 @@ export async function pack(srcDir: string, dstDir: string) {
           (err, stdout) => {
             if (err) {
               log.error(getErrorMessage(err));
-              return reject(err);
+              reject(err);
+              return;
             }
 
             resolve(stdout);
@@ -48,7 +49,8 @@ export async function pack(srcDir: string, dstDir: string) {
           execOptions,
           (err, stdout) => {
             if (err) {
-              return reject(err);
+              reject(err);
+              return;
             }
 
             resolve(stdout);

--- a/src/lib/utils/pack.ts
+++ b/src/lib/utils/pack.ts
@@ -17,11 +17,9 @@ export async function pack(srcDir: string, dstDir: string) {
   const log = useLogger();
 
   const execOptions = {
+    cwd: srcDir,
     maxBuffer: 10 * 1024 * 1024,
   };
-
-  const previousCwd = process.cwd();
-  process.chdir(srcDir);
 
   /**
    * PNPM pack seems to be a lot faster than NPM pack, so when PNPM is detected
@@ -67,8 +65,6 @@ export async function pack(srcDir: string, dstDir: string) {
   assert(fileName, `Failed to parse file name from: ${lastLine}`);
 
   const filePath = path.join(dstDir, fileName);
-
-  process.chdir(previousCwd);
 
   /**
    * `pnpm pack` (and occasionally `npm pack`) can return before the tarball is

--- a/src/lib/utils/reset-isolate-dir.ts
+++ b/src/lib/utils/reset-isolate-dir.ts
@@ -78,13 +78,13 @@ export async function resetIsolateDir(
        * `isolateDir` is gone. Any debris left behind will be swept on the
        * next run.
        */
-      void fs.remove(trashDir).catch((err: unknown) => {
+      void fs.remove(trashDir).catch((error: unknown) => {
         log.debug(
           "Background cleanup of trashed isolate directory did not complete:",
-          err instanceof Error ? err.message : String(err),
+          error instanceof Error ? error.message : String(error),
         );
       });
-    } catch (err) {
+    } catch (error) {
       /**
        * `rename` can fail with `EXDEV` if `trashParentDir` ends up on a
        * different filesystem from `isolateDir`, or with `EPERM` on platforms
@@ -94,7 +94,7 @@ export async function resetIsolateDir(
        */
       log.debug(
         "Could not rename existing isolate output directory, falling back to recursive delete:",
-        err instanceof Error ? err.message : String(err),
+        error instanceof Error ? error.message : String(error),
       );
 
       await fs.remove(isolateDir);
@@ -138,10 +138,10 @@ async function sweepStaleTrash(parentDir: string, trashGlobPrefix: string) {
   await Promise.all(
     entries
       .filter((entry) => entry.startsWith(trashGlobPrefix))
-      .map((entry) =>
-        fs.remove(path.join(parentDir, entry)).catch(() => {
+      .map(async (entry) => {
+        await fs.remove(path.join(parentDir, entry)).catch(() => {
           /** Best-effort. */
-        }),
-      ),
+        });
+      }),
   );
 }

--- a/src/lib/utils/wait-for-complete-file.ts
+++ b/src/lib/utils/wait-for-complete-file.ts
@@ -26,14 +26,16 @@ export async function waitForCompleteFile(
       }
 
       lastSize = size;
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
-        throw err;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw error;
       }
       /** File not visible yet; keep polling. */
     }
 
-    await new Promise((resolve) => setTimeout(resolve, pollMs));
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, pollMs);
+    });
   }
 
   throw new Error(

--- a/src/lib/utils/yaml.ts
+++ b/src/lib/utils/yaml.ts
@@ -5,13 +5,13 @@ import { getErrorMessage } from "./get-error-message";
 export function readTypedYamlSync<T>(filePath: string) {
   try {
     const rawContent = fs.readFileSync(filePath, "utf-8");
-    const data = yaml.parse(rawContent);
+    const data = yaml.parse(rawContent) as unknown;
     /** @todo Add some zod validation maybe */
     return data as T;
-  } catch (err) {
+  } catch (error) {
     throw new Error(
-      `Failed to read YAML from ${filePath}: ${getErrorMessage(err)}`,
-      { cause: err },
+      `Failed to read YAML from ${filePath}: ${getErrorMessage(error)}`,
+      { cause: error },
     );
   }
 }


### PR DESCRIPTION
Expand the oxlint configuration with type-aware safety rules
(`no-unsafe-*`, `no-floating-promises`, `strict-void-return`,
`no-confusing-void-expression`, `no-deprecated`,
`prefer-nullish-coalescing`), consistency rules
(`consistent-type-imports/exports/definitions`, `array-type`,
`promise-function-async`), and unicorn rules
(`prefer-node-protocol`, `no-useless-undefined`,
`no-await-expression-member`, `catch-error-name`). The `pedantic`
category is enabled at the `warn` level so its findings are visible
without being blocking.

Test files and `src/lib/lockfile/helpers/**` get scoped overrides
that relax the `no-unsafe-*` rules — those helpers interact with
untyped third-party APIs (`@npmcli/arborist`, `@pnpm/lockfile-file`)
where the warnings would be noise.

Existing source is conformed to the new rules: interfaces converted
to type aliases, `node:` import protocol, `||` to `??`, non-null
assertions replaced, `err` catch parameters renamed to `error`, and
other minor cleanups.

Two small unrelated fixes are bundled in:
- `process.exit(1)` is now reached from both branches of the CLI's
  top-level `.catch`, so non-`Error` rejections no longer exit zero.
- `pack()` passes `cwd` to `exec` instead of mutating `process.cwd`,
  removing a leak where a failed pack left the global cwd pointing
  at the package source dir.

Decisions:
- `eslint/require-await` and `typescript/require-await` are off.
  They conflict with `promise-function-async` + `return-await` for
  pure delegation functions, and `promise-function-async` already
  guards the property they protect.
- For the `pack()` cwd fix, used `exec`'s `cwd` option instead of
  the reviewer-suggested try/finally — eliminates the bug class
  rather than patching it, and makes the function concurrency-safe.