### PR TITLE
Re-nest displaced hoisted dep when target pins a nested override

### DIFF
--- a/src/lib/lockfile/helpers/generate-npm-lockfile.test.ts
+++ b/src/lib/lockfile/helpers/generate-npm-lockfile.test.ts
@@ -671,6 +671,99 @@ describe("buildIsolatedLockfileJson", () => {
   });
 
   /**
+   * Cascade scenario: a reachable node is simultaneously (a) the loser of one
+   * collision (its slot is taken by a target-nested winner) and (b) a
+   * potential consumer of another displaced entry. Because the displaced
+   * consumer is not actually present in the isolate, the re-nesting loop must
+   * skip it — otherwise it would try to nest under a slot already held by an
+   * unrelated target-nested entry and throw a spurious secondary-collision
+   * error.
+   */
+  it("skips re-nesting under a consumer whose own entry has been displaced", () => {
+    const srcData: Parameters<typeof buildIsolatedLockfileJson>[0]["srcData"] =
+      {
+        name: "root",
+        version: "0.0.0",
+        lockfileVersion: 3,
+        requires: true,
+        packages: {
+          "": { name: "root", version: "0.0.0" },
+          "packages/api": {
+            name: "api",
+            version: "1.0.0",
+            dependencies: { "dep-a": "*", "dep-x": "^5" },
+          },
+          /** Target's nested A@v2 displaces the hoisted A@v1. */
+          "packages/api/node_modules/dep-a": {
+            version: "2.0.0",
+            resolved: "https://registry.npmjs.org/dep-a/-/dep-a-2.0.0.tgz",
+            integrity: "sha512-a-v2",
+            dependencies: { "dep-x": "^3" },
+          },
+          /** A@v2 brings its own nested X@v3. */
+          "packages/api/node_modules/dep-a/node_modules/dep-x": {
+            version: "3.0.0",
+            resolved: "https://registry.npmjs.org/dep-x/-/dep-x-3.0.0.tgz",
+            integrity: "sha512-x-v3",
+          },
+          /** Target's nested X@v5 displaces the hoisted X@v1. */
+          "packages/api/node_modules/dep-x": {
+            version: "5.0.0",
+            resolved: "https://registry.npmjs.org/dep-x/-/dep-x-5.0.0.tgz",
+            integrity: "sha512-x-v5",
+          },
+          /** Hoisted A@v1, still reachable through another transitive path. */
+          "node_modules/dep-a": {
+            version: "1.0.0",
+            resolved: "https://registry.npmjs.org/dep-a/-/dep-a-1.0.0.tgz",
+            integrity: "sha512-a-v1",
+            dependencies: { "dep-x": "^1" },
+          },
+          /** Hoisted X@v1, which A@v1 originally resolved to. */
+          "node_modules/dep-x": {
+            version: "1.0.0",
+            resolved: "https://registry.npmjs.org/dep-x/-/dep-x-1.0.0.tgz",
+            integrity: "sha512-x-v1",
+          },
+        },
+      };
+
+    const reachable: ReachableNode[] = [
+      { location: "packages/api", isLink: false },
+      { location: "packages/api/node_modules/dep-a", isLink: false },
+      {
+        location: "packages/api/node_modules/dep-a/node_modules/dep-x",
+        isLink: false,
+      },
+      { location: "packages/api/node_modules/dep-x", isLink: false },
+      { location: "node_modules/dep-a", isLink: false },
+      { location: "node_modules/dep-x", isLink: false },
+    ];
+
+    const out = buildIsolatedLockfileJson({
+      srcData,
+      reachable,
+      targetImporterLoc: "packages/api",
+      targetLinkLoc: "node_modules/api",
+      targetPackageManifest: {
+        name: "api",
+        version: "1.0.0",
+        dependencies: { "dep-a": "*", "dep-x": "^5" },
+      },
+    });
+
+    /** The displaced hoisted A@v1 leaves no consumer present in the isolate
+     * (its only reachable consumer was itself), so no re-nesting happens for
+     * dep-x under node_modules/dep-a — the existing X@v3 placed via remap
+     * stays untouched. */
+    expect(out.packages["node_modules/dep-a"]!.version).toBe("2.0.0");
+    expect(out.packages["node_modules/dep-x"]!.version).toBe("5.0.0");
+    expect(out.packages["node_modules/dep-a/node_modules/dep-x"]!.version).toBe(
+      "3.0.0",
+    );
+  });
+
+  /**
    * Identical entries at colliding paths should not throw — copying the
    * same content twice is a no-op.
    */

--- a/src/lib/lockfile/helpers/generate-npm-lockfile.test.ts
+++ b/src/lib/lockfile/helpers/generate-npm-lockfile.test.ts
@@ -405,12 +405,14 @@ describe("buildIsolatedLockfileJson", () => {
   });
 
   /**
-   * When the target's nested entry remaps onto the same path as a hoisted
-   * entry still needed by another reachable dependency, and the two
-   * entries differ in content, we must refuse to produce the lockfile
-   * rather than silently drop one version.
+   * Reproduces https://github.com/0x80/isolate-package/issues/187. When the
+   * target's nested entry remaps onto the same path as a hoisted entry still
+   * needed by another reachable dependency, the target's nested version must
+   * win at the new root (the target becomes the isolate root) and the
+   * displaced hoisted entry must be re-nested under each consumer that
+   * originally resolved to it.
    */
-  it("throws on a remap collision with conflicting entries", () => {
+  it("re-nests the displaced hoisted entry under each consumer that resolved to it", () => {
     const srcData: Parameters<typeof buildIsolatedLockfileJson>[0]["srcData"] =
       {
         name: "root",
@@ -430,13 +432,13 @@ describe("buildIsolatedLockfileJson", () => {
             dependencies: { semver: "^7" },
           },
           "node_modules/shared": { resolved: "packages/shared", link: true },
-          /** Hoisted v7 used by the internal dep. */
+          /** Hoisted v7 used by the internal dep "shared". */
           "node_modules/semver": {
             version: "7.7.4",
             resolved: "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
             integrity: "sha512-hoisted-v7",
           },
-          /** Nested v6 used by the target — will collide with the hoisted one. */
+          /** Nested v6 used by the target — collides with the hoisted one. */
           "packages/api/node_modules/semver": {
             version: "6.3.1",
             resolved: "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -457,15 +459,215 @@ describe("buildIsolatedLockfileJson", () => {
       { location: "packages/api/node_modules/semver", isLink: false },
     ];
 
-    expect(() =>
-      buildIsolatedLockfileJson({
-        srcData,
-        reachable,
-        targetImporterLoc: "packages/api",
-        targetLinkLoc: "node_modules/api",
-        targetPackageManifest: { name: "api", version: "1.0.0" },
-      }),
-    ).toThrow(/Path collision at "node_modules\/semver"/);
+    const out = buildIsolatedLockfileJson({
+      srcData,
+      reachable,
+      targetImporterLoc: "packages/api",
+      targetLinkLoc: "node_modules/api",
+      targetPackageManifest: {
+        name: "api",
+        version: "1.0.0",
+        dependencies: { semver: "^6", shared: "file:./packages/shared" },
+      },
+    });
+
+    /** Target's nested v6 wins at the new root. */
+    expect(out.packages["node_modules/semver"]).toEqual({
+      version: "6.3.1",
+      resolved: "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      integrity: "sha512-nested-v6",
+    });
+
+    /** Original nested path must not leak through. */
+    expect(out.packages["packages/api/node_modules/semver"]).toBeUndefined();
+
+    /** Displaced v7 is re-nested under the consumer that resolved to it. */
+    expect(out.packages["packages/shared/node_modules/semver"]).toEqual({
+      version: "7.7.4",
+      resolved: "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      integrity: "sha512-hoisted-v7",
+    });
+  });
+
+  /**
+   * When multiple reachable consumers each resolve to the displaced hoisted
+   * entry, every consumer should get its own nested copy.
+   */
+  it("re-nests the displaced entry under every consumer that needs it", () => {
+    const srcData: Parameters<typeof buildIsolatedLockfileJson>[0]["srcData"] =
+      {
+        name: "root",
+        version: "0.0.0",
+        lockfileVersion: 3,
+        requires: true,
+        packages: {
+          "": { name: "root", version: "0.0.0" },
+          "packages/api": {
+            name: "api",
+            version: "1.0.0",
+            dependencies: { "resolve-from": "^5" },
+          },
+          /** Target's nested override — wins at the new root. */
+          "packages/api/node_modules/resolve-from": {
+            version: "5.0.0",
+            resolved:
+              "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+            integrity: "sha512-nested-v5",
+          },
+          /** Hoisted older version used by two transitive deps. */
+          "node_modules/resolve-from": {
+            version: "4.0.0",
+            resolved:
+              "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+            integrity: "sha512-hoisted-v4",
+          },
+          "node_modules/cosmiconfig": {
+            version: "7.0.0",
+            resolved:
+              "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.0.tgz",
+            integrity: "sha512-cosmi",
+            dependencies: { "resolve-from": "^4" },
+          },
+          "node_modules/import-fresh": {
+            version: "3.3.0",
+            resolved:
+              "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+            integrity: "sha512-import-fresh",
+            dependencies: { "resolve-from": "^4" },
+          },
+        },
+      };
+
+    const reachable: ReachableNode[] = [
+      { location: "packages/api", isLink: false },
+      { location: "packages/api/node_modules/resolve-from", isLink: false },
+      { location: "node_modules/resolve-from", isLink: false },
+      { location: "node_modules/cosmiconfig", isLink: false },
+      { location: "node_modules/import-fresh", isLink: false },
+    ];
+
+    const out = buildIsolatedLockfileJson({
+      srcData,
+      reachable,
+      targetImporterLoc: "packages/api",
+      targetLinkLoc: "node_modules/api",
+      targetPackageManifest: {
+        name: "api",
+        version: "1.0.0",
+        dependencies: { "resolve-from": "^5" },
+      },
+    });
+
+    expect(out.packages["node_modules/resolve-from"]!.version).toBe("5.0.0");
+    expect(
+      out.packages["node_modules/cosmiconfig/node_modules/resolve-from"],
+    ).toEqual({
+      version: "4.0.0",
+      resolved:
+        "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      integrity: "sha512-hoisted-v4",
+    });
+    expect(
+      out.packages["node_modules/import-fresh/node_modules/resolve-from"],
+    ).toEqual({
+      version: "4.0.0",
+      resolved:
+        "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      integrity: "sha512-hoisted-v4",
+    });
+  });
+
+  /**
+   * If a reachable consumer has its own nested copy that already satisfies
+   * the dep, it should not get an additional copy of the displaced entry.
+   */
+  it("skips consumers that have their own nested resolution", () => {
+    const srcData: Parameters<typeof buildIsolatedLockfileJson>[0]["srcData"] =
+      {
+        name: "root",
+        version: "0.0.0",
+        lockfileVersion: 3,
+        requires: true,
+        packages: {
+          "": { name: "root", version: "0.0.0" },
+          "packages/api": {
+            name: "api",
+            version: "1.0.0",
+            dependencies: { "resolve-from": "^5" },
+          },
+          "packages/api/node_modules/resolve-from": {
+            version: "5.0.0",
+            resolved:
+              "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+            integrity: "sha512-nested-v5",
+          },
+          /** Displaced hoisted version. */
+          "node_modules/resolve-from": {
+            version: "4.0.0",
+            resolved:
+              "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+            integrity: "sha512-hoisted-v4",
+          },
+          /** Consumer with its own nested override (v3) — should not be re-nested. */
+          "node_modules/legacy-dep": {
+            version: "1.0.0",
+            resolved:
+              "https://registry.npmjs.org/legacy-dep/-/legacy-dep-1.0.0.tgz",
+            integrity: "sha512-legacy-dep",
+            dependencies: { "resolve-from": "^3" },
+          },
+          "node_modules/legacy-dep/node_modules/resolve-from": {
+            version: "3.0.0",
+            resolved:
+              "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+            integrity: "sha512-legacy-v3",
+          },
+          /** Consumer without an own override — resolves to the displaced v4. */
+          "node_modules/cosmiconfig": {
+            version: "7.0.0",
+            resolved:
+              "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.0.tgz",
+            integrity: "sha512-cosmi",
+            dependencies: { "resolve-from": "^4" },
+          },
+        },
+      };
+
+    const reachable: ReachableNode[] = [
+      { location: "packages/api", isLink: false },
+      { location: "packages/api/node_modules/resolve-from", isLink: false },
+      { location: "node_modules/resolve-from", isLink: false },
+      { location: "node_modules/legacy-dep", isLink: false },
+      {
+        location: "node_modules/legacy-dep/node_modules/resolve-from",
+        isLink: false,
+      },
+      { location: "node_modules/cosmiconfig", isLink: false },
+    ];
+
+    const out = buildIsolatedLockfileJson({
+      srcData,
+      reachable,
+      targetImporterLoc: "packages/api",
+      targetLinkLoc: "node_modules/api",
+      targetPackageManifest: {
+        name: "api",
+        version: "1.0.0",
+        dependencies: { "resolve-from": "^5" },
+      },
+    });
+
+    /** legacy-dep keeps its own nested v3 — no extra copy at this path. */
+    expect(
+      out.packages["node_modules/legacy-dep/node_modules/resolve-from"]!
+        .version,
+    ).toBe("3.0.0");
+
+    /** cosmiconfig had no own override and gets the displaced v4 nested. */
+    expect(
+      out.packages["node_modules/cosmiconfig/node_modules/resolve-from"]!
+        .version,
+    ).toBe("4.0.0");
   });
 
   /**

--- a/src/lib/lockfile/helpers/generate-npm-lockfile.ts
+++ b/src/lib/lockfile/helpers/generate-npm-lockfile.ts
@@ -297,7 +297,6 @@ export function buildIsolatedLockfileJson({
    * is still reachable from other deps. The displaced entry needs to be
    * re-nested under each consumer that originally resolved to it. */
   type Collision = {
-    newLoc: string;
     loserOrigLoc: string;
     loserEntry: LockfilePackageEntry;
   };
@@ -339,7 +338,6 @@ export function buildIsolatedLockfileJson({
         /** The target-nested entry wins. The previously-stored hoisted entry
          * is displaced and must be re-nested under its consumers. */
         collisions.push({
-          newLoc,
           loserOrigLoc: previousOrigLoc,
           loserEntry: existing,
         });
@@ -352,7 +350,6 @@ export function buildIsolatedLockfileJson({
         /** The previously-stored target-nested entry wins; the incoming
          * hoisted entry is the loser. */
         collisions.push({
-          newLoc,
           loserOrigLoc: origLoc,
           loserEntry: { ...srcEntry },
         });
@@ -362,7 +359,8 @@ export function buildIsolatedLockfileJson({
       /** Neither side is the target's nested version, or both are — we have
        * no rule to pick a winner. Bail loudly. */
       throw new Error(
-        `Path collision at "${newLoc}": source locations "${previousOrigLoc}" and "${origLoc}" both map there with conflicting entries, and neither is a target-nested override. ` +
+        `Path collision at "${newLoc}": source locations "${previousOrigLoc}" and "${origLoc}" both map there with conflicting entries and no rule applies to pick a winner ` +
+          `(neither is a target-nested override, or both are). ` +
           `Please report a reproduction at https://github.com/0x80/isolate-package/issues.`,
       );
     }
@@ -384,7 +382,8 @@ export function buildIsolatedLockfileJson({
 
       const consumerEntry = srcPackages[consumerSrcLoc];
       if (!consumerEntry) continue;
-      /** Links carry no dependency metadata of their own. */
+      /** Workspace links carry dependency metadata on the importer entry,
+       * not the link entry itself. Skip the link side. */
       if (consumerEntry.link) continue;
 
       if (!entryDependsOn(consumerEntry, loserName)) continue;
@@ -398,9 +397,23 @@ export function buildIsolatedLockfileJson({
 
       const consumerNewLoc = remapToOutputLoc(consumerSrcLoc);
       /** Consumer maps to the isolate root (the target itself). The root
-       * slot is already taken by the winning version; we cannot satisfy
-       * the consumer's original resolution from here. Leave it to npm. */
+       * slot is already taken by the winning version. The target's own
+       * dependencies use that version — we cannot serve a different one
+       * here without nesting under the target, which would be its own
+       * collision. Accept the resolution shift. */
       if (consumerNewLoc === "") continue;
+
+      /** If the consumer was itself displaced by another collision (its
+       * src-side entry doesn't match the entry we actually placed at its
+       * new location), the consumer isn't really present in the isolate.
+       * Its original dep needs are irrelevant here. */
+      const consumerOutEntry = outPackages[consumerNewLoc];
+      if (
+        !consumerOutEntry ||
+        !entriesAreEquivalent(consumerOutEntry, consumerEntry)
+      ) {
+        continue;
+      }
 
       const nestedLoc = `${consumerNewLoc}/node_modules/${loserName}`;
 

--- a/src/lib/lockfile/helpers/generate-npm-lockfile.ts
+++ b/src/lib/lockfile/helpers/generate-npm-lockfile.ts
@@ -277,10 +277,31 @@ export function buildIsolatedLockfileJson({
 
   const targetNestedNodeModulesPrefix = `${targetImporterLoc}/node_modules/`;
 
-  /** Track the source location each output entry came from, so we can
-   * produce a clear error if two source paths remap to the same target.
-   */
+  const remapToOutputLoc = (origLoc: string): string => {
+    if (origLoc === targetImporterLoc) return "";
+    if (origLoc.startsWith(targetNestedNodeModulesPrefix)) {
+      return origLoc.slice(targetImporterLoc.length + 1);
+    }
+    return origLoc;
+  };
+
+  const isTargetNested = (origLoc: string): boolean =>
+    origLoc === targetImporterLoc ||
+    origLoc.startsWith(targetNestedNodeModulesPrefix);
+
+  /** Track the source location each output entry came from, used to identify
+   * the displaced entry when a collision occurs. */
   const origLocByNewLoc = new Map<string, string>();
+
+  /** Collisions where the target's nested entry displaces a hoisted entry that
+   * is still reachable from other deps. The displaced entry needs to be
+   * re-nested under each consumer that originally resolved to it. */
+  type Collision = {
+    newLoc: string;
+    loserOrigLoc: string;
+    loserEntry: LockfilePackageEntry;
+  };
+  const collisions: Collision[] = [];
 
   for (const node of reachable) {
     const origLoc = node.location;
@@ -299,14 +320,7 @@ export function buildIsolatedLockfileJson({
      * `packages/app/lib/core`) are preserved verbatim because their disk
      * location in the isolate is unchanged.
      */
-    let newLoc: string;
-    if (origLoc === targetImporterLoc) {
-      newLoc = "";
-    } else if (origLoc.startsWith(targetNestedNodeModulesPrefix)) {
-      newLoc = origLoc.slice(targetImporterLoc.length + 1);
-    } else {
-      newLoc = origLoc;
-    }
+    const newLoc = remapToOutputLoc(origLoc);
 
     const srcEntry = srcPackages[origLoc];
     if (!srcEntry) {
@@ -318,15 +332,92 @@ export function buildIsolatedLockfileJson({
     const existing = outPackages[newLoc];
     if (existing && !entriesAreEquivalent(existing, srcEntry)) {
       const previousOrigLoc = origLocByNewLoc.get(newLoc) ?? "<unknown>";
+      const incomingIsTargetNested = isTargetNested(origLoc);
+      const previousIsTargetNested = isTargetNested(previousOrigLoc);
+
+      if (incomingIsTargetNested && !previousIsTargetNested) {
+        /** The target-nested entry wins. The previously-stored hoisted entry
+         * is displaced and must be re-nested under its consumers. */
+        collisions.push({
+          newLoc,
+          loserOrigLoc: previousOrigLoc,
+          loserEntry: existing,
+        });
+        outPackages[newLoc] = { ...srcEntry };
+        origLocByNewLoc.set(newLoc, origLoc);
+        continue;
+      }
+
+      if (!incomingIsTargetNested && previousIsTargetNested) {
+        /** The previously-stored target-nested entry wins; the incoming
+         * hoisted entry is the loser. */
+        collisions.push({
+          newLoc,
+          loserOrigLoc: origLoc,
+          loserEntry: { ...srcEntry },
+        });
+        continue;
+      }
+
+      /** Neither side is the target's nested version, or both are — we have
+       * no rule to pick a winner. Bail loudly. */
       throw new Error(
-        `Path collision at "${newLoc}": source locations "${previousOrigLoc}" and "${origLoc}" both map there with conflicting entries. ` +
-          `This happens when the target pins a nested version override that collides with a hoisted version still needed by another reachable dependency. ` +
+        `Path collision at "${newLoc}": source locations "${previousOrigLoc}" and "${origLoc}" both map there with conflicting entries, and neither is a target-nested override. ` +
           `Please report a reproduction at https://github.com/0x80/isolate-package/issues.`,
       );
     }
 
     outPackages[newLoc] = { ...srcEntry };
     origLocByNewLoc.set(newLoc, origLoc);
+  }
+
+  /** Re-nest each displaced entry under the reachable consumers that
+   * originally resolved to it via node_modules walk-up. */
+  for (const collision of collisions) {
+    const loserName = extractPackageNameFromLockfileLoc(collision.loserOrigLoc);
+    if (!loserName) continue;
+
+    for (const consumer of reachable) {
+      const consumerSrcLoc = consumer.location;
+      if (consumerSrcLoc === collision.loserOrigLoc) continue;
+      if (consumerSrcLoc === targetLinkLoc) continue;
+
+      const consumerEntry = srcPackages[consumerSrcLoc];
+      if (!consumerEntry) continue;
+      /** Links carry no dependency metadata of their own. */
+      if (consumerEntry.link) continue;
+
+      if (!entryDependsOn(consumerEntry, loserName)) continue;
+
+      const resolvedSrcLoc = resolveDepInSrcLockfile(
+        consumerSrcLoc,
+        loserName,
+        srcPackages,
+      );
+      if (resolvedSrcLoc !== collision.loserOrigLoc) continue;
+
+      const consumerNewLoc = remapToOutputLoc(consumerSrcLoc);
+      /** Consumer maps to the isolate root (the target itself). The root
+       * slot is already taken by the winning version; we cannot satisfy
+       * the consumer's original resolution from here. Leave it to npm. */
+      if (consumerNewLoc === "") continue;
+
+      const nestedLoc = `${consumerNewLoc}/node_modules/${loserName}`;
+
+      const existingNested = outPackages[nestedLoc];
+      if (existingNested) {
+        if (entriesAreEquivalent(existingNested, collision.loserEntry)) {
+          continue;
+        }
+        throw new Error(
+          `Cannot re-nest displaced "${loserName}" under "${consumerNewLoc}": ` +
+            `the slot "${nestedLoc}" already contains a different entry. ` +
+            `Please report a reproduction at https://github.com/0x80/isolate-package/issues.`,
+        );
+      }
+
+      outPackages[nestedLoc] = { ...collision.loserEntry };
+    }
   }
 
   /**
@@ -394,6 +485,71 @@ function entriesAreEquivalent(
     a.integrity === b.integrity &&
     !!a.link === !!b.link
   );
+}
+
+/**
+ * Extracts the package name from a lockfile install location. Handles scoped
+ * packages, where the name is two segments after the last `node_modules/`.
+ *
+ *   "node_modules/foo"                          -> "foo"
+ *   "node_modules/@scope/foo"                   -> "@scope/foo"
+ *   "node_modules/a/node_modules/b"             -> "b"
+ *   "node_modules/a/node_modules/@scope/b"      -> "@scope/b"
+ *
+ * Returns null for locations that don't contain `node_modules/`.
+ */
+function extractPackageNameFromLockfileLoc(loc: string): string | null {
+  const marker = "node_modules/";
+  const lastIdx = loc.lastIndexOf(marker);
+  if (lastIdx < 0) return null;
+  const tail = loc.slice(lastIdx + marker.length);
+  if (tail.startsWith("@")) {
+    const slashIdx = tail.indexOf("/");
+    if (slashIdx < 0) return tail;
+    /** Stop at the second `/` so we don't include any further nesting. */
+    const secondSlash = tail.indexOf("/", slashIdx + 1);
+    return secondSlash < 0 ? tail : tail.slice(0, secondSlash);
+  }
+  const slashIdx = tail.indexOf("/");
+  return slashIdx < 0 ? tail : tail.slice(0, slashIdx);
+}
+
+/**
+ * Returns true if the lockfile entry lists `depName` in any of its dependency
+ * fields. Includes peer/optional/dev because any of them may have been the
+ * reason for the dep being installed at runtime.
+ */
+function entryDependsOn(entry: LockfilePackageEntry, depName: string): boolean {
+  return (
+    entry.dependencies?.[depName] !== undefined ||
+    entry.devDependencies?.[depName] !== undefined ||
+    entry.peerDependencies?.[depName] !== undefined ||
+    entry.optionalDependencies?.[depName] !== undefined
+  );
+}
+
+/**
+ * Resolves `depName` against `srcPackages` from the perspective of a consumer
+ * at `consumerLoc`, mirroring Node.js `node_modules` walk-up. Returns the
+ * lockfile key of the entry the consumer would load at runtime, or null when
+ * no candidate exists.
+ */
+function resolveDepInSrcLockfile(
+  consumerLoc: string,
+  depName: string,
+  srcPackages: Record<string, LockfilePackageEntry>,
+): string | null {
+  let scope = consumerLoc;
+  while (true) {
+    const candidate =
+      scope === ""
+        ? `node_modules/${depName}`
+        : `${scope}/node_modules/${depName}`;
+    if (srcPackages[candidate]) return candidate;
+    if (scope === "") return null;
+    const idx = scope.lastIndexOf("/node_modules/");
+    scope = idx < 0 ? "" : scope.slice(0, idx);
+  }
 }
 
 function overlayManifestDeps(


### PR DESCRIPTION
When the target workspace has its own nested `node_modules/X` (a version override) and the originally-hoisted `node_modules/X` (a different version) is still reachable through some other transitive dep of the target, both source entries remapped to the same path in the isolate output. The generator threw a "Path collision" error even though the error message described it as an intended-but-unimplemented case.

The target-nested entry now wins at the new root (the target becomes the isolate root, so its overrides take precedence). The displaced hoisted entry is re-nested under every reachable consumer that originally resolved to it, found by checking each reachable node's lockfile entry for a dependency on the displaced package and simulating npm's `node_modules` walk-up against the source lockfile. Original `resolved`/`integrity` is preserved end-to-end.

A known limitation, left for a follow-up if it shows up in the wild: cascading collisions (a re-nested loser whose own transitive dep is also a loser) would need a second pass. The code throws a clear error if it detects a secondary slot conflict during re-nesting.

Closes #187.

Scope: lockfile (npm)
Visibility: user-facing