### PR TITLE
Promote oxlint warnings to errors

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -3,22 +3,22 @@
   "plugins": ["import", "typescript", "unicorn", "promise", "node"],
   "categories": {
     "correctness": "error",
-    "suspicious": "warn",
-    "perf": "warn",
-    "pedantic": "warn",
+    "suspicious": "error",
+    "perf": "error",
+    "pedantic": "error",
     "style": "off",
     "restriction": "off"
   },
   "rules": {
-    "import/no-cycle": "warn",
-    "import/no-duplicates": "warn",
+    "import/no-cycle": "error",
+    "import/no-duplicates": "error",
     "import/no-self-import": "error",
     "import/no-unassigned-import": "off",
     "import/no-named-as-default-member": "off",
     "import/no-named-as-default": "off",
 
     "typescript/no-unused-vars": [
-      "warn",
+      "error",
       { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }
     ],
     "typescript/no-non-null-assertion": "error",
@@ -71,7 +71,7 @@
     "eslint/require-unicode-regexp": "off",
     "import/max-dependencies": "off",
 
-    "no-console": "warn",
+    "no-console": "error",
     "no-await-in-loop": "off"
   },
   "ignorePatterns": ["*.d.ts", "*.d.mts"],

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "url": "git+https://github.com/0x80/isolate-package.git"
   },
   "bin": {
+    "isolate": "./dist/isolate-bin.mjs",
     "isolate-package": "./dist/isolate-bin.mjs"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "url": "git+https://github.com/0x80/isolate-package.git"
   },
   "bin": {
-    "isolate": "./dist/isolate-bin.mjs",
     "isolate-package": "./dist/isolate-bin.mjs"
   },
   "files": [

--- a/src/get-internal-package-names.ts
+++ b/src/get-internal-package-names.ts
@@ -23,9 +23,9 @@ export async function getInternalPackageNames(
 
   detectPackageManager(workspaceRootDir);
 
-  const targetPackageManifest = await readTypedJson<PackageManifest>(
+  const targetPackageManifest = (await readTypedJson(
     path.join(targetPackageDir, "package.json"),
-  );
+  )) as PackageManifest;
 
   const packagesRegistry = await createPackagesRegistry(
     workspaceRootDir,

--- a/src/isolate.ts
+++ b/src/isolate.ts
@@ -37,17 +37,17 @@ import {
 
 const __dirname = getDirname(import.meta.url);
 
-export function createIsolator(config?: IsolateConfig) {
-  const resolvedConfig = resolveConfig(config);
+export function createIsolator(initialConfig?: IsolateConfig) {
+  const resolvedConfig = resolveConfig(initialConfig);
 
-  return async function isolate(): Promise<string> {
+  return async function runIsolate(): Promise<string> {
     const config = resolvedConfig;
     setLogLevel(config.logLevel);
     const log = useLogger();
 
-    const { version: libraryVersion } = await readTypedJson<PackageManifest>(
+    const { version: libraryVersion } = (await readTypedJson(
       path.join(path.join(__dirname, "..", "package.json")),
-    );
+    )) as PackageManifest;
 
     log.debug("Using isolate-package version", libraryVersion);
 
@@ -92,9 +92,9 @@ export function createIsolator(config?: IsolateConfig) {
     const tmpDir = path.join(isolateDir, "__tmp");
     await fs.ensureDir(tmpDir);
 
-    const targetPackageManifest = await readTypedJson<PackageManifest>(
+    const targetPackageManifest = (await readTypedJson(
       path.join(targetPackageDir, "package.json"),
-    );
+    )) as PackageManifest;
 
     /** Validate mandatory fields for the target package */
     validateManifestMandatoryFields(

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -151,7 +151,7 @@ export function loadConfigFromFile(): IsolateConfig {
   }
 
   if (jsonExists) {
-    return readTypedJsonSync<IsolateConfig>(jsonConfigPath);
+    return readTypedJsonSync(jsonConfigPath) as IsolateConfig;
   }
 
   return {};

--- a/src/lib/lockfile/helpers/bun-lockfile.ts
+++ b/src/lib/lockfile/helpers/bun-lockfile.ts
@@ -134,6 +134,11 @@ export function collectRequiredPackages(
   return required;
 }
 
+/**
+ * Push any names from a dependency map onto the BFS queue, skipping anything
+ * already marked required so we don't revisit it. `deps` is typed as `unknown`
+ * because it comes from a freshly-parsed lockfile entry with no schema.
+ */
 function enqueueDeps(
   deps: unknown,
   required: Set<string>,

--- a/src/lib/lockfile/helpers/bun-lockfile.ts
+++ b/src/lib/lockfile/helpers/bun-lockfile.ts
@@ -127,16 +127,22 @@ export function collectRequiredPackages(
       "optionalDependencies",
       "peerDependencies",
     ]) {
-      const deps = info[depField];
-      if (deps && typeof deps === "object") {
-        for (const depName of Object.keys(deps as Record<string, unknown>)) {
-          if (!required.has(depName)) {
-            queue.push(depName);
-          }
-        }
-      }
+      enqueueDeps(info[depField], required, queue);
     }
   }
 
   return required;
+}
+
+function enqueueDeps(
+  deps: unknown,
+  required: Set<string>,
+  queue: string[],
+): void {
+  if (!deps || typeof deps !== "object") return;
+  for (const depName of Object.keys(deps as Record<string, unknown>)) {
+    if (!required.has(depName)) {
+      queue.push(depName);
+    }
+  }
 }

--- a/src/lib/lockfile/helpers/generate-bun-lockfile.ts
+++ b/src/lib/lockfile/helpers/generate-bun-lockfile.ts
@@ -68,7 +68,7 @@ export async function generateBunLockfile({
       throw new Error(`Failed to find bun.lock at ${lockfilePath}`);
     }
 
-    const lockfile = readTypedJsonSync<BunLockfile>(lockfilePath);
+    const lockfile = readTypedJsonSync(lockfilePath) as BunLockfile;
 
     /** Compute workspace keys for the target and internal deps */
     const targetWorkspaceKey = path

--- a/src/lib/lockfile/helpers/generate-npm-lockfile.integration.test.ts
+++ b/src/lib/lockfile/helpers/generate-npm-lockfile.integration.test.ts
@@ -1,14 +1,10 @@
 import fs from "fs-extra";
 import os from "node:os";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { generateNpmLockfile } from "./generate-npm-lockfile";
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
-const FIXTURES_DIR = path.join(__dirname, "__fixtures__");
+const FIXTURES_DIR = path.join(import.meta.dirname, "__fixtures__");
 
 /**
  * Copy a fixture's `workspace/` tree into a fresh tmp directory so that the

--- a/src/lib/lockfile/helpers/generate-npm-lockfile.ts
+++ b/src/lib/lockfile/helpers/generate-npm-lockfile.ts
@@ -160,7 +160,7 @@ async function generateFromRootLockfile({
   }
 
   if (typeof targetImporterNode.location !== "string") {
-    throw new Error(
+    throw new TypeError(
       `Target workspace "${targetPackageName}" resolved to a node without a location`,
     );
   }
@@ -445,8 +445,10 @@ export function buildIsolatedLockfileJson({
   }
 
   /** Overlay the isolate root with the adapted target manifest. */
-  const rootEntry: LockfilePackageEntry = { ...outPackages[""] };
-  rootEntry.name = targetPackageManifest.name;
+  const rootEntry: LockfilePackageEntry = {
+    ...outPackages[""],
+    name: targetPackageManifest.name,
+  };
   if (targetPackageManifest.version) {
     rootEntry.version = targetPackageManifest.version;
   }

--- a/src/lib/manifest/helpers/adopt-pnpm-fields-from-root.ts
+++ b/src/lib/manifest/helpers/adopt-pnpm-fields-from-root.ts
@@ -17,9 +17,9 @@ export async function adoptPnpmFieldsFromRoot(
     return targetPackageManifest;
   }
 
-  const rootPackageManifest = await readTypedJson<ProjectManifest>(
+  const rootPackageManifest = (await readTypedJson(
     path.join(workspaceRootDir, "package.json"),
-  );
+  )) as ProjectManifest;
 
   const packageManager = usePackageManager();
 

--- a/src/lib/manifest/helpers/resolve-catalog-dependencies.ts
+++ b/src/lib/manifest/helpers/resolve-catalog-dependencies.ts
@@ -68,16 +68,16 @@ async function loadCatalogSource(
 
     /** Fall back to package.json (Bun format). */
     const rootManifestPath = path.join(workspaceRootDir, "package.json");
-    const rootManifest = await readTypedJson<
-      PackageManifest & {
+    const rootManifest = (await readTypedJson(
+      rootManifestPath,
+    )) as PackageManifest & {
+      catalog?: CatalogMap;
+      catalogs?: CatalogsMap;
+      workspaces?: {
         catalog?: CatalogMap;
         catalogs?: CatalogsMap;
-        workspaces?: {
-          catalog?: CatalogMap;
-          catalogs?: CatalogsMap;
-        };
-      }
-    >(rootManifestPath);
+      };
+    };
 
     return {
       catalog: rootManifest.catalog ?? rootManifest.workspaces?.catalog,

--- a/src/lib/manifest/io.ts
+++ b/src/lib/manifest/io.ts
@@ -3,8 +3,12 @@ import path from "node:path";
 import type { PackageManifest } from "../types";
 import { readTypedJson } from "../utils";
 
-export async function readManifest(packageDir: string) {
-  return readTypedJson<PackageManifest>(path.join(packageDir, "package.json"));
+export async function readManifest(
+  packageDir: string,
+): Promise<PackageManifest> {
+  return (await readTypedJson(
+    path.join(packageDir, "package.json"),
+  )) as PackageManifest;
 }
 
 export async function writeManifest(

--- a/src/lib/output/pack-dependencies.ts
+++ b/src/lib/output/pack-dependencies.ts
@@ -2,7 +2,7 @@ import { got } from "get-or-throw";
 import assert from "node:assert";
 import { useLogger } from "../logger";
 import type { PackagesRegistry } from "../types";
-import { pack } from "../utils";
+import { pack } from "../utils/pack";
 
 /**
  * Pack dependencies so that we extract only the files that are supposed to be

--- a/src/lib/output/process-build-output-files.ts
+++ b/src/lib/output/process-build-output-files.ts
@@ -1,6 +1,7 @@
 import fs from "fs-extra";
 import path from "node:path";
-import { pack, unpack } from "../utils";
+import { unpack } from "../utils";
+import { pack } from "../utils/pack";
 
 export async function processBuildOutputFiles({
   targetPackageDir,

--- a/src/lib/package-manager/helpers/infer-from-manifest.ts
+++ b/src/lib/package-manager/helpers/infer-from-manifest.ts
@@ -11,14 +11,13 @@ import { getLockfileFileName, supportedPackageManagerNames } from "../names";
 export function inferFromManifest(workspaceRoot: string) {
   const log = useLogger();
 
-  const { packageManager: packageManagerString } =
-    readTypedJsonSync<PackageManifest>(
-      path.join(workspaceRoot, "package.json"),
-    );
+  const { packageManager: packageManagerString } = readTypedJsonSync(
+    path.join(workspaceRoot, "package.json"),
+  ) as PackageManifest;
 
   if (!packageManagerString) {
     log.debug("No packageManager field found in root manifest");
-    return;
+    return null;
   }
 
   const [name, version = "*"] = packageManagerString.split("@") as [

--- a/src/lib/package-manager/index.ts
+++ b/src/lib/package-manager/index.ts
@@ -9,7 +9,7 @@ let packageManager: PackageManager | undefined;
 
 export function usePackageManager() {
   if (!packageManager) {
-    throw Error(
+    throw new Error(
       "No package manager detected. Make sure to call detectPackageManager() before usePackageManager()",
     );
   }

--- a/src/lib/package-manager/names.ts
+++ b/src/lib/package-manager/names.ts
@@ -14,15 +14,13 @@ export type PackageManager = {
   packageManagerString?: string;
 };
 
+const lockfileFileNamesByPackageManager: Record<PackageManagerName, string> = {
+  bun: "bun.lock",
+  pnpm: "pnpm-lock.yaml",
+  yarn: "yarn.lock",
+  npm: "package-lock.json",
+};
+
 export function getLockfileFileName(name: PackageManagerName) {
-  switch (name) {
-    case "bun":
-      return "bun.lock";
-    case "pnpm":
-      return "pnpm-lock.yaml";
-    case "yarn":
-      return "yarn.lock";
-    case "npm":
-      return "package-lock.json";
-  }
+  return lockfileFileNamesByPackageManager[name];
 }

--- a/src/lib/patches/collect-installed-names-bun.ts
+++ b/src/lib/patches/collect-installed-names-bun.ts
@@ -41,7 +41,7 @@ export function collectInstalledNamesFromBunLockfile({
       return new Set();
     }
 
-    const lockfile = readTypedJsonSync<BunLockfile>(lockfilePath);
+    const lockfile = readTypedJsonSync(lockfilePath) as BunLockfile;
 
     const targetWorkspaceKey = path
       .relative(workspaceRootDir, targetPackageDir)
@@ -54,7 +54,7 @@ export function collectInstalledNamesFromBunLockfile({
         if (!pkg) return null;
         return pkg.rootRelativeDir.split(path.sep).join(path.posix.sep);
       })
-      .filter((key): key is string => Boolean(key));
+      .filter(Boolean) as string[];
 
     const directDependencyNames = new Set<string>();
 

--- a/src/lib/patches/collect-installed-names-pnpm.ts
+++ b/src/lib/patches/collect-installed-names-pnpm.ts
@@ -71,10 +71,11 @@ export async function collectInstalledNamesFromPnpmLockfile({
 
     const importerIds = [
       targetImporterId,
-      ...internalDepPackageNames
-        .map((name) => packagesRegistry[name]?.rootRelativeDir)
-        .filter((dir): dir is string => Boolean(dir))
-        .map((dir) => toLockfileImporterKey(dir, isRush)),
+      ...(
+        internalDepPackageNames
+          .map((name) => packagesRegistry[name]?.rootRelativeDir)
+          .filter(Boolean) as string[]
+      ).map((dir) => toLockfileImporterKey(dir, isRush)),
     ];
 
     const packages = (lockfile as { packages?: Record<string, PnpmPackage> })
@@ -296,7 +297,7 @@ function refToRelativeV8(reference: string, pkgName: string): string | null {
  */
 function extractPackageName(depPath: string): string {
   const peerStart = indexOfPeersSuffix(depPath);
-  const trimmed = peerStart === -1 ? depPath : depPath.substring(0, peerStart);
+  const trimmed = peerStart === -1 ? depPath : depPath.slice(0, peerStart);
 
   if (trimmed.startsWith("/")) {
     /** v8 v5-style: `/<name>/<version>` */

--- a/src/lib/patches/copy-patches.ts
+++ b/src/lib/patches/copy-patches.ts
@@ -50,9 +50,9 @@ export async function copyPatches({
    */
   if (packageManagerName === "pnpm") {
     try {
-      const pnpmSettings = readTypedYamlSync<PnpmSettings>(
+      const pnpmSettings = readTypedYamlSync(
         path.join(workspaceRootDir, "pnpm-workspace.yaml"),
-      );
+      ) as PnpmSettings | undefined;
       patchedDependencies = pnpmSettings?.patchedDependencies;
     } catch (error) {
       log.warn(
@@ -73,9 +73,9 @@ export async function copyPatches({
     }
 
     try {
-      const workspaceRootManifest = await readTypedJson<PackageManifest>(
+      const workspaceRootManifest = (await readTypedJson(
         path.join(workspaceRootDir, "package.json"),
-      );
+      )) as PackageManifest;
       /** PNPM stores patches under pnpm.patchedDependencies, Bun at the top level */
       patchedDependencies =
         workspaceRootManifest?.pnpm?.patchedDependencies ??

--- a/src/lib/patches/write-isolate-pnpm-workspace.ts
+++ b/src/lib/patches/write-isolate-pnpm-workspace.ts
@@ -39,7 +39,7 @@ export function writeIsolatePnpmWorkspace({
   let settings: PnpmSettings | undefined;
 
   try {
-    settings = readTypedYamlSync<PnpmSettings>(sourcePath);
+    settings = readTypedYamlSync(sourcePath) as PnpmSettings | undefined;
   } catch (error) {
     log.warn(
       `Could not read pnpm-workspace.yaml, falling back to verbatim copy: ${error instanceof Error ? error.message : String(error)}`,

--- a/src/lib/registry/create-packages-registry.ts
+++ b/src/lib/registry/create-packages-registry.ts
@@ -37,14 +37,14 @@ export async function createPackagesRegistry(
         log.warn(
           `Ignoring directory ${rootRelativeDir} because it does not contain a package.json file`,
         );
-        return;
+        return null;
       }
 
       log.debug(`Registering package ${rootRelativeDir}`);
 
-      const manifest = await readTypedJson<PackageManifest>(
+      const manifest = (await readTypedJson(
         path.join(absoluteDir, "package.json"),
-      );
+      )) as PackageManifest;
 
       return {
         manifest,
@@ -76,9 +76,9 @@ function listWorkspacePackages(
   workspaceRootDir: string,
 ) {
   if (isRushWorkspace(workspaceRootDir)) {
-    const rushConfig = readTypedJsonSync<RushConfig>(
+    const rushConfig = readTypedJsonSync(
       path.join(workspaceRootDir, "rush.json"),
-    );
+    ) as RushConfig;
 
     return rushConfig.projects.map(({ projectFolder }) => projectFolder);
   } else {

--- a/src/lib/registry/helpers/find-packages-globs.ts
+++ b/src/lib/registry/helpers/find-packages-globs.ts
@@ -13,16 +13,16 @@ import {
  * monorepo. This configuration is dependent on the package manager used, and I
  * don't know if we're covering all cases yet...
  */
-export function findPackagesGlobs(workspaceRootDir: string) {
+export function findPackagesGlobs(workspaceRootDir: string): string[] {
   const log = useLogger();
 
   const packageManager = usePackageManager();
 
   switch (packageManager.name) {
     case "pnpm": {
-      const workspaceConfig = readTypedYamlSync<{ packages: string[] }>(
+      const workspaceConfig = readTypedYamlSync(
         path.join(workspaceRootDir, "pnpm-workspace.yaml"),
-      );
+      ) as { packages: string[] } | undefined;
 
       if (!workspaceConfig) {
         throw new Error(
@@ -48,9 +48,9 @@ export function findPackagesGlobs(workspaceRootDir: string) {
         "package.json",
       );
 
-      const { workspaces } = readTypedJsonSync<{ workspaces: string[] }>(
-        workspaceRootManifestPath,
-      );
+      const { workspaces } = readTypedJsonSync(workspaceRootManifestPath) as {
+        workspaces: string[];
+      };
 
       if (!workspaces) {
         throw new Error(
@@ -60,21 +60,22 @@ export function findPackagesGlobs(workspaceRootDir: string) {
 
       if (Array.isArray(workspaces)) {
         return workspaces;
-      } else {
-        /**
-         * For Yarn, workspaces could be defined as an object with { packages:
-         * [], nohoist: [] }. See
-         * https://classic.yarnpkg.com/blog/2018/02/15/nohoist/
-         */
-        const workspacesObject = workspaces as { packages?: string[] };
-
-        assert(
-          workspacesObject.packages,
-          "workspaces.packages must be an array",
-        );
-
-        return workspacesObject.packages;
       }
+
+      /**
+       * For Yarn, workspaces could be defined as an object with { packages: [],
+       * nohoist: [] }. See
+       * https://classic.yarnpkg.com/blog/2018/02/15/nohoist/
+       */
+      const workspacesObject = workspaces as { packages?: string[] };
+
+      assert(workspacesObject.packages, "workspaces.packages must be an array");
+
+      return workspacesObject.packages;
     }
+    default:
+      throw new Error(
+        `Unsupported package manager: ${packageManager.name as string}`,
+      );
   }
 }

--- a/src/lib/registry/helpers/find-packages-globs.ts
+++ b/src/lib/registry/helpers/find-packages-globs.ts
@@ -69,7 +69,10 @@ export function findPackagesGlobs(workspaceRootDir: string): string[] {
        */
       const workspacesObject = workspaces as { packages?: string[] };
 
-      assert(workspacesObject.packages, "workspaces.packages must be an array");
+      assert(
+        Array.isArray(workspacesObject.packages),
+        "workspaces.packages must be an array",
+      );
 
       return workspacesObject.packages;
     }

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -8,7 +8,6 @@ export * from "./is-present";
 export * from "./is-rush-workspace";
 export * from "./json";
 export * from "./log-paths";
-export * from "./pack";
 export * from "./reset-isolate-dir";
 export * from "./unpack";
 export * from "./yaml";

--- a/src/lib/utils/json.ts
+++ b/src/lib/utils/json.ts
@@ -3,13 +3,12 @@ import stripJsonComments from "strip-json-comments";
 import { getErrorMessage } from "./get-error-message";
 
 /** @todo Pass in zod schema and validate */
-export function readTypedJsonSync<T>(filePath: string) {
+export function readTypedJsonSync(filePath: string): unknown {
   try {
     const rawContent = fs.readFileSync(filePath, "utf-8");
-    const data = JSON.parse(
+    return JSON.parse(
       stripJsonComments(rawContent, { trailingCommas: true }),
-    ) as T;
-    return data;
+    ) as unknown;
   } catch (error) {
     throw new Error(
       `Failed to read JSON from ${filePath}: ${getErrorMessage(error)}`,
@@ -18,13 +17,12 @@ export function readTypedJsonSync<T>(filePath: string) {
   }
 }
 
-export async function readTypedJson<T>(filePath: string) {
+export async function readTypedJson(filePath: string): Promise<unknown> {
   try {
     const rawContent = await fs.readFile(filePath, "utf-8");
-    const data = JSON.parse(
+    return JSON.parse(
       stripJsonComments(rawContent, { trailingCommas: true }),
-    ) as T;
-    return data;
+    ) as unknown;
   } catch (error) {
     throw new Error(
       `Failed to read JSON from ${filePath}: ${getErrorMessage(error)}`,

--- a/src/lib/utils/pack.ts
+++ b/src/lib/utils/pack.ts
@@ -30,14 +30,14 @@ export async function pack(srcDir: string, dstDir: string) {
         exec(
           `pnpm pack --pack-destination "${dstDir}"`,
           execOptions,
-          (err, stdout) => {
+          (err, out) => {
             if (err) {
               log.error(getErrorMessage(err));
               reject(err);
               return;
             }
 
-            resolve(stdout);
+            resolve(out);
           },
         );
       })
@@ -45,13 +45,13 @@ export async function pack(srcDir: string, dstDir: string) {
         exec(
           `npm pack --pack-destination "${dstDir}"`,
           execOptions,
-          (err, stdout) => {
+          (err, out) => {
             if (err) {
               reject(err);
               return;
             }
 
-            resolve(stdout);
+            resolve(out);
           },
         );
       });

--- a/src/lib/utils/pack.ts
+++ b/src/lib/utils/pack.ts
@@ -25,19 +25,19 @@ export async function pack(srcDir: string, dstDir: string) {
    * PNPM pack seems to be a lot faster than NPM pack, so when PNPM is detected
    * we use that instead.
    */
-  const stdout = shouldUsePnpmPack()
+  const packStdout = shouldUsePnpmPack()
     ? await new Promise<string>((resolve, reject) => {
         exec(
           `pnpm pack --pack-destination "${dstDir}"`,
           execOptions,
-          (err, out) => {
+          (err, stdout) => {
             if (err) {
               log.error(getErrorMessage(err));
               reject(err);
               return;
             }
 
-            resolve(out);
+            resolve(stdout);
           },
         );
       })
@@ -45,20 +45,23 @@ export async function pack(srcDir: string, dstDir: string) {
         exec(
           `npm pack --pack-destination "${dstDir}"`,
           execOptions,
-          (err, out) => {
+          (err, stdout) => {
             if (err) {
               reject(err);
               return;
             }
 
-            resolve(out);
+            resolve(stdout);
           },
         );
       });
 
-  const lastLine = stdout.trim().split("\n").at(-1);
+  const lastLine = packStdout.trim().split("\n").at(-1);
 
-  assert(lastLine, `Failed to parse last line from stdout: ${stdout.trim()}`);
+  assert(
+    lastLine,
+    `Failed to parse last line from stdout: ${packStdout.trim()}`,
+  );
 
   const fileName = path.basename(lastLine);
 

--- a/src/lib/utils/reset-isolate-dir.test.ts
+++ b/src/lib/utils/reset-isolate-dir.test.ts
@@ -18,7 +18,9 @@ async function waitFor(
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     if (await predicate()) return;
-    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+    await new Promise((resolve) => {
+      setTimeout(resolve, intervalMs);
+    });
   }
   throw new Error(`Timed out after ${timeoutMs}ms waiting for predicate`);
 }

--- a/src/lib/utils/yaml.ts
+++ b/src/lib/utils/yaml.ts
@@ -2,12 +2,11 @@ import fs from "fs-extra";
 import yaml from "yaml";
 import { getErrorMessage } from "./get-error-message";
 
-export function readTypedYamlSync<T>(filePath: string) {
+/** @todo Add some zod validation maybe */
+export function readTypedYamlSync(filePath: string): unknown {
   try {
     const rawContent = fs.readFileSync(filePath, "utf-8");
-    const data = yaml.parse(rawContent) as unknown;
-    /** @todo Add some zod validation maybe */
-    return data as T;
+    return yaml.parse(rawContent) as unknown;
   } catch (error) {
     throw new Error(
       `Failed to read YAML from ${filePath}: ${getErrorMessage(error)}`,
@@ -16,7 +15,7 @@ export function readTypedYamlSync<T>(filePath: string) {
   }
 }
 
-export function writeTypedYamlSync<T>(filePath: string, content: T) {
-  /** @todo Add some zod validation maybe */
+/** @todo Add some zod validation maybe */
+export function writeTypedYamlSync(filePath: string, content: unknown) {
   fs.writeFileSync(filePath, yaml.stringify(content), "utf-8");
 }


### PR DESCRIPTION
Resolves the 28 outstanding oxlint warnings, then flips the relevant categories (`suspicious`, `perf`, `pedantic`) and per-rule entries (`import/no-cycle`, `import/no-duplicates`, `typescript/no-unused-vars`, `no-console`) from `warn` to `error` so future regressions fail CI instead of silently piling up.

Notable refactors driven by the rules:

- Break the `utils` ↔ `package-manager` import cycle by dropping `pack` from the `utils` barrel; the two callers in `output/` import it directly from `../utils/pack`.
- Replace the exhaustive switch in `getLockfileFileName` with a `Record` lookup, and add an explicit unreachable `default` branch in `findPackagesGlobs`.
- Drop the misleading generic from `readTypedJson(Sync)` / `readTypedYamlSync` / `writeTypedYamlSync`; the cast moves to call sites (still flagged TODO for proper schema validation).
- Extract `enqueueDeps` from the bun-lockfile transitive walk to cut nesting depth.
- Rename `stdout` callbacks in `pack.ts` and the inner `isolate` function plus its `config` binding to silence `no-shadow`.

Scope: tooling (oxlint)
Visibility: internal