### PR TITLE
Fix publish workflow + switch internal alias to subpath imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
   ],
   "type": "module",
   "types": "./dist/index.d.mts",
+  "imports": {
+    "#/*": "./src/*"
+  },
   "exports": {
     ".": "./dist/index.mjs",
     "./isolate-bin": "./dist/isolate-bin.mjs",

--- a/src/get-internal-package-names.test.ts
+++ b/src/get-internal-package-names.test.ts
@@ -14,7 +14,7 @@ const mockDetectPackageManager = vi.fn(
   (_workspaceRootDir: string) => packageManagerResult,
 );
 
-vi.mock("~/lib/package-manager", () => ({
+vi.mock("#/lib/package-manager", () => ({
   usePackageManager: () => packageManagerResult,
   detectPackageManager: (workspaceRootDir: string) =>
     mockDetectPackageManager(workspaceRootDir),

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -12,7 +12,7 @@ const mockLogger = {
   error: vi.fn(),
 };
 
-vi.mock("~/lib/logger", () => ({
+vi.mock("#/lib/logger", () => ({
   useLogger: () => mockLogger,
 }));
 

--- a/src/lib/lockfile/helpers/generate-bun-lockfile.test.ts
+++ b/src/lib/lockfile/helpers/generate-bun-lockfile.test.ts
@@ -13,8 +13,8 @@ vi.mock("fs-extra", () => ({
 }));
 
 /** Mock the utils */
-vi.mock("~/lib/utils", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("~/lib/utils")>();
+vi.mock("#/lib/utils", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("#/lib/utils")>();
   return {
     getErrorMessage: vi.fn((err: Error) => err.message),
     getPackageName: actual.getPackageName,
@@ -23,7 +23,7 @@ vi.mock("~/lib/utils", async (importOriginal) => {
 });
 
 const fs = vi.mocked((await import("fs-extra")).default);
-const { readTypedJsonSync } = vi.mocked(await import("~/lib/utils"));
+const { readTypedJsonSync } = vi.mocked(await import("#/lib/utils"));
 
 /** Reusable packages registry fixture */
 function createPackagesRegistry() {

--- a/src/lib/lockfile/helpers/generate-bun-lockfile.ts
+++ b/src/lib/lockfile/helpers/generate-bun-lockfile.ts
@@ -1,13 +1,13 @@
 import fs from "fs-extra";
 import { got } from "get-or-throw";
 import path from "node:path";
-import { useLogger } from "~/lib/logger";
-import type { PackagesRegistry } from "~/lib/types";
+import { useLogger } from "#/lib/logger";
+import type { PackagesRegistry } from "#/lib/types";
 import {
   getErrorMessage,
   getPackageName,
   readTypedJsonSync,
-} from "~/lib/utils";
+} from "#/lib/utils";
 import {
   type BunLockfile,
   type BunWorkspaceEntry,

--- a/src/lib/lockfile/helpers/generate-npm-lockfile.ts
+++ b/src/lib/lockfile/helpers/generate-npm-lockfile.ts
@@ -1,9 +1,9 @@
 import Arborist from "@npmcli/arborist";
 import fs from "fs-extra";
 import path from "node:path";
-import { useLogger } from "~/lib/logger";
-import type { PackageManifest, PackagesRegistry } from "~/lib/types";
-import { getErrorMessage } from "~/lib/utils";
+import { useLogger } from "#/lib/logger";
+import type { PackageManifest, PackagesRegistry } from "#/lib/types";
+import { getErrorMessage } from "#/lib/utils";
 import { loadNpmConfig } from "./load-npm-config";
 
 /**

--- a/src/lib/lockfile/helpers/generate-pnpm-lockfile.test.ts
+++ b/src/lib/lockfile/helpers/generate-pnpm-lockfile.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { generatePnpmLockfile } from "./generate-pnpm-lockfile";
 
 /** Mock utils */
-vi.mock("~/lib/utils", () => ({
+vi.mock("#/lib/utils", () => ({
   getErrorMessage: vi.fn((err: Error) => err.message),
   isRushWorkspace: vi.fn(() => false),
 }));
@@ -57,7 +57,7 @@ const { pruneLockfile: pruneLockfile_v9 } = vi.mocked(
   await import("pnpm_prune_lockfile_v9"),
 );
 
-const { isRushWorkspace } = vi.mocked(await import("~/lib/utils"));
+const { isRushWorkspace } = vi.mocked(await import("#/lib/utils"));
 
 /** Reusable lockfile fixture */
 function createMockLockfile() {

--- a/src/lib/lockfile/helpers/generate-pnpm-lockfile.ts
+++ b/src/lib/lockfile/helpers/generate-pnpm-lockfile.ts
@@ -13,9 +13,9 @@ import {
 import { pruneLockfile as pruneLockfile_v8 } from "pnpm_prune_lockfile_v8";
 import { pruneLockfile as pruneLockfile_v9 } from "pnpm_prune_lockfile_v9";
 import { pick } from "remeda";
-import { useLogger } from "~/lib/logger";
-import type { PackageManifest, PackagesRegistry, PatchFile } from "~/lib/types";
-import { getErrorMessage, isRushWorkspace } from "~/lib/utils";
+import { useLogger } from "#/lib/logger";
+import type { PackageManifest, PackagesRegistry, PatchFile } from "#/lib/types";
+import { getErrorMessage, isRushWorkspace } from "#/lib/utils";
 import { pnpmMapImporter } from "./pnpm-map-importer";
 
 export async function generatePnpmLockfile({

--- a/src/lib/lockfile/helpers/generate-yarn-lockfile.ts
+++ b/src/lib/lockfile/helpers/generate-yarn-lockfile.ts
@@ -1,8 +1,8 @@
 import fs from "fs-extra";
 import { execSync } from "node:child_process";
 import path from "node:path";
-import { useLogger } from "~/lib/logger";
-import { getErrorMessage, isRushWorkspace } from "~/lib/utils";
+import { useLogger } from "#/lib/logger";
+import { getErrorMessage, isRushWorkspace } from "#/lib/utils";
 
 /**
  * Generate an isolated / pruned lockfile, based on the existing lockfile from

--- a/src/lib/lockfile/process-lockfile.test.ts
+++ b/src/lib/lockfile/process-lockfile.test.ts
@@ -3,7 +3,7 @@ import { processLockfile } from "./process-lockfile";
 import type { IsolateConfigResolved } from "../config";
 
 /** Mock the package manager detection */
-vi.mock("~/lib/package-manager", () => ({
+vi.mock("#/lib/package-manager", () => ({
   usePackageManager: vi.fn(),
 }));
 
@@ -15,7 +15,7 @@ vi.mock("./helpers", () => ({
   generateYarnLockfile: vi.fn(),
 }));
 
-const { usePackageManager } = vi.mocked(await import("~/lib/package-manager"));
+const { usePackageManager } = vi.mocked(await import("#/lib/package-manager"));
 const {
   generateBunLockfile,
   generateNpmLockfile,

--- a/src/lib/manifest/helpers/adapt-internal-package-manifests.test.ts
+++ b/src/lib/manifest/helpers/adapt-internal-package-manifests.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import type { PackageManifest, PackagesRegistry } from "~/lib/types";
+import type { PackageManifest, PackagesRegistry } from "#/lib/types";
 
 /** Mock dependencies */
-vi.mock("~/lib/package-manager", () => ({
+vi.mock("#/lib/package-manager", () => ({
   usePackageManager: vi.fn(),
 }));
 
@@ -18,7 +18,7 @@ vi.mock("./resolve-catalog-dependencies", () => ({
   resolveCatalogDependencies: vi.fn((deps) => Promise.resolve(deps)),
 }));
 
-const { usePackageManager } = vi.mocked(await import("~/lib/package-manager"));
+const { usePackageManager } = vi.mocked(await import("#/lib/package-manager"));
 
 const { writeManifest } = vi.mocked(await import("../io"));
 

--- a/src/lib/manifest/helpers/adapt-internal-package-manifests.ts
+++ b/src/lib/manifest/helpers/adapt-internal-package-manifests.ts
@@ -1,8 +1,8 @@
 import { got } from "get-or-throw";
 import path from "node:path";
 import { omit } from "remeda";
-import { usePackageManager } from "~/lib/package-manager";
-import type { PackagesRegistry } from "~/lib/types";
+import { usePackageManager } from "#/lib/package-manager";
+import type { PackagesRegistry } from "#/lib/types";
 import { writeManifest } from "../io";
 import { adaptManifestInternalDeps } from "./adapt-manifest-internal-deps";
 import { resolveCatalogDependencies } from "./resolve-catalog-dependencies";

--- a/src/lib/manifest/helpers/adapt-manifest-internal-deps.ts
+++ b/src/lib/manifest/helpers/adapt-manifest-internal-deps.ts
@@ -1,4 +1,4 @@
-import type { PackageManifest, PackagesRegistry } from "~/lib/types";
+import type { PackageManifest, PackagesRegistry } from "#/lib/types";
 import { patchInternalEntries } from "./patch-internal-entries";
 
 /**

--- a/src/lib/manifest/helpers/adopt-pnpm-fields-from-root.test.ts
+++ b/src/lib/manifest/helpers/adopt-pnpm-fields-from-root.test.ts
@@ -7,20 +7,20 @@ import type {
 import { adoptPnpmFieldsFromRoot } from "./adopt-pnpm-fields-from-root";
 
 /** Mock the dependencies */
-vi.mock("~/lib/utils", () => ({
+vi.mock("#/lib/utils", () => ({
   isRushWorkspace: vi.fn(),
   readTypedJson: vi.fn(),
 }));
 
-vi.mock("~/lib/package-manager", () => ({
+vi.mock("#/lib/package-manager", () => ({
   usePackageManager: vi.fn(() => ({ name: "pnpm", majorVersion: 9 })),
 }));
 
 const { isRushWorkspace, readTypedJson } = vi.mocked(
-  await import("~/lib/utils"),
+  await import("#/lib/utils"),
 );
 
-const { usePackageManager } = vi.mocked(await import("~/lib/package-manager"));
+const { usePackageManager } = vi.mocked(await import("#/lib/package-manager"));
 
 describe("adoptPnpmFieldsFromRoot", () => {
   beforeEach(() => {

--- a/src/lib/manifest/helpers/adopt-pnpm-fields-from-root.ts
+++ b/src/lib/manifest/helpers/adopt-pnpm-fields-from-root.ts
@@ -1,8 +1,8 @@
 import type { ProjectManifest, PnpmSettings } from "@pnpm/types";
 import path from "node:path";
-import { usePackageManager } from "~/lib/package-manager";
-import type { PackageManifest } from "~/lib/types";
-import { isRushWorkspace, readTypedJson } from "~/lib/utils";
+import { usePackageManager } from "#/lib/package-manager";
+import type { PackageManifest } from "#/lib/types";
+import { isRushWorkspace, readTypedJson } from "#/lib/utils";
 
 /**
  * Adopts workspace-level fields from the root package manifest. For pnpm this

--- a/src/lib/manifest/helpers/resolve-catalog-dependencies.test.ts
+++ b/src/lib/manifest/helpers/resolve-catalog-dependencies.test.ts
@@ -9,7 +9,7 @@ const mockLogger = {
   warn: vi.fn(),
 };
 
-vi.mock("~/lib/logger", () => ({
+vi.mock("#/lib/logger", () => ({
   useLogger: vi.fn(() => mockLogger),
 }));
 

--- a/src/lib/manifest/helpers/resolve-catalog-dependencies.ts
+++ b/src/lib/manifest/helpers/resolve-catalog-dependencies.ts
@@ -1,8 +1,8 @@
 import fs from "fs-extra";
 import path from "node:path";
-import { useLogger } from "~/lib/logger";
-import type { PackageManifest } from "~/lib/types";
-import { readTypedJson } from "~/lib/utils";
+import { useLogger } from "#/lib/logger";
+import type { PackageManifest } from "#/lib/types";
+import { readTypedJson } from "#/lib/utils";
 import yaml from "yaml";
 
 type CatalogMap = Record<string, string>;

--- a/src/lib/package-manager/helpers/infer-from-files.ts
+++ b/src/lib/package-manager/helpers/infer-from-files.ts
@@ -1,8 +1,8 @@
 import fs from "fs-extra";
 import { execSync } from "node:child_process";
 import path from "node:path";
-import { getErrorMessage } from "~/lib/utils";
-import { getMajorVersion } from "~/lib/utils/get-major-version";
+import { getErrorMessage } from "#/lib/utils";
+import { getMajorVersion } from "#/lib/utils/get-major-version";
 import type { PackageManager, PackageManagerName } from "../names";
 import { getLockfileFileName, supportedPackageManagerNames } from "../names";
 

--- a/src/lib/package-manager/helpers/infer-from-manifest.ts
+++ b/src/lib/package-manager/helpers/infer-from-manifest.ts
@@ -1,8 +1,8 @@
 import fs from "fs-extra";
 import assert from "node:assert";
 import path from "node:path";
-import { useLogger } from "~/lib/logger";
-import { getMajorVersion } from "~/lib/utils/get-major-version";
+import { useLogger } from "#/lib/logger";
+import { getMajorVersion } from "#/lib/utils/get-major-version";
 import type { PackageManifest } from "../../types";
 import { readTypedJsonSync } from "../../utils";
 import type { PackageManagerName } from "../names";

--- a/src/lib/patches/collect-installed-names-bun.test.ts
+++ b/src/lib/patches/collect-installed-names-bun.test.ts
@@ -7,12 +7,12 @@ vi.mock("fs-extra", () => ({
   },
 }));
 
-vi.mock("~/lib/utils", () => ({
+vi.mock("#/lib/utils", () => ({
   readTypedJsonSync: vi.fn(),
 }));
 
 const fs = vi.mocked((await import("fs-extra")).default);
-const { readTypedJsonSync } = vi.mocked(await import("~/lib/utils"));
+const { readTypedJsonSync } = vi.mocked(await import("#/lib/utils"));
 
 const baseArgs = {
   workspaceRootDir: "/workspace",

--- a/src/lib/patches/collect-installed-names-bun.ts
+++ b/src/lib/patches/collect-installed-names-bun.ts
@@ -4,10 +4,10 @@ import {
   type BunLockfile,
   collectDependencyNames,
   collectRequiredPackages,
-} from "~/lib/lockfile/helpers/bun-lockfile";
-import { useLogger } from "~/lib/logger";
-import type { PackagesRegistry } from "~/lib/types";
-import { readTypedJsonSync } from "~/lib/utils";
+} from "#/lib/lockfile/helpers/bun-lockfile";
+import { useLogger } from "#/lib/logger";
+import type { PackagesRegistry } from "#/lib/types";
+import { readTypedJsonSync } from "#/lib/utils";
 
 /**
  * Walk the workspace bun.lock starting from the target package and its

--- a/src/lib/patches/collect-installed-names-pnpm.test.ts
+++ b/src/lib/patches/collect-installed-names-pnpm.test.ts
@@ -15,7 +15,7 @@ vi.mock("pnpm_lockfile_file_v9", () => ({
   ),
 }));
 
-vi.mock("~/lib/utils", () => ({
+vi.mock("#/lib/utils", () => ({
   getPackageName: vi.fn((spec: string) => {
     if (spec.startsWith("@")) {
       const parts = spec.split("@");

--- a/src/lib/patches/collect-installed-names-pnpm.ts
+++ b/src/lib/patches/collect-installed-names-pnpm.ts
@@ -7,9 +7,9 @@ import {
   getLockfileImporterId as getLockfileImporterId_v9,
   readWantedLockfile as readWantedLockfile_v9,
 } from "pnpm_lockfile_file_v9";
-import { useLogger } from "~/lib/logger";
-import type { PackagesRegistry } from "~/lib/types";
-import { getPackageName, isRushWorkspace } from "~/lib/utils";
+import { useLogger } from "#/lib/logger";
+import type { PackagesRegistry } from "#/lib/types";
+import { getPackageName, isRushWorkspace } from "#/lib/utils";
 
 /**
  * Walk the workspace pnpm lockfile starting from the target package and its

--- a/src/lib/patches/copy-patches.test.ts
+++ b/src/lib/patches/copy-patches.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import type { PackageManifest, PnpmSettings } from "~/lib/types";
+import type { PackageManifest, PnpmSettings } from "#/lib/types";
 import { copyPatches } from "./copy-patches";
 
 /** Mock fs-extra */
@@ -12,7 +12,7 @@ vi.mock("fs-extra", () => ({
 }));
 
 /** Mock the utils */
-vi.mock("~/lib/utils", () => ({
+vi.mock("#/lib/utils", () => ({
   filterPatchedDependencies: vi.fn(),
   getIsolateRelativeLogPath: vi.fn((p: string) => p),
   getPackageName: vi.fn((spec: string) => {
@@ -30,7 +30,7 @@ vi.mock("~/lib/utils", () => ({
 }));
 
 /** Mock the package manager */
-vi.mock("~/lib/package-manager", () => ({
+vi.mock("#/lib/package-manager", () => ({
   usePackageManager: vi.fn(() => ({ name: "pnpm", majorVersion: 9 })),
 }));
 
@@ -51,8 +51,8 @@ vi.mock("pnpm_lockfile_file_v9", () => ({
 
 const fs = vi.mocked((await import("fs-extra")).default);
 const { filterPatchedDependencies, readTypedJson, readTypedYamlSync } =
-  vi.mocked(await import("~/lib/utils"));
-const { usePackageManager } = vi.mocked(await import("~/lib/package-manager"));
+  vi.mocked(await import("#/lib/utils"));
+const { usePackageManager } = vi.mocked(await import("#/lib/package-manager"));
 const { readWantedLockfile: readWantedLockfile_v9 } = vi.mocked(
   await import("pnpm_lockfile_file_v9"),
 );

--- a/src/lib/patches/copy-patches.ts
+++ b/src/lib/patches/copy-patches.ts
@@ -2,22 +2,22 @@ import fs from "fs-extra";
 import path from "node:path";
 import { readWantedLockfile as readWantedLockfile_v8 } from "pnpm_lockfile_file_v8";
 import { readWantedLockfile as readWantedLockfile_v9 } from "pnpm_lockfile_file_v9";
-import { useLogger } from "~/lib/logger";
-import { usePackageManager } from "~/lib/package-manager";
-import { collectReachablePackageNames } from "~/lib/registry";
+import { useLogger } from "#/lib/logger";
+import { usePackageManager } from "#/lib/package-manager";
+import { collectReachablePackageNames } from "#/lib/registry";
 import type {
   PackageManifest,
   PackagesRegistry,
   PatchFile,
   PnpmSettings,
-} from "~/lib/types";
+} from "#/lib/types";
 import {
   filterPatchedDependencies,
   getRootRelativeLogPath,
   isRushWorkspace,
   readTypedJson,
   readTypedYamlSync,
-} from "~/lib/utils";
+} from "#/lib/utils";
 import { collectInstalledNamesFromBunLockfile } from "./collect-installed-names-bun";
 import { collectInstalledNamesFromPnpmLockfile } from "./collect-installed-names-pnpm";
 

--- a/src/lib/patches/write-isolate-pnpm-workspace.test.ts
+++ b/src/lib/patches/write-isolate-pnpm-workspace.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { PatchFile } from "~/lib/types";
+import type { PatchFile } from "#/lib/types";
 import { writeIsolatePnpmWorkspace } from "./write-isolate-pnpm-workspace";
 
 vi.mock("fs-extra", () => ({
@@ -8,14 +8,14 @@ vi.mock("fs-extra", () => ({
   },
 }));
 
-vi.mock("~/lib/utils", () => ({
+vi.mock("#/lib/utils", () => ({
   readTypedYamlSync: vi.fn(),
   writeTypedYamlSync: vi.fn(),
 }));
 
 const fs = vi.mocked((await import("fs-extra")).default);
 const { readTypedYamlSync, writeTypedYamlSync } = vi.mocked(
-  await import("~/lib/utils"),
+  await import("#/lib/utils"),
 );
 
 const workspaceRootDir = "/workspace";

--- a/src/lib/patches/write-isolate-pnpm-workspace.ts
+++ b/src/lib/patches/write-isolate-pnpm-workspace.ts
@@ -1,8 +1,8 @@
 import fs from "fs-extra";
 import path from "node:path";
-import { useLogger } from "~/lib/logger";
-import type { PatchFile, PnpmSettings } from "~/lib/types";
-import { readTypedYamlSync, writeTypedYamlSync } from "~/lib/utils";
+import { useLogger } from "#/lib/logger";
+import type { PatchFile, PnpmSettings } from "#/lib/types";
+import { readTypedYamlSync, writeTypedYamlSync } from "#/lib/utils";
 
 /**
  * Copy `pnpm-workspace.yaml` from the workspace root to the isolate directory,

--- a/src/lib/registry/collect-reachable-package-names.test.ts
+++ b/src/lib/registry/collect-reachable-package-names.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { PackageManifest, PackagesRegistry } from "~/lib/types";
+import type { PackageManifest, PackagesRegistry } from "#/lib/types";
 import { collectReachablePackageNames } from "./collect-reachable-package-names";
 
 function entry(manifest: PackageManifest) {

--- a/src/lib/registry/list-internal-packages.test.ts
+++ b/src/lib/registry/list-internal-packages.test.ts
@@ -1,10 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { PackageManifest, PackagesRegistry } from "~/lib/types";
+import type { PackageManifest, PackagesRegistry } from "#/lib/types";
 import { listInternalPackages } from "./list-internal-packages";
 
 const mockWarn = vi.fn();
 
-vi.mock("~/lib/logger", () => ({
+vi.mock("#/lib/logger", () => ({
   useLogger: () => ({
     debug: vi.fn(),
     info: vi.fn(),

--- a/src/lib/utils/filter-patched-dependencies.test.ts
+++ b/src/lib/utils/filter-patched-dependencies.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { PackageManifest } from "~/lib/types";
+import type { PackageManifest } from "#/lib/types";
 import { filterPatchedDependencies } from "./filter-patched-dependencies";
 
 describe("filterPatchedDependencies", () => {

--- a/src/lib/utils/filter-patched-dependencies.ts
+++ b/src/lib/utils/filter-patched-dependencies.ts
@@ -1,5 +1,5 @@
-import { useLogger } from "~/lib/logger";
-import type { PackageManifest } from "~/lib/types";
+import { useLogger } from "#/lib/logger";
+import type { PackageManifest } from "#/lib/types";
 import { getPackageName } from "./get-package-name";
 
 /**

--- a/src/testing/setup.ts
+++ b/src/testing/setup.ts
@@ -1,7 +1,7 @@
 import { vi } from "vitest";
 
 /** Mock the logger for all tests to prevent console output during tests */
-vi.mock("~/lib/logger", () => ({
+vi.mock("#/lib/logger", () => ({
   useLogger: () => ({
     debug: vi.fn(),
     info: vi.fn(),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,8 @@
 {
   "extends": "@codecompose/typescript-config/library",
   "compilerOptions": {
-    /** tsgo wants baseUrl to be removed */
-    "baseUrl": null,
-    /** tsgo doesn't inherit paths from base config  */
     "paths": {
-      "~/*": ["./src/*"]
+      "#/*": ["./src/*"]
     }
   }
 }

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -10,5 +10,4 @@ export default defineConfig({
   sourcemap: true,
   dts: true,
   clean: true,
-  exports: true,
 });


### PR DESCRIPTION
Two independent changes on this branch.

## Publish workflow fix

The publish workflow (`.github/workflows/publish.yml`) was failing at the `Bump version` step with:

```
npm error Git working directory not clean.
```

Root cause: `tsdown.config.ts` had `exports: true`, which makes tsdown rewrite `package.json`'s `bin` and `exports` fields from the entry config on every build. With the entries named `index` and `isolate-bin`, tsdown strips the `isolate` bin alias that PR #188 explicitly restored alongside `isolate-package` for backwards compatibility. Locally that just leaves a dirty diff after `pnpm build`; in CI, `pnpm build` dirties the tree and the subsequent `npm version` aborts.

Fix: remove `exports: true` so the manually maintained `bin`/`exports` in `package.json` is the source of truth, and `pnpm build` no longer mutates the working tree.

## Internal alias: `~/*` -> `#/*` via subpath imports

Replace the TypeScript-only `~/*` path alias with Node subpath imports. The mapping now lives in `package.json` as `"imports": { "#/*": "./src/*" }`, which is understood natively by Node, bundlers, and TypeScript — not only by tsc via tsconfig paths.

A matching `paths` entry remains in `tsconfig.json` because TS's bundler resolution of the `imports` field does not do directory-index fallback (so barrel imports like `#/lib/utils` -> `src/lib/utils/index.ts` would otherwise fail in tsc). The package.json `imports` field is the source of truth at runtime.

Engines is already `>=22.22.1`, well above the 14.6 cutoff for stable subpath imports.

Scope: packages (isolate-package), infra (publish workflow)
Visibility: internal