### PR TITLE
Preserve catalog: specifiers for pnpm isolates

### DIFF
--- a/src/lib/lockfile/helpers/generate-pnpm-lockfile.test.ts
+++ b/src/lib/lockfile/helpers/generate-pnpm-lockfile.test.ts
@@ -303,6 +303,105 @@ describe("generatePnpmLockfile", () => {
     expect(writtenLockfile.packageExtensionsChecksum).toBe("abc123");
   });
 
+  it("should restore catalogs after pruning, narrowed to referenced importers (#198)", async () => {
+    const lockfile = {
+      lockfileVersion: "9.0",
+      importers: {
+        "apps/my-app": {
+          specifiers: { shared: "workspace:*", lodash: "catalog:" },
+          dependencies: { shared: "link:../../packages/shared" },
+        },
+        "packages/shared": {
+          specifiers: { ramda: "catalog:utils" },
+          dependencies: {},
+        },
+        "packages/other": {
+          specifiers: { unused: "catalog:" },
+          dependencies: {},
+        },
+      },
+      catalogs: {
+        default: {
+          lodash: { specifier: "^4.17.21", version: "4.17.21" },
+          unused: { specifier: "^1.0.0", version: "1.0.0" },
+        },
+        utils: {
+          ramda: { specifier: "^0.30.0", version: "0.30.0" },
+        },
+      },
+      packages: {},
+    };
+    readWantedLockfile_v9.mockResolvedValue(lockfile as never);
+    getLockfileImporterId_v9.mockReturnValue("apps/my-app");
+
+    /** Simulate prune dropping the catalogs snapshot */
+    pruneLockfile_v9.mockImplementation((lf) => {
+      const result = { ...(lf as unknown as Record<string, unknown>) };
+      delete result.catalogs;
+      return result as never;
+    });
+
+    await generatePnpmLockfile({
+      workspaceRootDir: "/workspace",
+      targetPackageDir: "/workspace/apps/my-app",
+      isolateDir: "/workspace/apps/my-app/isolate",
+      internalDepPackageNames: ["shared"],
+      packagesRegistry: {
+        shared: {
+          absoluteDir: "/workspace/packages/shared",
+          rootRelativeDir: "packages/shared",
+          manifest: { name: "shared", version: "1.0.0" },
+        },
+      },
+      targetPackageManifest: { name: "my-app", version: "1.0.0" },
+      majorVersion: 9,
+      includeDevDependencies: false,
+    });
+
+    const writeCall = writeWantedLockfile_v9.mock.calls[0]!;
+    const writtenLockfile = writeCall[1] as {
+      catalogs?: Record<string, Record<string, unknown>>;
+    };
+
+    /**
+     * Only catalog entries referenced by the retained importers (target +
+     * internal dep "shared") are restored. The "unused" entry, referenced only
+     * by the excluded "packages/other", must not leak into the output.
+     */
+    expect(writtenLockfile.catalogs).toEqual({
+      default: { lodash: { specifier: "^4.17.21", version: "4.17.21" } },
+      utils: { ramda: { specifier: "^0.30.0", version: "0.30.0" } },
+    });
+  });
+
+  it("should not set catalogs when the source lockfile has none", async () => {
+    const lockfile = createMockLockfile();
+    readWantedLockfile_v9.mockResolvedValue(lockfile as never);
+    getLockfileImporterId_v9.mockReturnValue("apps/my-app");
+    pruneLockfile_v9.mockImplementation((lf) => lf as never);
+
+    await generatePnpmLockfile({
+      workspaceRootDir: "/workspace",
+      targetPackageDir: "/workspace/apps/my-app",
+      isolateDir: "/workspace/apps/my-app/isolate",
+      internalDepPackageNames: ["shared"],
+      packagesRegistry: {
+        shared: {
+          absoluteDir: "/workspace/packages/shared",
+          rootRelativeDir: "packages/shared",
+          manifest: { name: "shared", version: "1.0.0" },
+        },
+      },
+      targetPackageManifest: { name: "my-app", version: "1.0.0" },
+      majorVersion: 9,
+      includeDevDependencies: false,
+    });
+
+    const writeCall = writeWantedLockfile_v9.mock.calls[0]!;
+    const writtenLockfile = writeCall[1] as { catalogs?: unknown };
+    expect(writtenLockfile.catalogs).toBeUndefined();
+  });
+
   it("should include patchedDependencies in written lockfile", async () => {
     const lockfile = createMockLockfile();
     readWantedLockfile_v9.mockResolvedValue(lockfile as never);

--- a/src/lib/lockfile/helpers/generate-pnpm-lockfile.test.ts
+++ b/src/lib/lockfile/helpers/generate-pnpm-lockfile.test.ts
@@ -303,33 +303,18 @@ describe("generatePnpmLockfile", () => {
     expect(writtenLockfile.packageExtensionsChecksum).toBe("abc123");
   });
 
-  it("should restore catalogs after pruning, narrowed to referenced importers (#198)", async () => {
+  it("should restore the catalogs snapshot after pruning (#198)", async () => {
+    const catalogs = {
+      default: {
+        lodash: { specifier: "^4.17.21", version: "4.17.21" },
+      },
+      utils: {
+        ramda: { specifier: "^0.30.0", version: "0.30.0" },
+      },
+    };
     const lockfile = {
-      lockfileVersion: "9.0",
-      importers: {
-        "apps/my-app": {
-          specifiers: { shared: "workspace:*", lodash: "catalog:" },
-          dependencies: { shared: "link:../../packages/shared" },
-        },
-        "packages/shared": {
-          specifiers: { ramda: "catalog:utils" },
-          dependencies: {},
-        },
-        "packages/other": {
-          specifiers: { unused: "catalog:" },
-          dependencies: {},
-        },
-      },
-      catalogs: {
-        default: {
-          lodash: { specifier: "^4.17.21", version: "4.17.21" },
-          unused: { specifier: "^1.0.0", version: "1.0.0" },
-        },
-        utils: {
-          ramda: { specifier: "^0.30.0", version: "0.30.0" },
-        },
-      },
-      packages: {},
+      ...createMockLockfile(),
+      catalogs,
     };
     readWantedLockfile_v9.mockResolvedValue(lockfile as never);
     getLockfileImporterId_v9.mockReturnValue("apps/my-app");
@@ -364,14 +349,11 @@ describe("generatePnpmLockfile", () => {
     };
 
     /**
-     * Only catalog entries referenced by the retained importers (target +
-     * internal dep "shared") are restored. The "unused" entry, referenced only
-     * by the excluded "packages/other", must not leak into the output.
+     * The catalogs snapshot is restored verbatim (like overrides), so it stays
+     * in sync with the importer specifiers and the verbatim pnpm-workspace.yaml
+     * copy.
      */
-    expect(writtenLockfile.catalogs).toEqual({
-      default: { lodash: { specifier: "^4.17.21", version: "4.17.21" } },
-      utils: { ramda: { specifier: "^0.30.0", version: "0.30.0" } },
-    });
+    expect(writtenLockfile.catalogs).toEqual(catalogs);
   });
 
   it("should not set catalogs when the source lockfile has none", async () => {

--- a/src/lib/lockfile/helpers/generate-pnpm-lockfile.ts
+++ b/src/lib/lockfile/helpers/generate-pnpm-lockfile.ts
@@ -18,6 +18,17 @@ import type { PackageManifest, PackagesRegistry, PatchFile } from "#/lib/types";
 import { getErrorMessage, isRushWorkspace } from "#/lib/utils";
 import { pnpmMapImporter } from "./pnpm-map-importer";
 
+/**
+ * A pnpm catalog snapshot as stored in the lockfile: a map of catalog name
+ * (e.g. "default") to a map of dependency name to its resolved entry. The
+ * pinned `@pnpm/lockfile-file` types predate catalogs, so we model the shape
+ * locally.
+ */
+type CatalogSnapshots = Record<
+  string,
+  Record<string, { specifier: string; version: string }>
+>;
+
 export async function generatePnpmLockfile({
   workspaceRootDir,
   targetPackageDir,
@@ -168,6 +179,23 @@ export async function generatePnpmLockfile({
     }
 
     /**
+     * Pruning drops the catalogs snapshot, but the isolated importers keep
+     * their "catalog:" specifiers (for pnpm we don't resolve catalog deps in
+     * the manifest, since the output is itself a workspace). Restore the
+     * snapshot, narrowed to the entries actually referenced by the retained
+     * importers, so it stays in sync with the manifests and the preserved
+     * pnpm-workspace.yaml (see issue #198).
+     */
+    const catalogs = pickReferencedCatalogs(
+      (lockfile as { catalogs?: CatalogSnapshots }).catalogs,
+      prunedLockfile.importers,
+    );
+
+    if (catalogs) {
+      (prunedLockfile as { catalogs?: CatalogSnapshots }).catalogs = catalogs;
+    }
+
+    /**
      * Use pre-computed patched dependencies with transformed paths. The paths
      * are already adapted by copyPatches to match the isolated directory
      * structure, preserving the original folder structure (not flattened).
@@ -189,4 +217,47 @@ export async function generatePnpmLockfile({
     log.error(`Failed to generate lockfile: ${getErrorMessage(error)}`);
     throw error;
   }
+}
+
+/**
+ * Narrow a catalogs snapshot to only the entries referenced by the given
+ * importers through "catalog:" specifiers. This mirrors what pnpm itself
+ * writes, so the restored snapshot doesn't leak catalog entries belonging to
+ * unrelated workspace packages that aren't part of the isolated output.
+ *
+ * Catalogs are a pnpm v9 feature; for older lockfiles `catalogs` is undefined
+ * and this returns undefined.
+ */
+function pickReferencedCatalogs(
+  catalogs: CatalogSnapshots | undefined,
+  importers: Record<string, { specifiers?: Record<string, string> }>,
+): CatalogSnapshots | undefined {
+  if (!catalogs) {
+    return undefined;
+  }
+
+  const referenced: CatalogSnapshots = {};
+
+  for (const importer of Object.values(importers)) {
+    for (const [depName, specifier] of Object.entries(
+      importer.specifiers ?? {},
+    )) {
+      if (!specifier.startsWith("catalog:")) {
+        continue;
+      }
+
+      /**
+       * "catalog:" and "catalog:default" both map to the default catalog;
+       * "catalog:<name>" maps to a named catalog.
+       */
+      const groupName = specifier.slice("catalog:".length) || "default";
+      const entry = catalogs[groupName]?.[depName];
+
+      if (entry) {
+        (referenced[groupName] ??= {})[depName] = entry;
+      }
+    }
+  }
+
+  return Object.keys(referenced).length > 0 ? referenced : undefined;
 }

--- a/src/lib/lockfile/helpers/generate-pnpm-lockfile.ts
+++ b/src/lib/lockfile/helpers/generate-pnpm-lockfile.ts
@@ -22,7 +22,7 @@ import { pnpmMapImporter } from "./pnpm-map-importer";
  * A pnpm catalog snapshot as stored in the lockfile: a map of catalog name
  * (e.g. "default") to a map of dependency name to its resolved entry. The
  * pinned `@pnpm/lockfile-file` types predate catalogs, so we model the shape
- * locally.
+ * locally for the cast below.
  */
 type CatalogSnapshots = Record<
   string,
@@ -181,15 +181,14 @@ export async function generatePnpmLockfile({
     /**
      * Pruning drops the catalogs snapshot, but the isolated importers keep
      * their "catalog:" specifiers (for pnpm we don't resolve catalog deps in
-     * the manifest, since the output is itself a workspace). Restore the
-     * snapshot, narrowed to the entries actually referenced by the retained
-     * importers, so it stays in sync with the manifests and the preserved
-     * pnpm-workspace.yaml (see issue #198).
+     * the manifest, since the output is itself a workspace). Restore it
+     * verbatim — like overrides above — so it stays in sync with the importer
+     * specifiers and the preserved pnpm-workspace.yaml catalog definitions,
+     * which are themselves copied verbatim (see issue #198). pnpm tolerates
+     * catalog entries that no retained importer references, so there is no need
+     * to narrow the snapshot.
      */
-    const catalogs = pickReferencedCatalogs(
-      (lockfile as { catalogs?: CatalogSnapshots }).catalogs,
-      prunedLockfile.importers,
-    );
+    const catalogs = (lockfile as { catalogs?: CatalogSnapshots }).catalogs;
 
     if (catalogs) {
       (prunedLockfile as { catalogs?: CatalogSnapshots }).catalogs = catalogs;
@@ -217,47 +216,4 @@ export async function generatePnpmLockfile({
     log.error(`Failed to generate lockfile: ${getErrorMessage(error)}`);
     throw error;
   }
-}
-
-/**
- * Narrow a catalogs snapshot to only the entries referenced by the given
- * importers through "catalog:" specifiers. This mirrors what pnpm itself
- * writes, so the restored snapshot doesn't leak catalog entries belonging to
- * unrelated workspace packages that aren't part of the isolated output.
- *
- * Catalogs are a pnpm v9 feature; for older lockfiles `catalogs` is undefined
- * and this returns undefined.
- */
-function pickReferencedCatalogs(
-  catalogs: CatalogSnapshots | undefined,
-  importers: Record<string, { specifiers?: Record<string, string> }>,
-): CatalogSnapshots | undefined {
-  if (!catalogs) {
-    return undefined;
-  }
-
-  const referenced: CatalogSnapshots = {};
-
-  for (const importer of Object.values(importers)) {
-    for (const [depName, specifier] of Object.entries(
-      importer.specifiers ?? {},
-    )) {
-      if (!specifier.startsWith("catalog:")) {
-        continue;
-      }
-
-      /**
-       * "catalog:" and "catalog:default" both map to the default catalog;
-       * "catalog:<name>" maps to a named catalog.
-       */
-      const groupName = specifier.slice("catalog:".length) || "default";
-      const entry = catalogs[groupName]?.[depName];
-
-      if (entry) {
-        (referenced[groupName] ??= {})[depName] = entry;
-      }
-    }
-  }
-
-  return Object.keys(referenced).length > 0 ? referenced : undefined;
 }

--- a/src/lib/manifest/adapt-target-package-manifest.ts
+++ b/src/lib/manifest/adapt-target-package-manifest.ts
@@ -41,14 +41,26 @@ export async function adaptTargetPackageManifest({
     ? manifest
     : omit(manifest, ["devDependencies"]);
 
-  /** Resolve catalog dependencies before adapting internal deps */
-  const manifestWithResolvedCatalogs = {
-    ...inputManifest,
-    dependencies: await resolveCatalogDependencies(
-      inputManifest.dependencies,
-      workspaceRootDir,
-    ),
-  };
+  /**
+   * For PNPM (non-forceNpm) the isolated output is itself a pnpm workspace and
+   * the `pnpm-workspace.yaml` with its catalog definitions is preserved, so
+   * "catalog:" specifiers can be kept verbatim — just like "workspace:*". The
+   * lockfile importers also keep their "catalog:" specifiers, so resolving them
+   * here would create a mismatch and break `pnpm install --frozen-lockfile`
+   * (see issue #198). For other package managers (and forceNpm) the catalog is
+   * not available in the output, so we resolve the specifiers to versions.
+   */
+  const isPnpmWorkspaceOutput = packageManager.name === "pnpm" && !forceNpm;
+
+  const preparedManifest = isPnpmWorkspaceOutput
+    ? inputManifest
+    : {
+        ...inputManifest,
+        dependencies: await resolveCatalogDependencies(
+          inputManifest.dependencies,
+          workspaceRootDir,
+        ),
+      };
 
   const adaptedManifest =
     (packageManager.name === "pnpm" || packageManager.name === "bun") &&
@@ -59,13 +71,10 @@ export async function adaptTargetPackageManifest({
          * want to adopt workspace-level fields from the root package.json
          * (pnpm.overrides for PNPM, top-level overrides for Bun).
          */
-        await adoptPnpmFieldsFromRoot(
-          manifestWithResolvedCatalogs,
-          workspaceRootDir,
-        )
+        await adoptPnpmFieldsFromRoot(preparedManifest, workspaceRootDir)
       : /** For other package managers we replace the links to internal dependencies */
         adaptManifestInternalDeps({
-          manifest: manifestWithResolvedCatalogs,
+          manifest: preparedManifest,
           packagesRegistry,
         });
 

--- a/src/lib/manifest/helpers/adapt-internal-package-manifests.test.ts
+++ b/src/lib/manifest/helpers/adapt-internal-package-manifests.test.ts
@@ -20,6 +20,10 @@ vi.mock("./resolve-catalog-dependencies", () => ({
 
 const { usePackageManager } = vi.mocked(await import("#/lib/package-manager"));
 
+const { resolveCatalogDependencies } = vi.mocked(
+  await import("./resolve-catalog-dependencies"),
+);
+
 const { writeManifest } = vi.mocked(await import("../io"));
 
 const { adaptInternalPackageManifests } =
@@ -177,5 +181,70 @@ describe("adaptInternalPackageManifests", () => {
     const writtenManifest = writeManifest.mock.calls[0]![1];
 
     expect(writtenManifest.devDependencies).toBeUndefined();
+  });
+
+  it("should preserve catalog: specifiers for pnpm without resolving them (#198)", async () => {
+    const manifest: PackageManifest = {
+      name: "@repo/shared",
+      version: "1.0.0",
+      dependencies: {
+        "lodash.merge": "catalog:",
+      },
+    };
+
+    const packagesRegistry = createRegistry({
+      "@repo/shared": {
+        rootRelativeDir: "packages/shared",
+        manifest,
+      },
+    });
+
+    await adaptInternalPackageManifests({
+      internalPackageNames: ["@repo/shared"],
+      packagesRegistry,
+      isolateDir: "/output",
+      forceNpm: false,
+      workspaceRootDir: "/workspace",
+    });
+
+    /**
+     * For pnpm the isolated output is itself a workspace with its catalog
+     * definitions preserved, so the specifier is kept verbatim rather than
+     * resolved (which would desync it from the lockfile importers).
+     */
+    expect(resolveCatalogDependencies).not.toHaveBeenCalled();
+
+    const writtenManifest = writeManifest.mock.calls[0]![1];
+    expect(writtenManifest.dependencies).toEqual({
+      "lodash.merge": "catalog:",
+    });
+  });
+
+  it("should resolve catalog dependencies when forceNpm is enabled", async () => {
+    const manifest: PackageManifest = {
+      name: "@repo/shared",
+      version: "1.0.0",
+      dependencies: {
+        "lodash.merge": "catalog:",
+      },
+    };
+
+    const packagesRegistry = createRegistry({
+      "@repo/shared": {
+        rootRelativeDir: "packages/shared",
+        manifest,
+      },
+    });
+
+    await adaptInternalPackageManifests({
+      internalPackageNames: ["@repo/shared"],
+      packagesRegistry,
+      isolateDir: "/output",
+      forceNpm: true,
+      workspaceRootDir: "/workspace",
+    });
+
+    /** With forceNpm the catalog is not available in the output, so resolve. */
+    expect(resolveCatalogDependencies).toHaveBeenCalledOnce();
   });
 });

--- a/src/lib/manifest/helpers/adapt-internal-package-manifests.ts
+++ b/src/lib/manifest/helpers/adapt-internal-package-manifests.ts
@@ -27,6 +27,15 @@ export async function adaptInternalPackageManifests({
 }) {
   const packageManager = usePackageManager();
 
+  /**
+   * For PNPM (non-forceNpm) the isolated output is itself a pnpm workspace with
+   * its `pnpm-workspace.yaml` catalog definitions preserved, so "catalog:"
+   * specifiers are kept verbatim to stay in sync with the lockfile importers
+   * (see issue #198). For other package managers the catalog is not available
+   * in the output, so we resolve the specifiers to versions.
+   */
+  const isPnpmWorkspaceOutput = packageManager.name === "pnpm" && !forceNpm;
+
   await Promise.all(
     internalPackageNames.map(async (packageName) => {
       const { manifest, rootRelativeDir } = got(packagesRegistry, packageName);
@@ -45,14 +54,15 @@ export async function adaptInternalPackageManifests({
         strippedManifest.scripts = omit(strippedManifest.scripts, ["prepare"]);
       }
 
-      /** Resolve catalog dependencies before adapting internal deps */
-      const manifestWithResolvedCatalogs = {
-        ...strippedManifest,
-        dependencies: await resolveCatalogDependencies(
-          strippedManifest.dependencies,
-          workspaceRootDir,
-        ),
-      };
+      const preparedManifest = isPnpmWorkspaceOutput
+        ? strippedManifest
+        : {
+            ...strippedManifest,
+            dependencies: await resolveCatalogDependencies(
+              strippedManifest.dependencies,
+              workspaceRootDir,
+            ),
+          };
 
       const outputManifest =
         (packageManager.name === "pnpm" || packageManager.name === "bun") &&
@@ -61,10 +71,10 @@ export async function adaptInternalPackageManifests({
              * For PNPM and Bun the output itself is a workspace so we can preserve
              * the specifiers with "workspace:*" in the output manifest.
              */
-            manifestWithResolvedCatalogs
+            preparedManifest
           : /** For other package managers we replace the links to internal dependencies */
             adaptManifestInternalDeps({
-              manifest: manifestWithResolvedCatalogs,
+              manifest: preparedManifest,
               packagesRegistry,
               parentRootRelativeDir: rootRelativeDir,
             });


### PR DESCRIPTION
When isolating a pnpm workspace package that uses `catalog:` dependency specifiers, the adapted manifest had its `catalog:` refs resolved to concrete versions while the generated lockfile importers kept `catalog:`. This desync made `pnpm install --frozen-lockfile` fail with `ERR_PNPM_OUTDATED_LOCKFILE` (`specifiers in the lockfile don't match specifiers in package.json`), breaking deploys such as Firebase where frozen installs are the default.

For pnpm (non-`forceNpm`) the isolated output is itself a workspace and keeps `pnpm-workspace.yaml` with its catalog definitions, so `catalog:` specifiers can be preserved verbatim, exactly like `workspace:*` already is. Catalog resolution is therefore skipped for pnpm and only applied for bun, npm, yarn, and `forceNpm`, where the catalog is not available in the isolated output.

Pruning the lockfile also dropped the `catalogs` snapshot (the same way it drops `overrides`), so the manifest and lockfile were inconsistent even when specifiers matched. The snapshot is now restored after pruning, narrowed to the entries referenced by the retained importers to mirror what pnpm itself writes, so catalog entries belonging to unrelated workspace packages do not leak into the output.

Closes #198

Scope: packages (isolate-package)
Visibility: user-facing