### PR TITLE
Fix empty patch hash on pnpm 11 lockfiles

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -74,7 +74,7 @@
     "no-console": "error",
     "no-await-in-loop": "off"
   },
-  "ignorePatterns": ["*.d.ts", "*.d.mts"],
+  "ignorePatterns": ["*.d.ts", "*.d.mts", "**/.worktrees/**"],
   "overrides": [
     {
       "files": [

--- a/src/lib/patches/copy-patches.test.ts
+++ b/src/lib/patches/copy-patches.test.ts
@@ -653,4 +653,124 @@ describe("copyPatches", () => {
     expect(reachable!.has("@react-pdf/renderer")).toBe(true);
     expect(reachable!.has("@react-pdf/render")).toBe(true);
   });
+
+  it("should read the patch hash from the pnpm 11 string lockfile format (regression: issue #201)", async () => {
+    /**
+     * pnpm 11 simplified the lockfile `patchedDependencies` format from
+     * `Record<string, { path, hash }>` to `Record<string, string>` (selector to
+     * hash). The hash must be read from the bare string, otherwise it ends up
+     * empty and pnpm rejects the isolated install with
+     * ERR_PNPM_LOCKFILE_CONFIG_MISMATCH.
+     */
+    const targetManifest: PackageManifest = {
+      name: "test",
+      version: "1.0.0",
+      dependencies: { lodash: "^4.0.0" },
+    };
+
+    readTypedYamlSync.mockReturnValue({
+      patchedDependencies: {
+        "lodash@4.17.21": "patches/lodash.patch",
+      },
+    });
+    readTypedJson.mockResolvedValue({
+      name: "root",
+      version: "1.0.0",
+    } as PackageManifest);
+
+    filterPatchedDependencies.mockReturnValue({
+      "lodash@4.17.21": "patches/lodash.patch",
+    });
+
+    fs.existsSync.mockReturnValue(true);
+
+    usePackageManager.mockReturnValue({
+      name: "pnpm",
+      majorVersion: 9,
+      version: "9.0.0",
+      packageManagerString: "pnpm@9.0.0",
+    });
+
+    readWantedLockfile_v9.mockResolvedValue({
+      lockfileVersion: "9.0",
+      patchedDependencies: {
+        "lodash@4.17.21": "sha256-abc123",
+      },
+    } as unknown as Awaited<ReturnType<typeof readWantedLockfile_v9>>);
+
+    const result = await copyPatches({
+      workspaceRootDir: "/workspace",
+      targetPackageDir: "/workspace/packages/test",
+      internalDepPackageNames: [],
+      targetPackageManifest: targetManifest,
+      isolateDir: "/workspace/isolate",
+      packagesRegistry: {},
+      includeDevDependencies: false,
+    });
+
+    expect(result).toEqual({
+      "lodash@4.17.21": {
+        path: "patches/lodash.patch",
+        hash: "sha256-abc123",
+      },
+    });
+  });
+
+  it("should read the patch hash from the pnpm <=10 object lockfile format (regression: issue #201)", async () => {
+    const targetManifest: PackageManifest = {
+      name: "test",
+      version: "1.0.0",
+      dependencies: { lodash: "^4.0.0" },
+    };
+
+    readTypedYamlSync.mockReturnValue({
+      patchedDependencies: {
+        "lodash@4.17.21": "patches/lodash.patch",
+      },
+    });
+    readTypedJson.mockResolvedValue({
+      name: "root",
+      version: "1.0.0",
+    } as PackageManifest);
+
+    filterPatchedDependencies.mockReturnValue({
+      "lodash@4.17.21": "patches/lodash.patch",
+    });
+
+    fs.existsSync.mockReturnValue(true);
+
+    usePackageManager.mockReturnValue({
+      name: "pnpm",
+      majorVersion: 9,
+      version: "9.0.0",
+      packageManagerString: "pnpm@9.0.0",
+    });
+
+    readWantedLockfile_v9.mockResolvedValue({
+      lockfileVersion: "9.0",
+      patchedDependencies: {
+        "lodash@4.17.21": {
+          path: "patches/lodash.patch",
+          hash: "sha256-def456",
+        },
+      },
+    } as unknown as Awaited<ReturnType<typeof readWantedLockfile_v9>>);
+
+    const result = await copyPatches({
+      workspaceRootDir: "/workspace",
+      targetPackageDir: "/workspace/packages/test",
+      internalDepPackageNames: [],
+      targetPackageManifest: targetManifest,
+      isolateDir: "/workspace/isolate",
+      packagesRegistry: {},
+      includeDevDependencies: false,
+    });
+
+    expect(result).toEqual({
+      "lodash@4.17.21": {
+        path: "patches/lodash.patch",
+        hash: "sha256-def456",
+      },
+    });
+  });
 });

--- a/src/lib/patches/copy-patches.ts
+++ b/src/lib/patches/copy-patches.ts
@@ -177,9 +177,17 @@ export async function copyPatches({
     await fs.copy(sourcePatchPath, targetPatchPath);
     log.debug(`Copied patch for ${packageSpec}: ${patchPath}`);
 
-    /** Get the hash from the original lockfile, or use empty string if not found */
+    /**
+     * Get the hash from the original lockfile, or use empty string if not
+     * found. pnpm 11 simplified the lockfile `patchedDependencies` format from
+     * `Record<string, { path, hash }>` to `Record<string, string>` (selector to
+     * hash), so the entry may be a bare hash string. See issue #201.
+     */
     const originalPatchFile = lockfilePatchedDependencies?.[packageSpec];
-    const hash = originalPatchFile?.hash ?? "";
+    const hash =
+      typeof originalPatchFile === "string"
+        ? originalPatchFile
+        : (originalPatchFile?.hash ?? "");
 
     if (packageManagerName === "pnpm" && !hash) {
       log.warn(`No hash found for patch ${packageSpec} in lockfile`);
@@ -201,10 +209,14 @@ export async function copyPatches({
 /**
  * Read the patchedDependencies from the original lockfile to get the hashes.
  * Since the file content is the same after copying, the hash remains valid.
+ *
+ * The value type is `PatchFile | string` because pnpm 11 simplified the format
+ * to store the bare hash string per selector, while pnpm <=10 stored a
+ * `{ path, hash }` object. See issue #201.
  */
 async function readLockfilePatchedDependencies(
   workspaceRootDir: string,
-): Promise<Record<string, PatchFile> | undefined> {
+): Promise<Record<string, PatchFile | string> | undefined> {
   try {
     const { majorVersion } = usePackageManager();
     const useVersion9 = majorVersion >= 9;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,7 +3,8 @@ import { configDefaults, defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    exclude: [...configDefaults.exclude],
+    /** Exclude nested git worktrees so we don't run another branch's tests */
+    exclude: [...configDefaults.exclude, "**/.worktrees/**"],
     setupFiles: ["./src/testing/setup.ts"],
   },
   resolve: {


### PR DESCRIPTION
pnpm 11 simplified the lockfile `patchedDependencies` format from `Record<string, { path, hash }>` to `Record<string, string>` (selector to hash), and existing lockfiles are migrated automatically. `@pnpm/lockfile-file@9` passes this field through unchanged, so reading a pnpm 11 lockfile yields bare hash strings instead of `{ path, hash }` objects.

`copyPatches` only read `originalPatchFile?.hash`, which is `undefined` for a string entry, so the hash ended up empty. That empty hash was written into the isolated lockfile, and pnpm then rejected the isolated install with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH: Cannot proceed with the frozen installation. The current "patchedDependencies" configuration doesn't match the value found in the lockfile`.

The hash is now read from either the string (pnpm 11) or the object (pnpm <=10) shape, with the reader's return type widened accordingly. Regression tests cover both formats.

Separately, nested git worktrees under `.worktrees/` are now excluded from vitest and oxlint. Git auto-ignores registered worktree paths, but both tools walk the filesystem and were running another branch's tests and linting its files.

Decisions:
- The fix is read-only; the isolated lockfile is still written in the old `{ path, hash }` format by `@pnpm/lockfile-file@9`. This is intentional: pnpm 11 reads old-format lockfiles, extracts the hash (discarding the path), and respects `frozen-lockfile` mode while doing so (pnpm/pnpm#10911), so a correct hash in the old format is accepted. Serializing the new string format would require post-processing YAML the library does not emit, for no functional gain.

Fixes #201

Scope: packages (isolate-package)
Visibility: user-facing
