### PR TITLE
Skip isolation for targets without package manifests

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -30,3 +30,6 @@ npx isolate --pick-from-scripts build --pick-from-scripts start
 ```
 
 Boolean flags support `--no-` negation, for example: `--no-force-npm`.
+
+Targets without a `package.json` bypass isolation and keep their original
+source directory.

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -17,10 +17,11 @@ It is tightly coupled to PNPM and only works in PNPM workspaces.
 
 ### isolate-package
 
-`isolate-package` produces a self-contained source directory containing the
-target package, its internal dependencies as `file:` references, and a pruned
-lockfile. No install is performed — the deployment target is expected to run its
-own `install` step.
+For Node packages, `isolate-package` produces a self-contained source directory
+containing the target package, its internal dependencies as `file:` references,
+and a pruned lockfile. No install is performed — the deployment target is
+expected to run its own `install` step. Targets without a `package.json` bypass
+isolation and keep their original source directory.
 
 It works with PNPM, NPM, Bun, and Yarn.
 
@@ -36,11 +37,11 @@ It works with PNPM, NPM, Bun, and Yarn.
 
 ## Firebase compatibility
 
-Firebase-tools deployment expects a source directory with a `package.json` and a
-lockfile. It runs its own `npm install` (or equivalent) as part of the deployment
-process. `pnpm deploy` cannot produce this kind of output because it delivers a
-pre-installed `node_modules` instead of the manifest-and-lockfile combination
-that Firebase expects.
+Firebase-tools deployment of Node functions expects a source directory with a
+`package.json` and a lockfile. It runs its own `npm install` (or equivalent) as
+part of the deployment process. `pnpm deploy` cannot produce this kind of output
+because it delivers a pre-installed `node_modules` instead of the
+manifest-and-lockfile combination that Firebase expects.
 
 The
 [firebase-tools-with-isolate](https://github.com/0x80/firebase-tools-with-isolate)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -139,6 +139,10 @@ same way as when `targetPackagePath` is omitted: from the `workspaceRoot`
 setting, or otherwise auto-detected by walking upward from the target package
 directory.
 
+If the target directory has no `package.json`, isolation is skipped and the
+original target path is returned unchanged. This lets mixed-runtime tools pass
+non-Node sources, such as Python functions, through the same API.
+
 ### tsconfigPath
 
 Type: `string`, default: `"./tsconfig.json"`

--- a/docs/deploying-to-firebase.md
+++ b/docs/deploying-to-firebase.md
@@ -78,9 +78,10 @@ the root of the monorepo. If you do want to keep the firebase config in the
 root, read the instructions for
 [deploying from the root](#deploying-from-the-root).
 
-In order to deploy to Firebase, the `functions.source` setting in
-`firebase.json` needs to point to the isolated output folder, which would be
-`./isolate` when using the default configuration.
+For Node functions, the `functions.source` setting in `firebase.json` needs to
+point to the isolated output folder, which is `./isolate` with the default
+configuration. Other runtimes without a `package.json`, such as Python, bypass
+isolation and keep their configured source directory.
 
 The `predeploy` phase should first build and then isolate the output.
 

--- a/docs/deploying-to-firebase.md
+++ b/docs/deploying-to-firebase.md
@@ -43,7 +43,8 @@ If your setup diverges from a traditional one, please continue reading the
 2. For Node functions, set `"source"` to `"./isolate"` in `firebase.json` and
    set `"predeploy"` to `["turbo build", "isolate"]` or whatever suits your
    build tool. The important part here is that isolate runs after the build
-   stage. Other runtimes keep their original source directory.
+   stage. Targets without a `package.json` keep their original source
+   directory, which covers typical Python functions packages.
 3. From the target package folder, you should now be able to deploy with
    `npx firebase deploy`.
 

--- a/docs/deploying-to-firebase.md
+++ b/docs/deploying-to-firebase.md
@@ -40,10 +40,10 @@ If your setup diverges from a traditional one, please continue reading the
    running `pnpm add isolate-package firebase-tools -D` or the Yarn / NPM
    equivalent. I tend to install firebase-tools as a devDependency in every
    Firebase package, but you could also use a global install if you prefer that.
-2. In the `firebase.json` config set `"source"` to `"./isolate"` and
-   `"predeploy"` to `["turbo build", "isolate"]` or whatever suits your build
-   tool. The important part here is that isolate is being executed after the
-   build stage.
+2. For Node functions, set `"source"` to `"./isolate"` in `firebase.json` and
+   set `"predeploy"` to `["turbo build", "isolate"]` or whatever suits your
+   build tool. The important part here is that isolate runs after the build
+   stage. Other runtimes keep their original source directory.
 3. From the target package folder, you should now be able to deploy with
    `npx firebase deploy`.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -108,7 +108,9 @@ The `isolate` binary will try to infer your build output location from a
 `tsconfig` file, but see the [buildDirName configuration](/configuration#builddirname)
 if you are not using TypeScript.
 
-By default the isolated output will become available at `./isolate`.
+By default the isolated output for a Node package will become available at
+`./isolate`. A target without a `package.json` bypasses isolation and keeps its
+original directory.
 
 All [configuration options](/configuration) can also be set via
 [CLI flags](/cli-reference), which take precedence over the config file.

--- a/src/isolate.integration.test.ts
+++ b/src/isolate.integration.test.ts
@@ -1,0 +1,68 @@
+import fs from "fs-extra";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { isolate } from "./isolate";
+
+describe("isolate integration", () => {
+  const temporaryDirectories: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      temporaryDirectories.splice(0).map((directory) => fs.remove(directory)),
+    );
+  });
+
+  it("continues isolation for a Node package", async () => {
+    const workspaceRoot = await fs.mkdtemp(
+      path.join(os.tmpdir(), "isolate-node-functions-test-"),
+    );
+    temporaryDirectories.push(workspaceRoot);
+    const targetPackageDir = path.join(
+      workspaceRoot,
+      "packages",
+      "functions-node",
+    );
+    await fs.ensureDir(targetPackageDir);
+    await fs.writeJson(path.join(workspaceRoot, "package.json"), {
+      name: "workspace",
+      version: "1.0.0",
+      private: true,
+      workspaces: ["packages/*"],
+    });
+    await fs.writeJson(path.join(workspaceRoot, "package-lock.json"), {
+      name: "workspace",
+      version: "1.0.0",
+      lockfileVersion: 3,
+      requires: true,
+      packages: {
+        "": {
+          name: "workspace",
+          version: "1.0.0",
+          workspaces: ["packages/*"],
+        },
+        "packages/functions-node": {
+          name: "functions-node",
+          version: "1.0.0",
+        },
+      },
+    });
+    await fs.writeJson(path.join(targetPackageDir, "package.json"), {
+      name: "functions-node",
+      version: "1.0.0",
+      files: ["index.js"],
+    });
+    await fs.writeFile(path.join(targetPackageDir, "index.js"), "export {};\n");
+
+    const result = await isolate({
+      targetPackagePath: targetPackageDir,
+      buildDirName: ".",
+      workspaceRoot: "../..",
+    });
+
+    expect(result).toBe(path.join(targetPackageDir, "isolate"));
+    await expect(
+      fs.readJson(path.join(result, "package.json")),
+    ).resolves.toMatchObject({ name: "functions-node", version: "1.0.0" });
+  });
+});

--- a/src/isolate.test.ts
+++ b/src/isolate.test.ts
@@ -1,13 +1,26 @@
 import fs from "fs-extra";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { isolate } from "./isolate";
+
+const mockLogger = vi.hoisted(() => ({
+  debug: vi.fn(),
+  error: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+}));
+
+vi.mock("./lib/logger", () => ({
+  setLogLevel: vi.fn(),
+  useLogger: () => mockLogger,
+}));
 
 describe("isolate", () => {
   const temporaryDirectories: string[] = [];
 
   afterEach(async () => {
+    vi.clearAllMocks();
     await Promise.all(
       temporaryDirectories.splice(0).map((directory) => fs.remove(directory)),
     );
@@ -33,6 +46,29 @@ describe("isolate", () => {
     await expect(
       fs.pathExists(path.join(targetPackageDir, "isolate")),
     ).resolves.toBe(false);
+    expect(mockLogger.info).toHaveBeenCalledWith(
+      "Skipping isolation because the target directory has no package.json",
+      targetPackageDir,
+    );
+  });
+
+  it("warns when a skipped target contains stale isolate output", async () => {
+    const targetPackageDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "isolate-stale-output-test-"),
+    );
+    temporaryDirectories.push(targetPackageDir);
+    const existingIsolateDir = path.join(targetPackageDir, "previous-output");
+    await fs.ensureDir(existingIsolateDir);
+
+    await isolate({
+      targetPackagePath: targetPackageDir,
+      isolateDirName: "previous-output",
+    });
+
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      "The skipped target contains an existing isolate directory that may be stale",
+      existingIsolateDir,
+    );
   });
 
   it("rejects a target directory that does not exist", async () => {
@@ -106,6 +142,7 @@ describe("isolate", () => {
     const result = await isolate({
       targetPackagePath: targetPackageDir,
       buildDirName: ".",
+      workspaceRoot: "../..",
     });
 
     expect(result).toBe(path.join(targetPackageDir, "isolate"));
@@ -123,6 +160,8 @@ describe("isolate", () => {
 
     await expect(
       isolate({ targetPackagePath: targetPackageDir }),
-    ).rejects.toThrow();
+    ).rejects.toThrow(
+      `Package manifest is not a file: ${path.join(targetPackageDir, "package.json")}`,
+    );
   });
 });

--- a/src/isolate.test.ts
+++ b/src/isolate.test.ts
@@ -27,7 +27,6 @@ describe("isolate", () => {
 
     const result = await isolate({
       targetPackagePath: targetPackageDir,
-      workspaceRoot: "..",
     });
 
     expect(result).toBe(targetPackageDir);
@@ -44,7 +43,37 @@ describe("isolate", () => {
     const targetPackageDir = path.join(workspaceRoot, "missing-functions");
 
     await expect(
-      isolate({ targetPackagePath: targetPackageDir, workspaceRoot: ".." }),
+      isolate({ targetPackagePath: targetPackageDir }),
     ).rejects.toThrow();
+  });
+
+  it("rejects a target path that is not a directory", async () => {
+    const workspaceRoot = await fs.mkdtemp(
+      path.join(os.tmpdir(), "isolate-file-target-test-"),
+    );
+    temporaryDirectories.push(workspaceRoot);
+    const targetPackagePath = path.join(workspaceRoot, "functions-python");
+    await fs.writeFile(targetPackagePath, "not a directory\n");
+
+    await expect(isolate({ targetPackagePath })).rejects.toThrow(
+      /Target package path is not a directory/,
+    );
+  });
+
+  it("continues isolation for a Node package", async () => {
+    const workspaceRoot = await fs.mkdtemp(
+      path.join(os.tmpdir(), "isolate-node-functions-test-"),
+    );
+    temporaryDirectories.push(workspaceRoot);
+    const targetPackageDir = path.join(workspaceRoot, "functions-node");
+    await fs.ensureDir(targetPackageDir);
+    await fs.writeJson(path.join(targetPackageDir, "package.json"), {
+      name: "functions-node",
+      version: "1.0.0",
+    });
+
+    await expect(
+      isolate({ targetPackagePath: targetPackageDir, workspaceRoot: ".." }),
+    ).rejects.toThrow(/Failed to infer the build output directory/);
   });
 });

--- a/src/isolate.test.ts
+++ b/src/isolate.test.ts
@@ -111,4 +111,19 @@ describe("isolate", () => {
       `Package manifest is not a file: ${path.join(targetPackageDir, "package.json")}`,
     );
   });
+
+  it("rejects a dangling package.json symlink", async () => {
+    const targetPackageDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "isolate-dangling-manifest-test-"),
+    );
+    temporaryDirectories.push(targetPackageDir);
+    const targetManifestPath = path.join(targetPackageDir, "package.json");
+    await fs.symlink("missing-package.json", targetManifestPath);
+
+    await expect(
+      isolate({ targetPackagePath: targetPackageDir }),
+    ).rejects.toThrow(
+      `Package manifest cannot be resolved: ${targetManifestPath}`,
+    );
+  });
 });

--- a/src/isolate.test.ts
+++ b/src/isolate.test.ts
@@ -26,7 +26,7 @@ describe("isolate", () => {
     );
   });
 
-  it("returns a non-Node target directory without isolating it", async () => {
+  it("returns a target without a package manifest without isolating it", async () => {
     const workspaceRoot = await fs.mkdtemp(
       path.join(os.tmpdir(), "isolate-python-functions-test-"),
     );

--- a/src/isolate.test.ts
+++ b/src/isolate.test.ts
@@ -1,0 +1,50 @@
+import fs from "fs-extra";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { isolate } from "./isolate";
+
+describe("isolate", () => {
+  const temporaryDirectories: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      temporaryDirectories.splice(0).map((directory) => fs.remove(directory)),
+    );
+  });
+
+  it("returns a non-Node target directory without isolating it", async () => {
+    const workspaceRoot = await fs.mkdtemp(
+      path.join(os.tmpdir(), "isolate-python-functions-test-"),
+    );
+    temporaryDirectories.push(workspaceRoot);
+    const targetPackageDir = path.join(workspaceRoot, "functions-python");
+    await fs.ensureDir(targetPackageDir);
+    await fs.writeFile(
+      path.join(targetPackageDir, "main.py"),
+      "def hello(): pass\n",
+    );
+
+    const result = await isolate({
+      targetPackagePath: targetPackageDir,
+      workspaceRoot: "..",
+    });
+
+    expect(result).toBe(targetPackageDir);
+    await expect(
+      fs.pathExists(path.join(targetPackageDir, "isolate")),
+    ).resolves.toBe(false);
+  });
+
+  it("rejects a target directory that does not exist", async () => {
+    const workspaceRoot = await fs.mkdtemp(
+      path.join(os.tmpdir(), "isolate-missing-target-test-"),
+    );
+    temporaryDirectories.push(workspaceRoot);
+    const targetPackageDir = path.join(workspaceRoot, "missing-functions");
+
+    await expect(
+      isolate({ targetPackagePath: targetPackageDir, workspaceRoot: ".." }),
+    ).rejects.toThrow();
+  });
+});

--- a/src/isolate.test.ts
+++ b/src/isolate.test.ts
@@ -44,7 +44,9 @@ describe("isolate", () => {
 
     await expect(
       isolate({ targetPackagePath: targetPackageDir }),
-    ).rejects.toThrow();
+    ).rejects.toThrow(
+      `Target package path does not exist: ${targetPackageDir}`,
+    );
   });
 
   it("rejects a target path that is not a directory", async () => {
@@ -65,15 +67,62 @@ describe("isolate", () => {
       path.join(os.tmpdir(), "isolate-node-functions-test-"),
     );
     temporaryDirectories.push(workspaceRoot);
-    const targetPackageDir = path.join(workspaceRoot, "functions-node");
+    const targetPackageDir = path.join(
+      workspaceRoot,
+      "packages",
+      "functions-node",
+    );
     await fs.ensureDir(targetPackageDir);
+    await fs.writeJson(path.join(workspaceRoot, "package.json"), {
+      name: "workspace",
+      version: "1.0.0",
+      private: true,
+      workspaces: ["packages/*"],
+    });
+    await fs.writeJson(path.join(workspaceRoot, "package-lock.json"), {
+      name: "workspace",
+      version: "1.0.0",
+      lockfileVersion: 3,
+      requires: true,
+      packages: {
+        "": {
+          name: "workspace",
+          version: "1.0.0",
+          workspaces: ["packages/*"],
+        },
+        "packages/functions-node": {
+          name: "functions-node",
+          version: "1.0.0",
+        },
+      },
+    });
     await fs.writeJson(path.join(targetPackageDir, "package.json"), {
       name: "functions-node",
       version: "1.0.0",
+      files: ["index.js"],
+    });
+    await fs.writeFile(path.join(targetPackageDir, "index.js"), "export {};\n");
+
+    const result = await isolate({
+      targetPackagePath: targetPackageDir,
+      buildDirName: ".",
     });
 
+    expect(result).toBe(path.join(targetPackageDir, "isolate"));
     await expect(
-      isolate({ targetPackagePath: targetPackageDir, workspaceRoot: ".." }),
-    ).rejects.toThrow(/Failed to infer the build output directory/);
+      fs.readJson(path.join(result, "package.json")),
+    ).resolves.toMatchObject({ name: "functions-node", version: "1.0.0" });
+  });
+
+  it("rejects an invalid package.json path", async () => {
+    const targetPackageDir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "isolate-invalid-manifest-test-"),
+    );
+    temporaryDirectories.push(targetPackageDir);
+    await fs.ensureDir(path.join(targetPackageDir, "package.json"));
+
+    await expect(
+      isolate({ targetPackagePath: targetPackageDir }),
+    ).rejects.toThrow();
   });
 });

--- a/src/isolate.test.ts
+++ b/src/isolate.test.ts
@@ -66,7 +66,7 @@ describe("isolate", () => {
     });
 
     expect(mockLogger.warn).toHaveBeenCalledWith(
-      "The skipped target contains an existing isolate directory that may be stale",
+      "The skipped target contains an existing isolate path that may be stale",
       existingIsolateDir,
     );
   });
@@ -96,59 +96,6 @@ describe("isolate", () => {
     await expect(isolate({ targetPackagePath })).rejects.toThrow(
       /Target package path is not a directory/,
     );
-  });
-
-  it("continues isolation for a Node package", async () => {
-    const workspaceRoot = await fs.mkdtemp(
-      path.join(os.tmpdir(), "isolate-node-functions-test-"),
-    );
-    temporaryDirectories.push(workspaceRoot);
-    const targetPackageDir = path.join(
-      workspaceRoot,
-      "packages",
-      "functions-node",
-    );
-    await fs.ensureDir(targetPackageDir);
-    await fs.writeJson(path.join(workspaceRoot, "package.json"), {
-      name: "workspace",
-      version: "1.0.0",
-      private: true,
-      workspaces: ["packages/*"],
-    });
-    await fs.writeJson(path.join(workspaceRoot, "package-lock.json"), {
-      name: "workspace",
-      version: "1.0.0",
-      lockfileVersion: 3,
-      requires: true,
-      packages: {
-        "": {
-          name: "workspace",
-          version: "1.0.0",
-          workspaces: ["packages/*"],
-        },
-        "packages/functions-node": {
-          name: "functions-node",
-          version: "1.0.0",
-        },
-      },
-    });
-    await fs.writeJson(path.join(targetPackageDir, "package.json"), {
-      name: "functions-node",
-      version: "1.0.0",
-      files: ["index.js"],
-    });
-    await fs.writeFile(path.join(targetPackageDir, "index.js"), "export {};\n");
-
-    const result = await isolate({
-      targetPackagePath: targetPackageDir,
-      buildDirName: ".",
-      workspaceRoot: "../..",
-    });
-
-    expect(result).toBe(path.join(targetPackageDir, "isolate"));
-    await expect(
-      fs.readJson(path.join(result, "package.json")),
-    ).resolves.toMatchObject({ name: "functions-node", version: "1.0.0" });
   });
 
   it("rejects an invalid package.json path", async () => {

--- a/src/isolate.ts
+++ b/src/isolate.ts
@@ -95,7 +95,7 @@ export function createIsolator(initialConfig?: IsolateConfig) {
 
       if (await fs.pathExists(existingIsolateDir)) {
         log.warn(
-          "The skipped target contains an existing isolate directory that may be stale",
+          "The skipped target contains an existing isolate path that may be stale",
           existingIsolateDir,
         );
       }

--- a/src/isolate.ts
+++ b/src/isolate.ts
@@ -42,7 +42,7 @@ import {
 
 const __dirname = getDirname(import.meta.url);
 
-/** Create an isolator that returns the unchanged target for non-Node sources. */
+/** Create an isolator that returns targets without package manifests unchanged. */
 export function createIsolator(initialConfig?: IsolateConfig) {
   const resolvedConfig = resolveConfig(initialConfig);
 
@@ -443,7 +443,7 @@ export function createIsolator(initialConfig?: IsolateConfig) {
   };
 }
 
-/** Return the isolate directory, or the unchanged target for non-Node sources. */
+/** Return the isolate directory, or an unchanged target without a package manifest. */
 export async function isolate(config?: IsolateConfig): Promise<string> {
   return createIsolator(config)();
 }

--- a/src/isolate.ts
+++ b/src/isolate.ts
@@ -1,13 +1,14 @@
 import fs from "fs-extra";
 import { got } from "get-or-throw";
 import assert from "node:assert";
+import type { Stats } from "node:fs";
 import path from "node:path";
 import { unique } from "remeda";
 import type { IsolateConfig } from "./lib/config";
 import {
   resolveConfig,
   resolveTargetPackageDir,
-  resolveWorkspacePaths,
+  resolveWorkspaceRootDir,
 } from "./lib/config";
 import { processLockfile } from "./lib/lockfile";
 import { setLogLevel, useLogger } from "./lib/logger";
@@ -41,6 +42,7 @@ import {
 
 const __dirname = getDirname(import.meta.url);
 
+/** Create an isolator that returns the unchanged target for non-Node sources. */
 export function createIsolator(initialConfig?: IsolateConfig) {
   const resolvedConfig = resolveConfig(initialConfig);
 
@@ -56,32 +58,60 @@ export function createIsolator(initialConfig?: IsolateConfig) {
     log.debug("Using isolate-package version", libraryVersion);
 
     const targetPackageDir = resolveTargetPackageDir(config);
-    const targetStats = await fs.stat(targetPackageDir);
-
-    assert(
-      targetStats.isDirectory(),
-      `Target package path is not a directory: ${targetPackageDir}`,
-    );
-
-    const targetManifestPath = path.join(targetPackageDir, "package.json");
-    let targetHasManifest = true;
+    let targetStats: Stats;
 
     try {
-      await fs.stat(targetManifestPath);
+      targetStats = await fs.stat(targetPackageDir);
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
-      targetHasManifest = false;
+      throw new Error(
+        `Target package path does not exist: ${targetPackageDir}`,
+        { cause: error },
+      );
     }
 
-    if (!targetHasManifest) {
-      log.debug(
+    if (!targetStats.isDirectory()) {
+      throw new Error(
+        `Target package path is not a directory: ${targetPackageDir}`,
+      );
+    }
+
+    const targetManifestPath = path.join(targetPackageDir, "package.json");
+    let targetManifestStats: Stats;
+
+    try {
+      targetManifestStats = await fs.stat(targetManifestPath);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      log.info(
         "Skipping isolation because the target directory has no package.json",
         targetPackageDir,
       );
+
+      const existingIsolateDir = path.join(
+        targetPackageDir,
+        config.isolateDirName,
+      );
+
+      if (await fs.pathExists(existingIsolateDir)) {
+        log.warn(
+          "The skipped target contains an existing isolate directory that may be stale",
+          existingIsolateDir,
+        );
+      }
+
       return targetPackageDir;
     }
 
-    const { workspaceRootDir } = resolveWorkspacePaths(config);
+    if (!targetManifestStats.isFile()) {
+      throw new Error(`Package manifest is not a file: ${targetManifestPath}`);
+    }
+
+    const targetPackageManifest = (await readTypedJson(
+      targetManifestPath,
+    )) as PackageManifest;
+
+    const workspaceRootDir = resolveWorkspaceRootDir(config, targetPackageDir);
 
     const buildOutputDir = getBuildOutputDir({
       targetPackageDir,
@@ -120,10 +150,6 @@ export function createIsolator(initialConfig?: IsolateConfig) {
 
     const tmpDir = path.join(isolateDir, "__tmp");
     await fs.ensureDir(tmpDir);
-
-    const targetPackageManifest = (await readTypedJson(
-      targetManifestPath,
-    )) as PackageManifest;
 
     /** Validate mandatory fields for the target package */
     validateManifestMandatoryFields(
@@ -417,7 +443,7 @@ export function createIsolator(initialConfig?: IsolateConfig) {
   };
 }
 
-/** Keep the original function for backward compatibility */
+/** Return the isolate directory, or the unchanged target for non-Node sources. */
 export async function isolate(config?: IsolateConfig): Promise<string> {
   return createIsolator(config)();
 }

--- a/src/isolate.ts
+++ b/src/isolate.ts
@@ -83,6 +83,19 @@ export function createIsolator(initialConfig?: IsolateConfig) {
       targetManifestStats = await fs.stat(targetManifestPath);
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+
+      try {
+        await fs.lstat(targetManifestPath);
+        throw new Error(
+          `Package manifest cannot be resolved: ${targetManifestPath}`,
+          { cause: error },
+        );
+      } catch (manifestError) {
+        if ((manifestError as NodeJS.ErrnoException).code !== "ENOENT") {
+          throw manifestError;
+        }
+      }
+
       log.info(
         "Skipping isolation because the target directory has no package.json",
         targetPackageDir,

--- a/src/isolate.ts
+++ b/src/isolate.ts
@@ -54,6 +54,19 @@ export function createIsolator(initialConfig?: IsolateConfig) {
     const { targetPackageDir, workspaceRootDir } =
       resolveWorkspacePaths(config);
 
+    const targetManifestPath = path.join(targetPackageDir, "package.json");
+
+    if (
+      (await fs.pathExists(targetPackageDir)) &&
+      !(await fs.pathExists(targetManifestPath))
+    ) {
+      log.debug(
+        "Skipping isolation because the target directory has no package.json",
+        getRootRelativeLogPath(targetPackageDir, workspaceRootDir),
+      );
+      return targetPackageDir;
+    }
+
     const buildOutputDir = getBuildOutputDir({
       targetPackageDir,
       buildDirName: config.buildDirName,
@@ -93,7 +106,7 @@ export function createIsolator(initialConfig?: IsolateConfig) {
     await fs.ensureDir(tmpDir);
 
     const targetPackageManifest = (await readTypedJson(
-      path.join(targetPackageDir, "package.json"),
+      targetManifestPath,
     )) as PackageManifest;
 
     /** Validate mandatory fields for the target package */

--- a/src/isolate.ts
+++ b/src/isolate.ts
@@ -4,7 +4,11 @@ import assert from "node:assert";
 import path from "node:path";
 import { unique } from "remeda";
 import type { IsolateConfig } from "./lib/config";
-import { resolveConfig, resolveWorkspacePaths } from "./lib/config";
+import {
+  resolveConfig,
+  resolveTargetPackageDir,
+  resolveWorkspacePaths,
+} from "./lib/config";
 import { processLockfile } from "./lib/lockfile";
 import { setLogLevel, useLogger } from "./lib/logger";
 import {
@@ -51,21 +55,33 @@ export function createIsolator(initialConfig?: IsolateConfig) {
 
     log.debug("Using isolate-package version", libraryVersion);
 
-    const { targetPackageDir, workspaceRootDir } =
-      resolveWorkspacePaths(config);
+    const targetPackageDir = resolveTargetPackageDir(config);
+    const targetStats = await fs.stat(targetPackageDir);
+
+    assert(
+      targetStats.isDirectory(),
+      `Target package path is not a directory: ${targetPackageDir}`,
+    );
 
     const targetManifestPath = path.join(targetPackageDir, "package.json");
+    let targetHasManifest = true;
 
-    if (
-      (await fs.pathExists(targetPackageDir)) &&
-      !(await fs.pathExists(targetManifestPath))
-    ) {
+    try {
+      await fs.stat(targetManifestPath);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      targetHasManifest = false;
+    }
+
+    if (!targetHasManifest) {
       log.debug(
         "Skipping isolation because the target directory has no package.json",
-        getRootRelativeLogPath(targetPackageDir, workspaceRootDir),
+        targetPackageDir,
       );
       return targetPackageDir;
     }
+
+    const { workspaceRootDir } = resolveWorkspacePaths(config);
 
     const buildOutputDir = getBuildOutputDir({
       targetPackageDir,

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -193,16 +193,31 @@ function validateConfig(config: IsolateConfig) {
  */
 export function resolveWorkspacePaths(config: IsolateConfigResolved) {
   const targetPackageDir = resolveTargetPackageDir(config);
+  const workspaceRootDir = resolveWorkspaceRootDir(config, targetPackageDir);
 
+  return { targetPackageDir, workspaceRootDir };
+}
+
+/** Resolve the package target without requiring a JavaScript workspace. */
+export function resolveTargetPackageDir(config: IsolateConfigResolved) {
+  return config.targetPackagePath
+    ? path.isAbsolute(config.targetPackagePath)
+      ? config.targetPackagePath
+      : path.join(process.cwd(), config.targetPackagePath)
+    : process.cwd();
+}
+
+/** Resolve the workspace root for a target that requires isolation. */
+export function resolveWorkspaceRootDir(
+  config: IsolateConfigResolved,
+  targetPackageDir: string,
+) {
   if (config.targetPackagePath && !path.isAbsolute(config.targetPackagePath)) {
-    return { targetPackageDir, workspaceRootDir: process.cwd() };
+    return process.cwd();
   }
 
   if (config.workspaceRoot !== undefined) {
-    return {
-      targetPackageDir,
-      workspaceRootDir: path.join(targetPackageDir, config.workspaceRoot),
-    };
+    return path.join(targetPackageDir, config.workspaceRoot);
   }
 
   const detected = detectMonorepo(targetPackageDir);
@@ -213,15 +228,7 @@ export function resolveWorkspacePaths(config: IsolateConfigResolved) {
     );
   }
 
-  return { targetPackageDir, workspaceRootDir: detected.rootDir };
-}
-
-export function resolveTargetPackageDir(config: IsolateConfigResolved) {
-  return config.targetPackagePath
-    ? path.isAbsolute(config.targetPackagePath)
-      ? config.targetPackagePath
-      : path.join(process.cwd(), config.targetPackagePath)
-    : process.cwd();
+  return detected.rootDir;
 }
 
 export function resolveConfig(

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -192,11 +192,7 @@ function validateConfig(config: IsolateConfig) {
  * otherwise auto-detected by walking upward from the target package directory.
  */
 export function resolveWorkspacePaths(config: IsolateConfigResolved) {
-  const targetPackageDir = config.targetPackagePath
-    ? path.isAbsolute(config.targetPackagePath)
-      ? config.targetPackagePath
-      : path.join(process.cwd(), config.targetPackagePath)
-    : process.cwd();
+  const targetPackageDir = resolveTargetPackageDir(config);
 
   if (config.targetPackagePath && !path.isAbsolute(config.targetPackagePath)) {
     return { targetPackageDir, workspaceRootDir: process.cwd() };
@@ -218,6 +214,14 @@ export function resolveWorkspacePaths(config: IsolateConfigResolved) {
   }
 
   return { targetPackageDir, workspaceRootDir: detected.rootDir };
+}
+
+export function resolveTargetPackageDir(config: IsolateConfigResolved) {
+  return config.targetPackagePath
+    ? path.isAbsolute(config.targetPackagePath)
+      ? config.targetPackagePath
+      : path.join(process.cwd(), config.targetPackagePath)
+    : process.cwd();
 }
 
 export function resolveConfig(


### PR DESCRIPTION
Firebase monorepos can contain Node and Python functions codebases under the same workspace root. The Firebase integration passed both through `isolate()`, but a typical Python source has no `package.json` or TypeScript build output, so deployment failed before Firebase could package it.

`isolate()` now validates the target path before workspace detection. An existing directory without `package.json` bypasses isolation and returns its original path. Targets with a package manifest continue through the normal isolation flow, while missing targets, file targets, invalid manifest paths, and dangling manifest symlinks fail with explicit errors. Default logs report the bypass and warn when an old isolate path may be stale.

The path resolver now separates target resolution from workspace-root resolution, which avoids requiring JavaScript workspace markers for targets without a manifest. The Firebase and API documentation describes the two return paths. Regression coverage includes the bypass, target validation, and stale-output logging; the complete Node isolation case remains an integration test.

Decisions:
- Package-manifest presence selects whether isolation applies. Runtime metadata is unavailable at the Firebase call site, while `package.json` is the input contract isolate-package requires.
- Existing isolate output is preserved on bypass because deleting user data would be unsafe. A warning makes possible stale output visible.

Closes #203

Scope: packages (isolate-package), docs
Visibility: user-facing
Implementer: codex:gpt-5.6-sol:low
