### PR TITLE
Read the two-document pnpm-lock.yaml written by pnpm 12

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -106,6 +106,13 @@ The codebase uses `~/` as path alias for `src/` (configured in tsconfig.json).
 
 Tests use Vitest and are co-located with source files (`*.test.ts`).
 
+When a change exists to get different behavior out of a dependency, at least
+one test must exercise that dependency unmocked. Mocking the package whose
+behavior the change was made for proves nothing about it. Use the
+`*.integration.test.ts` pattern with a fixture under
+`__fixtures__/<name>/workspace`, as `generate-npm-lockfile.integration.test.ts`
+and `generate-pnpm-lockfile.integration.test.ts` do.
+
 ## Code Style
 
 - Use JSDoc style comments (`/** ... */`) for all comments, including

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -53,8 +53,11 @@ by name.
 
 **lockfile/** - Generates isolated lockfiles for each package manager:
 
-- PNPM: Prunes and adapts lockfile using `@pnpm/lockfile-file` and
-  `@pnpm/prune-lockfile` (supports v8 and v9)
+- PNPM: Prunes and adapts lockfile using `@pnpm/prune-lockfile`, reading and
+  writing with `@pnpm/lockfile-file` for lockfile v8 and `@pnpm/lockfile.fs`
+  for v9 (the maintained successor, which handles the two-document lockfile
+  pnpm 12 writes). Both are aliased in package.json as `pnpm_lockfile_file_v8`
+  and `pnpm_lockfile_file_v9`.
 - NPM: Uses `@npmcli/arborist`'s `loadVirtual` + `workspaceDependencySet`
   to compute the target's transitive closure, then copies matching entries
   verbatim from the root `package-lock.json` (preserves original resolved

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "meow": "^14.1.0",
     "outdent": "^0.8.0",
     "pnpm_lockfile_file_v8": "npm:@pnpm/lockfile-file@8",
-    "pnpm_lockfile_file_v9": "npm:@pnpm/lockfile.fs@1100.2.4",
+    "pnpm_lockfile_file_v9": "npm:@pnpm/lockfile.fs@1100.2.2",
     "pnpm_prune_lockfile_v8": "npm:@pnpm/prune-lockfile@5",
     "pnpm_prune_lockfile_v9": "npm:@pnpm/prune-lockfile@6.0.0",
     "remeda": "^2.33.7",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "meow": "^14.1.0",
     "outdent": "^0.8.0",
     "pnpm_lockfile_file_v8": "npm:@pnpm/lockfile-file@8",
-    "pnpm_lockfile_file_v9": "npm:@pnpm/lockfile-file@9.0.0",
+    "pnpm_lockfile_file_v9": "npm:@pnpm/lockfile.fs@1100.2.4",
     "pnpm_prune_lockfile_v8": "npm:@pnpm/prune-lockfile@5",
     "pnpm_prune_lockfile_v9": "npm:@pnpm/prune-lockfile@6.0.0",
     "remeda": "^2.33.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,8 +48,8 @@ importers:
         specifier: npm:@pnpm/lockfile-file@8
         version: '@pnpm/lockfile-file@8.1.8(@pnpm/logger@1100.0.0)'
       pnpm_lockfile_file_v9:
-        specifier: npm:@pnpm/lockfile.fs@1100.2.4
-        version: '@pnpm/lockfile.fs@1100.2.4(@pnpm/logger@1100.0.0)'
+        specifier: npm:@pnpm/lockfile.fs@1100.2.2
+        version: '@pnpm/lockfile.fs@1100.2.2(@pnpm/logger@1100.0.0)'
       pnpm_prune_lockfile_v8:
         specifier: npm:@pnpm/prune-lockfile@5
         version: '@pnpm/prune-lockfile@5.0.10'
@@ -787,12 +787,12 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@pnpm/config.normalize-registries@1101.0.0':
-    resolution: {integrity: sha512-+2p2vgurPOhlayWNsVq/zpfEgXLO+3KX/0H5YhpFgOCQ+wocE2T0/8HF+Dv1Xt13UnUNbL7pCDWEBLzIcKtw5w==}
+  '@pnpm/config.normalize-registries@1100.1.0':
+    resolution: {integrity: sha512-l8xf0PlDbupJsIYwh17Poc7+m/dIYTUcwK8HaLv/YOJCxKjt8KnOaVZE5ZPO2t9YQqa1YPFBBwdI+GCEy55E4A==}
     engines: {node: '>=22.13'}
 
-  '@pnpm/constants@1102.0.0':
-    resolution: {integrity: sha512-HIDFQTclaw7oxZjVUxDP+1dsNtBK8PRXj3qanALtK7iLi/FlVnwFQs9ISBocEX6Kivytn/YCT+UEStoFPBWQeQ==}
+  '@pnpm/constants@1101.0.0':
+    resolution: {integrity: sha512-jJQU6y8lhic2at0+W246+tMDdEqhbS1WSRlTjmIXeXrrWU2rAbhixi11loE+lI3f/E1Ci1+3i5N6ewOumeNJdg==}
     engines: {node: '>=22.13'}
 
   '@pnpm/constants@7.1.1':
@@ -823,20 +823,20 @@ packages:
     resolution: {integrity: sha512-7n6pwEN/BiqUQEEBct62kXU0SB0gSgt2b+1RObAD7aEo4kvHbqgRy5ZXn4/DPStUy6YlccZJ8veI5ne+GQ9hKA==}
     engines: {node: '>=18.12'}
 
-  '@pnpm/deps.path@1101.0.0':
-    resolution: {integrity: sha512-awgi3rf0/Kes/QTVLx/E34rGrg72hNASNDQVp3dE0sQkNv71D3RAQI3K4kaey2VPSvTPx4O/Kn8nMpEUnxVmvA==}
+  '@pnpm/deps.path@1100.1.0':
+    resolution: {integrity: sha512-1KbfwG1D5mKg0g1XacgGlw9NsBpO7HspQHdYbMhN6XvQ+10V3v4G9PQCo5Vlems6qolZKNYC0wv/HKOETuAsQA==}
     engines: {node: '>=22.13'}
 
-  '@pnpm/error@1100.1.3':
-    resolution: {integrity: sha512-YwnVAPxkVCzKksIqnMn+EmiM186KWPAnVwqp+ro5Y2N4b4nhvdzYSfbO6OM4Is9z/EC1qOA6rF63QQ+z4DVjgw==}
+  '@pnpm/error@1100.1.2':
+    resolution: {integrity: sha512-HzeZOy38srT5glZqrlBcdfHd13tec3wrLiVRB5vQnj+ScOswQ2DzZzMJpqMh39gss6zhiTl/MskqKzoY/qT9ew==}
     engines: {node: '>=22.13'}
 
   '@pnpm/error@5.0.3':
     resolution: {integrity: sha512-ONJU5cUeoeJSy50qOYsMZQHTA/9QKmGgh1ATfEpCLgtbdwqUiwD9MxHNeXUYYI/pocBCz6r1ZCFqiQvO+8SUKA==}
     engines: {node: '>=16.14'}
 
-  '@pnpm/fetching.fetcher-base@1100.2.8':
-    resolution: {integrity: sha512-j8rOlWD7hfW7emwtYudsQhzXTormlZbHtP94DDZhwzKJR8CrunHrmqEYHY68xwCb2Chd4FPYILNzTDHAYDK99Q==}
+  '@pnpm/fetching.fetcher-base@1100.2.7':
+    resolution: {integrity: sha512-piCdM7JfJ/CcaiSza3ge3fkOda1sV5q4PYwKpPVIKS/415CfwyGbqN2738NjHCQ6Nx5oiNPSDZIJ2ZTRZFG27Q==}
     engines: {node: '>=22.13'}
 
   '@pnpm/fs.graceful-fs@1100.1.1':
@@ -847,8 +847,8 @@ packages:
     resolution: {integrity: sha512-lUI+XrzOJN4zdPGOGnFUrmtXAXpXi8wD8OI0nWOZmlh+raqbLzC3VkXu1zgaduOK6YonOcnQW88O+ojav1rAdA==}
     engines: {node: '>=16.14'}
 
-  '@pnpm/hooks.types@1101.0.0':
-    resolution: {integrity: sha512-yuRQYUKJMW4D3OskOcBPhnExlFDeOmgxnQGWImCR5mXkNjcOAFAkd7EGFQ5jTCZ9b0z6rMZ6yqqKd/Kgcs7SzQ==}
+  '@pnpm/hooks.types@1100.2.6':
+    resolution: {integrity: sha512-45eHmVhaWiIeBPHzRmTAFhJMH6eVYMOCY/loa6jg9SDS19FTvYDKgAgOEXOWDXsUyzCMrpPsExGsHzDhKsPgrg==}
     engines: {node: '>=22.13'}
 
   '@pnpm/lockfile-file@8.1.8':
@@ -865,22 +865,22 @@ packages:
     resolution: {integrity: sha512-a4/ULIPLZIIq8Qmi2HEoFgRTtEouGU5RNhuGDxnSmkxu1BjlNMNjLJeEI5jzMZCGOjBoML+AirY/XOO3bcEQ/w==}
     engines: {node: '>=18.12'}
 
-  '@pnpm/lockfile.fs@1100.2.4':
-    resolution: {integrity: sha512-w1HbjT6L/NKlhdHe07cGgYCYrvPawC91O8eOkrWYfMXxvxBUK9SknkLiYNVy38935a3o4iv+/v+wdB/mdjfgpg==}
+  '@pnpm/lockfile.fs@1100.2.2':
+    resolution: {integrity: sha512-OxQswRFx3yjR8Y/7tNTTMkZVbig+CwbdtEvb3zzWbR1KSlowLt28Sl30vm7WyWymSAK1iEbqzrYRks2Wetp7YQ==}
     engines: {node: '>=22.13'}
     peerDependencies:
       '@pnpm/logger': ^1100.0.0
 
-  '@pnpm/lockfile.merger@1100.0.20':
-    resolution: {integrity: sha512-nYYEXJnCXtuim02z2yJ+mivJMho3G7iIBxNQINR6TZ66AtR2VHCdekZh2zGkODGxWPYBW3AhC7GqYYFc4DaeVQ==}
+  '@pnpm/lockfile.merger@1100.0.19':
+    resolution: {integrity: sha512-f5Ru2UfFxFi0/Bm4k40PG98plC60U+5adTZKKrYuaevpWxSAykxVCtP2XuS6SOc0LJ6YYaaaqW9Q82u9WUFNSw==}
     engines: {node: '>=22.13'}
 
-  '@pnpm/lockfile.types@1100.0.20':
-    resolution: {integrity: sha512-1nSWfBDvR1uzoKp7SaO+cgBJejO8DI18OqTrB5ugzgAWvViGnLGgkQk+sMHw/DOW5ChKOQ4ot2SEnQCfMxpC9A==}
+  '@pnpm/lockfile.types@1100.0.19':
+    resolution: {integrity: sha512-aGfowxMEG5r3kBA17JD9ZYmLrq8edKNl5aR10S1/5ebmNfCYvstaCH9Bh7U5AEvCwJREXp3i1vRt8rGsmDjYPQ==}
     engines: {node: '>=22.13'}
 
-  '@pnpm/lockfile.utils@1102.0.0':
-    resolution: {integrity: sha512-GjJi2mn53RxpxNs9CB0ZocT+CdtwqgTND9ZLxvdj2TJ2MIXD1my16eaGmxL2cMBgdziPHidE0MIQs61OCjQt1w==}
+  '@pnpm/lockfile.utils@1101.1.0':
+    resolution: {integrity: sha512-98O9GDf++r4h+WWB3rmKOv5cWZSD5pURbJf0QGguwZWuTwDUuMDigtejT2gY+OJQomoE15hdcN8I7ueQPYsdyg==}
     engines: {node: '>=22.13'}
 
   '@pnpm/logger@1100.0.0':
@@ -914,12 +914,12 @@ packages:
   '@pnpm/ramda@0.28.1':
     resolution: {integrity: sha512-zcAG+lvU0fMziNeGXpPyCyCJYp5ZVrPElEE4t14jAmViaihohocZ+dDkcRIyAomox8pQsuZnv1EyHR+pOhmUWw==}
 
-  '@pnpm/resolving.resolver-base@1101.1.1':
-    resolution: {integrity: sha512-306yAbFEvqFl+6PZf9K3sbl4DtV8Yej9jPixrSA7HTdlxIasQih3+b9tMaWg519IuzcFGX62VRbqeSs8zfOJWA==}
+  '@pnpm/resolving.resolver-base@1101.1.0':
+    resolution: {integrity: sha512-QKVY738e16fn7/A8AlY8YG/kGloPkwnqDTsC8N6f9wHD8t6/vr3W4ouroLzWtiRv2lY/PqCUAC3nYyng/GI+Qg==}
     engines: {node: '>=22.13'}
 
-  '@pnpm/resolving.tarball-url@1101.0.0':
-    resolution: {integrity: sha512-tlA74PFCSaAy1FfmrZt87g7y5fySr5bHpas+ht8CFrsxbnIy0NWulKefdpp+2GVXGSXLuHNAbW0T8QThIlI8yw==}
+  '@pnpm/resolving.tarball-url@1100.0.1':
+    resolution: {integrity: sha512-6LTJYB1l7VZIhFCSoEQKcrpW3xnyScAfJfukDBw5qAKTabehFsR+uwTM2mrLzsLMfXiJcRmAeFfJCQIwr7pamg==}
     engines: {node: '>=22.13'}
 
   '@pnpm/store.cafs-types@1100.0.2':
@@ -934,8 +934,8 @@ packages:
     resolution: {integrity: sha512-NLTXheat/u7OEGg5M5vF6Z85zx8uKUZE0+whtX/sbFV2XL48RdnOWGPTKYuVVkv8M+launaLUTgGEXNs/ess2w==}
     engines: {node: '>=18.12'}
 
-  '@pnpm/types@1102.0.0':
-    resolution: {integrity: sha512-mgR291P+TGABUzGifQyZyU+EE0lBSTGJ87C5J95Ez2XRFlfcH/9GIN5n2saIgzXQAiyoeFSlEVEiXeEIJy+B3A==}
+  '@pnpm/types@1101.9.0':
+    resolution: {integrity: sha512-lB2aSB2h950UX1GX3JW4AZ86xjXD92YJbV92IBSQqHXXZdiemoVKADLA2cDQ4/wKeS7djY8fkITM6X+6iYF62A==}
     engines: {node: '>=22.13'}
 
   '@pnpm/types@9.4.2':
@@ -3489,14 +3489,14 @@ snapshots:
   '@oxlint/binding-win32-x64-msvc@1.64.0':
     optional: true
 
-  '@pnpm/config.normalize-registries@1101.0.0':
+  '@pnpm/config.normalize-registries@1100.1.0':
     dependencies:
-      '@pnpm/constants': 1102.0.0
-      '@pnpm/types': 1102.0.0
+      '@pnpm/constants': 1101.0.0
+      '@pnpm/types': 1101.9.0
       normalize-registry-url: 2.0.1
       ramda: '@pnpm/ramda@0.28.1'
 
-  '@pnpm/constants@1102.0.0': {}
+  '@pnpm/constants@1101.0.0': {}
 
   '@pnpm/constants@7.1.1': {}
 
@@ -3528,24 +3528,24 @@ snapshots:
       '@pnpm/types': 10.0.0
       semver: 7.7.4
 
-  '@pnpm/deps.path@1101.0.0':
+  '@pnpm/deps.path@1100.1.0':
     dependencies:
       '@pnpm/crypto.hash': 1100.0.2
-      '@pnpm/types': 1102.0.0
+      '@pnpm/types': 1101.9.0
       semver: 7.8.5
 
-  '@pnpm/error@1100.1.3':
+  '@pnpm/error@1100.1.2':
     dependencies:
-      '@pnpm/constants': 1102.0.0
+      '@pnpm/constants': 1101.0.0
 
   '@pnpm/error@5.0.3':
     dependencies:
       '@pnpm/constants': 7.1.1
 
-  '@pnpm/fetching.fetcher-base@1100.2.8':
+  '@pnpm/fetching.fetcher-base@1100.2.7':
     dependencies:
-      '@pnpm/resolving.resolver-base': 1101.1.1
-      '@pnpm/types': 1102.0.0
+      '@pnpm/resolving.resolver-base': 1101.1.0
+      '@pnpm/types': 1101.9.0
       '@types/ssri': 7.1.5
 
   '@pnpm/fs.graceful-fs@1100.1.1':
@@ -3556,13 +3556,13 @@ snapshots:
     dependencies:
       execa: safe-execa@0.1.2
 
-  '@pnpm/hooks.types@1101.0.0':
+  '@pnpm/hooks.types@1100.2.6':
     dependencies:
-      '@pnpm/fetching.fetcher-base': 1100.2.8
-      '@pnpm/lockfile.types': 1100.0.20
-      '@pnpm/resolving.resolver-base': 1101.1.1
+      '@pnpm/fetching.fetcher-base': 1100.2.7
+      '@pnpm/lockfile.types': 1100.0.19
+      '@pnpm/resolving.resolver-base': 1101.1.0
       '@pnpm/store.cafs-types': 1100.0.2
-      '@pnpm/types': 1102.0.0
+      '@pnpm/types': 1101.9.0
 
   '@pnpm/lockfile-file@8.1.8(@pnpm/logger@1100.0.0)':
     dependencies:
@@ -3593,18 +3593,18 @@ snapshots:
     dependencies:
       '@pnpm/types': 10.0.0
 
-  '@pnpm/lockfile.fs@1100.2.4(@pnpm/logger@1100.0.0)':
+  '@pnpm/lockfile.fs@1100.2.2(@pnpm/logger@1100.0.0)':
     dependencies:
-      '@pnpm/constants': 1102.0.0
-      '@pnpm/deps.path': 1101.0.0
-      '@pnpm/error': 1100.1.3
-      '@pnpm/lockfile.merger': 1100.0.20
-      '@pnpm/lockfile.types': 1100.0.20
-      '@pnpm/lockfile.utils': 1102.0.0
+      '@pnpm/constants': 1101.0.0
+      '@pnpm/deps.path': 1100.1.0
+      '@pnpm/error': 1100.1.2
+      '@pnpm/lockfile.merger': 1100.0.19
+      '@pnpm/lockfile.types': 1100.0.19
+      '@pnpm/lockfile.utils': 1101.1.0
       '@pnpm/logger': 1100.0.0
       '@pnpm/network.git-utils': 1100.0.3
       '@pnpm/object.key-sorting': 1100.0.2
-      '@pnpm/types': 1102.0.0
+      '@pnpm/types': 1101.9.0
       '@zkochan/rimraf': 4.0.0
       comver-to-semver: 2.0.0
       js-yaml: '@zkochan/js-yaml@0.0.11'
@@ -3614,31 +3614,31 @@ snapshots:
       strip-bom: 5.0.0
       write-file-atomic: 7.0.1
 
-  '@pnpm/lockfile.merger@1100.0.20':
+  '@pnpm/lockfile.merger@1100.0.19':
     dependencies:
-      '@pnpm/lockfile.types': 1100.0.20
-      '@pnpm/types': 1102.0.0
+      '@pnpm/lockfile.types': 1100.0.19
+      '@pnpm/types': 1101.9.0
       comver-to-semver: 2.0.0
       ramda: '@pnpm/ramda@0.28.1'
       semver: 7.8.5
 
-  '@pnpm/lockfile.types@1100.0.20':
+  '@pnpm/lockfile.types@1100.0.19':
     dependencies:
       '@pnpm/patching.types': 1100.0.1
-      '@pnpm/resolving.resolver-base': 1101.1.1
-      '@pnpm/types': 1102.0.0
+      '@pnpm/resolving.resolver-base': 1101.1.0
+      '@pnpm/types': 1101.9.0
 
-  '@pnpm/lockfile.utils@1102.0.0':
+  '@pnpm/lockfile.utils@1101.1.0':
     dependencies:
-      '@pnpm/config.normalize-registries': 1101.0.0
-      '@pnpm/constants': 1102.0.0
-      '@pnpm/deps.path': 1101.0.0
-      '@pnpm/error': 1100.1.3
-      '@pnpm/hooks.types': 1101.0.0
-      '@pnpm/lockfile.types': 1100.0.20
-      '@pnpm/resolving.resolver-base': 1101.1.1
-      '@pnpm/resolving.tarball-url': 1101.0.0
-      '@pnpm/types': 1102.0.0
+      '@pnpm/config.normalize-registries': 1100.1.0
+      '@pnpm/constants': 1101.0.0
+      '@pnpm/deps.path': 1100.1.0
+      '@pnpm/error': 1100.1.2
+      '@pnpm/hooks.types': 1100.2.6
+      '@pnpm/lockfile.types': 1100.0.19
+      '@pnpm/resolving.resolver-base': 1101.1.0
+      '@pnpm/resolving.tarball-url': 1100.0.1
+      '@pnpm/types': 1101.9.0
       ramda: '@pnpm/ramda@0.28.1'
 
   '@pnpm/logger@1100.0.0':
@@ -3682,13 +3682,11 @@ snapshots:
 
   '@pnpm/ramda@0.28.1': {}
 
-  '@pnpm/resolving.resolver-base@1101.1.1':
+  '@pnpm/resolving.resolver-base@1101.1.0':
     dependencies:
-      '@pnpm/types': 1102.0.0
+      '@pnpm/types': 1101.9.0
 
-  '@pnpm/resolving.tarball-url@1101.0.0':
-    dependencies:
-      '@pnpm/types': 1102.0.0
+  '@pnpm/resolving.tarball-url@1100.0.1': {}
 
   '@pnpm/store.cafs-types@1100.0.2': {}
 
@@ -3696,7 +3694,7 @@ snapshots:
 
   '@pnpm/types@1001.3.0': {}
 
-  '@pnpm/types@1102.0.0': {}
+  '@pnpm/types@1101.9.0': {}
 
   '@pnpm/types@9.4.2': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  pretty-ms: 9.3.0
+
 importers:
 
   .:
@@ -2342,8 +2345,8 @@ packages:
   preact@10.29.1:
     resolution: {integrity: sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==}
 
-  pretty-ms@9.3.1:
-    resolution: {integrity: sha512-HzMy3Geq23nVALD/M2LliU+F+M+gVNsvkQWWqeBZ8HDiCgzo6YPJ/Omrmtq24EFrIsk0a3EkQGEd7bDOo+IhGA==}
+  pretty-ms@9.3.0:
+    resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
     engines: {node: '>=18'}
 
   proc-log@6.1.0:
@@ -4433,7 +4436,7 @@ snapshots:
       is-plain-obj: 4.1.0
       is-stream: 4.0.1
       npm-run-path: 6.0.0
-      pretty-ms: 9.3.1
+      pretty-ms: 9.3.0
       signal-exit: 4.1.0
       strip-final-newline: 4.0.0
       yoctocolors: 2.2.0
@@ -5040,7 +5043,7 @@ snapshots:
 
   preact@10.29.1: {}
 
-  pretty-ms@9.3.1:
+  pretty-ms@9.3.0:
     dependencies:
       parse-ms: 4.0.0
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,8 +48,8 @@ importers:
         specifier: npm:@pnpm/lockfile-file@8
         version: '@pnpm/lockfile-file@8.1.8(@pnpm/logger@1100.0.0)'
       pnpm_lockfile_file_v9:
-        specifier: npm:@pnpm/lockfile-file@9.0.0
-        version: '@pnpm/lockfile-file@9.0.0(@pnpm/logger@1100.0.0)'
+        specifier: npm:@pnpm/lockfile.fs@1100.2.4
+        version: '@pnpm/lockfile.fs@1100.2.4(@pnpm/logger@1100.0.0)'
       pnpm_prune_lockfile_v8:
         specifier: npm:@pnpm/prune-lockfile@5
         version: '@pnpm/prune-lockfile@5.0.10'
@@ -787,6 +787,14 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@pnpm/config.normalize-registries@1101.0.0':
+    resolution: {integrity: sha512-+2p2vgurPOhlayWNsVq/zpfEgXLO+3KX/0H5YhpFgOCQ+wocE2T0/8HF+Dv1Xt13UnUNbL7pCDWEBLzIcKtw5w==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/constants@1102.0.0':
+    resolution: {integrity: sha512-HIDFQTclaw7oxZjVUxDP+1dsNtBK8PRXj3qanALtK7iLi/FlVnwFQs9ISBocEX6Kivytn/YCT+UEStoFPBWQeQ==}
+    engines: {node: '>=22.13'}
+
   '@pnpm/constants@7.1.1':
     resolution: {integrity: sha512-31pZqMtjwV+Vaq7MaPrT1EoDFSYwye3dp6BiHIGRJmVThCQwySRKM7hCvqqI94epNkqFAAYoWrNynWoRYosGdw==}
     engines: {node: '>=16.14'}
@@ -803,6 +811,10 @@ packages:
     resolution: {integrity: sha512-iGKP6rRKng5Tcad1+S+j3UoY5wVZN+z0ZgemlGp69jNgn6EaM4N0Q3mvnDNJ7UZFmL2ClXZZYLNuCk9pUYV3Xg==}
     engines: {node: '>=18.12'}
 
+  '@pnpm/crypto.hash@1100.0.2':
+    resolution: {integrity: sha512-7MNukALUyiFMwOYQongnRWZnpjs4R5lBZgKcycnWjBhN4LxavPciczrz7XK0GuFrw3QS1V5wMV02lPYLF/bA4w==}
+    engines: {node: '>=22.13'}
+
   '@pnpm/dependency-path@2.1.8':
     resolution: {integrity: sha512-ywBaTjy0iSEF7lH3DlF8UXrdL2bw4AQFV2tTOeNeY7wc1W5CE+RHSJhf9MXBYcZPesqGRrPiU7Pimj3l05L9VA==}
     engines: {node: '>=16.14'}
@@ -811,31 +823,37 @@ packages:
     resolution: {integrity: sha512-7n6pwEN/BiqUQEEBct62kXU0SB0gSgt2b+1RObAD7aEo4kvHbqgRy5ZXn4/DPStUy6YlccZJ8veI5ne+GQ9hKA==}
     engines: {node: '>=18.12'}
 
+  '@pnpm/deps.path@1101.0.0':
+    resolution: {integrity: sha512-awgi3rf0/Kes/QTVLx/E34rGrg72hNASNDQVp3dE0sQkNv71D3RAQI3K4kaey2VPSvTPx4O/Kn8nMpEUnxVmvA==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/error@1100.1.3':
+    resolution: {integrity: sha512-YwnVAPxkVCzKksIqnMn+EmiM186KWPAnVwqp+ro5Y2N4b4nhvdzYSfbO6OM4Is9z/EC1qOA6rF63QQ+z4DVjgw==}
+    engines: {node: '>=22.13'}
+
   '@pnpm/error@5.0.3':
     resolution: {integrity: sha512-ONJU5cUeoeJSy50qOYsMZQHTA/9QKmGgh1ATfEpCLgtbdwqUiwD9MxHNeXUYYI/pocBCz6r1ZCFqiQvO+8SUKA==}
     engines: {node: '>=16.14'}
 
-  '@pnpm/error@6.0.0':
-    resolution: {integrity: sha512-SKtHdV09k9+6jkohv9YuYmKMKNpxknoGjo0c6eN8x2Z3MHW2cuSt1OD/L16eCqdKQL+FUbvULxig0b9X9VK2/g==}
-    engines: {node: '>=18.12'}
+  '@pnpm/fetching.fetcher-base@1100.2.8':
+    resolution: {integrity: sha512-j8rOlWD7hfW7emwtYudsQhzXTormlZbHtP94DDZhwzKJR8CrunHrmqEYHY68xwCb2Chd4FPYILNzTDHAYDK99Q==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/fs.graceful-fs@1100.1.1':
+    resolution: {integrity: sha512-knCLxjy9vx18Z1cwzzqD251jxrJhQpJ09Gch+AecX0rOWj/sygjk0UXSWZPaHPwVtK5Je7i2CIAoyYwsb8wZTg==}
+    engines: {node: '>=22.13'}
 
   '@pnpm/git-utils@1.0.0':
     resolution: {integrity: sha512-lUI+XrzOJN4zdPGOGnFUrmtXAXpXi8wD8OI0nWOZmlh+raqbLzC3VkXu1zgaduOK6YonOcnQW88O+ojav1rAdA==}
     engines: {node: '>=16.14'}
 
-  '@pnpm/git-utils@2.0.0':
-    resolution: {integrity: sha512-k1rv4Zvno/5zJAqE/Mh9V0ehlm14NsYwpXTdaGMtyhkoHvlSckRfr23OIOIM7Q/TRX+LhqyJ2kep50SY2TsZ+g==}
-    engines: {node: '>=18.12'}
+  '@pnpm/hooks.types@1101.0.0':
+    resolution: {integrity: sha512-yuRQYUKJMW4D3OskOcBPhnExlFDeOmgxnQGWImCR5mXkNjcOAFAkd7EGFQ5jTCZ9b0z6rMZ6yqqKd/Kgcs7SzQ==}
+    engines: {node: '>=22.13'}
 
   '@pnpm/lockfile-file@8.1.8':
     resolution: {integrity: sha512-bRadYzGFyFtwiynwp4Mkn7NDNHkgKvJ9xtjsCT5XiE6S8wpzS3W8yx2WzHGk9Mm1J/2wM0F52+NzCWhlz5eIqA==}
     engines: {node: '>=16.14'}
-    peerDependencies:
-      '@pnpm/logger': ^5.0.0
-
-  '@pnpm/lockfile-file@9.0.0':
-    resolution: {integrity: sha512-/V39Zl6EwHtgfZTgnwymQk6xCcC9uikHrrG677wyFfSOcBC4rPSSASan+Rbky8w2ztW+iMjSsfSZPCsIg2A7/Q==}
-    engines: {node: '>=18.12'}
     peerDependencies:
       '@pnpm/logger': ^5.0.0
 
@@ -847,9 +865,23 @@ packages:
     resolution: {integrity: sha512-a4/ULIPLZIIq8Qmi2HEoFgRTtEouGU5RNhuGDxnSmkxu1BjlNMNjLJeEI5jzMZCGOjBoML+AirY/XOO3bcEQ/w==}
     engines: {node: '>=18.12'}
 
-  '@pnpm/lockfile-utils@10.0.0':
-    resolution: {integrity: sha512-R2JXeAVdtXwu7NxfA4936Og6JHMGZCjOJ+45DUVP9SR7k2WS1bfOSeD5NRuuwqqdw+gYjsTvaYMYXhH6Sr0k2Q==}
-    engines: {node: '>=18.12'}
+  '@pnpm/lockfile.fs@1100.2.4':
+    resolution: {integrity: sha512-w1HbjT6L/NKlhdHe07cGgYCYrvPawC91O8eOkrWYfMXxvxBUK9SknkLiYNVy38935a3o4iv+/v+wdB/mdjfgpg==}
+    engines: {node: '>=22.13'}
+    peerDependencies:
+      '@pnpm/logger': ^1100.0.0
+
+  '@pnpm/lockfile.merger@1100.0.20':
+    resolution: {integrity: sha512-nYYEXJnCXtuim02z2yJ+mivJMho3G7iIBxNQINR6TZ66AtR2VHCdekZh2zGkODGxWPYBW3AhC7GqYYFc4DaeVQ==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/lockfile.types@1100.0.20':
+    resolution: {integrity: sha512-1nSWfBDvR1uzoKp7SaO+cgBJejO8DI18OqTrB5ugzgAWvViGnLGgkQk+sMHw/DOW5ChKOQ4ot2SEnQCfMxpC9A==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/lockfile.utils@1102.0.0':
+    resolution: {integrity: sha512-GjJi2mn53RxpxNs9CB0ZocT+CdtwqgTND9ZLxvdj2TJ2MIXD1my16eaGmxL2cMBgdziPHidE0MIQs61OCjQt1w==}
+    engines: {node: '>=22.13'}
 
   '@pnpm/logger@1100.0.0':
     resolution: {integrity: sha512-A3bRMTIZ5ptDPAE/KsDeY1J5UqqOiyo66+k/mUvaVjx++OJdMbp9If5kisEq9ljAV5r5TRpkxsJbSdrdJ5WtzQ==}
@@ -859,13 +891,17 @@ packages:
     resolution: {integrity: sha512-fYmX1+EHv3wg7l4A9FCEkjgEBIHaY6JosknkLk3pL8dbB9k6unjIrF9f2onNtpj3XUlWxZ3aBw9THk/Bf6hKow==}
     engines: {node: '>=16.14'}
 
-  '@pnpm/merge-lockfile-changes@6.0.0':
-    resolution: {integrity: sha512-K9ARTZ+o/EZ10RPZY4dftlSnvPgJrVeOG0QwZLNTb9Z9q8D6EqSVwEh7CxDobGFe5FAj2lkDK6DY7EgPI4hhdw==}
-    engines: {node: '>=18.12'}
+  '@pnpm/network.git-utils@1100.0.3':
+    resolution: {integrity: sha512-fm4/tRdIyE6gZ6/svQ6IToFQbzCEhPLtWVKxWcVxphWt+GKaLUFgKbLzVLWom301yShvv7VCX8bC336hdtpW3Q==}
+    engines: {node: '>=22.13'}
 
-  '@pnpm/pick-fetcher@3.0.0':
-    resolution: {integrity: sha512-2eisylRAU/jeuxFEPnS1gjLZKJGbYc4QEtEW6MVUYjO4Xi+2ttkSm7825S0J5IPpUIvln8HYPCUS0eQWSfpOaQ==}
-    engines: {node: '>=18.12'}
+  '@pnpm/object.key-sorting@1100.0.2':
+    resolution: {integrity: sha512-PWQPOBohMGXR7QHvHe4PvxWZjtjHv2+RSW2vXIGRM0mMawdO3I4lt8YxDq7HOXeEkJilZQ7DUu2H8uwqEFfwGQ==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/patching.types@1100.0.1':
+    resolution: {integrity: sha512-79os2WyGOHYnwrGeWNDNfrve12LSon6ovtDQDRktP+aW990pZY8TJ2S8X2lmkcjasi9QdsY5jiBuXvXryfE5xQ==}
+    engines: {node: '>=22.13'}
 
   '@pnpm/prune-lockfile@5.0.10':
     resolution: {integrity: sha512-0/BO97f6jOnCo0YTQcUrrIUQMtz7Y2tDBUteWKTvAPYFifOFkmeIPhPecEfNemxVv9ryBUoCS2KzyIHKDQv+ug==}
@@ -878,9 +914,17 @@ packages:
   '@pnpm/ramda@0.28.1':
     resolution: {integrity: sha512-zcAG+lvU0fMziNeGXpPyCyCJYp5ZVrPElEE4t14jAmViaihohocZ+dDkcRIyAomox8pQsuZnv1EyHR+pOhmUWw==}
 
-  '@pnpm/resolver-base@12.0.0':
-    resolution: {integrity: sha512-R5FmojIoHRIC8hZDyr6a9SM6TkpAQXQXgq5QrycUwknRvGjTnrOFD5JaTzMZohcfFg6TWdA3sp3B0w/mhj98Rg==}
-    engines: {node: '>=18.12'}
+  '@pnpm/resolving.resolver-base@1101.1.1':
+    resolution: {integrity: sha512-306yAbFEvqFl+6PZf9K3sbl4DtV8Yej9jPixrSA7HTdlxIasQih3+b9tMaWg519IuzcFGX62VRbqeSs8zfOJWA==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/resolving.tarball-url@1101.0.0':
+    resolution: {integrity: sha512-tlA74PFCSaAy1FfmrZt87g7y5fySr5bHpas+ht8CFrsxbnIy0NWulKefdpp+2GVXGSXLuHNAbW0T8QThIlI8yw==}
+    engines: {node: '>=22.13'}
+
+  '@pnpm/store.cafs-types@1100.0.2':
+    resolution: {integrity: sha512-eoD3eIkNsEwqUXq47Yc2RoRHpUyv0IDEdhrn5d8m/8l2sw9PRDCFBTPM76WPZ6nRfEN09ArsAAfihzZ96iEaIA==}
+    engines: {node: '>=22.13'}
 
   '@pnpm/types@10.0.0':
     resolution: {integrity: sha512-P608MRTOExt5BkIN2hsrb/ycEchwaPW/x80ujJUAqxKZSXNVAOrlEu3KJ+2+jTCunyWmo/EcE01ZdwCw8jgVrQ==}
@@ -890,6 +934,10 @@ packages:
     resolution: {integrity: sha512-NLTXheat/u7OEGg5M5vF6Z85zx8uKUZE0+whtX/sbFV2XL48RdnOWGPTKYuVVkv8M+launaLUTgGEXNs/ess2w==}
     engines: {node: '>=18.12'}
 
+  '@pnpm/types@1102.0.0':
+    resolution: {integrity: sha512-mgR291P+TGABUzGifQyZyU+EE0lBSTGJ87C5J95Ez2XRFlfcH/9GIN5n2saIgzXQAiyoeFSlEVEiXeEIJy+B3A==}
+    engines: {node: '>=22.13'}
+
   '@pnpm/types@9.4.2':
     resolution: {integrity: sha512-g1hcF8Nv4gd76POilz9gD4LITAPXOe5nX4ijgr8ixCbLQZfcpYiMfJ+C1RlMNRUDo8vhlNB4O3bUlxmT6EAQXA==}
     engines: {node: '>=16.14'}
@@ -897,6 +945,10 @@ packages:
   '@pnpm/util.lex-comparator@1.0.0':
     resolution: {integrity: sha512-3aBQPHntVgk5AweBWZn+1I/fqZ9krK/w01197aYVkAJQGftb+BVWgEepxY5GChjSW12j52XX+CmfynYZ/p0DFQ==}
     engines: {node: '>=12.22.0'}
+
+  '@pnpm/util.lex-comparator@4.0.1':
+    resolution: {integrity: sha512-EZ3aWU7ThppE3Xgq7/ftxq8J/nit6z8I2/wZbC/acea2Zw7KJ1k/fLkGBgyyVAE37CULFsOSmPl3EjYM18cB2Q==}
+    engines: {node: '>=22.13'}
 
   '@quansync/fs@1.0.0':
     resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==}
@@ -1137,6 +1189,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@sec-ant/readable-stream@0.4.1':
+    resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
+
   '@shikijs/core@2.5.0':
     resolution: {integrity: sha512-uu/8RExTKtavlpH7XqnVYBrfBkUc20ngXiX9NSrBhOVZYv/7XQRKUyhtkeflY5QsxC0GbJThCerruZfsUaSldg==}
 
@@ -1184,6 +1239,10 @@ packages:
   '@sigstore/verify@3.1.0':
     resolution: {integrity: sha512-mNe0Iigql08YupSOGv197YdHpPPr+EzDZmfCgMc7RPNaZTw5aLN01nBl6CHJOh3BGtnMIj83EeN4butBchc8Ag==}
     engines: {node: ^20.17.0 || >=22.9.0}
+
+  '@sindresorhus/merge-streams@4.0.0':
+    resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
+    engines: {node: '>=18'}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -1246,6 +1305,9 @@ packages:
 
   '@types/source-map-support@0.5.10':
     resolution: {integrity: sha512-tgVP2H469x9zq34Z0m/fgPewGhg/MLClalNOiPIzQlXrSS2YrKu/xCdSCKnEDwkFha51VKEKB6A9wW26/ZNwzA==}
+
+  '@types/ssri@7.1.5':
+    resolution: {integrity: sha512-odD/56S3B51liILSk5aXJlnYt99S6Rt9EFDDqGtJM26rKHApHcwyU/UoYHrzKkdkHMAIquGWCuHtQTbes+FRQw==}
 
   '@types/tar-fs@2.0.4':
     resolution: {integrity: sha512-ipPec0CjTmVDWE+QKr9cTmIIoTl7dFG/yARCM5MqK8i6CNLIG1P8x4kwDsOQY1ChZOZjH0wO9nvfgBvWl4R3kA==}
@@ -1386,17 +1448,21 @@ packages:
   '@vueuse/shared@12.8.2':
     resolution: {integrity: sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w==}
 
-  '@zkochan/js-yaml@0.0.6':
-    resolution: {integrity: sha512-nzvgl3VfhcELQ8LyVrYOru+UtAy1nrygk2+AGbTm8a5YcO6o8lSjAT+pfg3vJWxIoZKOUhrK6UU7xW/+00kQrg==}
+  '@zkochan/js-yaml@0.0.11':
+    resolution: {integrity: sha512-SO+h5Jg079r2JvGle0jbdtk1EY7ppu6TGzmfWTp3Gy61IEb1OVKBocJ6ydTn4++nYFNfRKYenI2MniZQwsM9KQ==}
     hasBin: true
 
-  '@zkochan/js-yaml@0.0.7':
-    resolution: {integrity: sha512-nrUSn7hzt7J6JWgWGz78ZYI8wj+gdIJdk0Ynjpp8l+trkn58Uqsf6RYrYkEK+3X18EX+TNdtJI0WxAtc+L84SQ==}
+  '@zkochan/js-yaml@0.0.6':
+    resolution: {integrity: sha512-nzvgl3VfhcELQ8LyVrYOru+UtAy1nrygk2+AGbTm8a5YcO6o8lSjAT+pfg3vJWxIoZKOUhrK6UU7xW/+00kQrg==}
     hasBin: true
 
   '@zkochan/rimraf@2.1.3':
     resolution: {integrity: sha512-mCfR3gylCzPC+iqdxEA6z5SxJeOgzgbwmyxanKriIne5qZLswDe/M43aD3p5MNzwzXRhbZg/OX+MpES6Zk1a6A==}
     engines: {node: '>=12.10'}
+
+  '@zkochan/rimraf@4.0.0':
+    resolution: {integrity: sha512-0EdBn93hMsbx4svJsKQCch+sNMuXvzWbVYqTCGdctQmxtuYK57uCURZPNiNdwS2Y31d96DMWI3BpJ9DLN2Jxfw==}
+    engines: {node: '>=22.13'}
 
   '@zkochan/which@2.0.3':
     resolution: {integrity: sha512-C1ReN7vt2/2O0fyTsx5xnbQuxBrmG5NMSbcIkPKCCfCTJgpZBsuRYzFXHj3nVq8vTfK7vxHUmzfCpSHgO7j4rg==}
@@ -1573,6 +1639,10 @@ packages:
     resolution: {integrity: sha512-gcGtbRxjwROQOdXLUWH1fQAXqThUVRZ219aAwgtX3KfYw429/Zv6EIJRf5TBSzWdAGwePmqH7w70WTaX4MDqag==}
     engines: {node: '>=12.17'}
 
+  comver-to-semver@2.0.0:
+    resolution: {integrity: sha512-4pxiLt2bXHe5BDrolTJs9wfwwT0pPQPQxeUj+X6SKTCkpi8VwvOvgMzohTVVDLXHmAjrZuKEq+tyb0C5zzTSxw==}
+    engines: {node: '>=22.13'}
+
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
@@ -1688,6 +1758,10 @@ packages:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
 
+  execa@9.6.1:
+    resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
+    engines: {node: ^18.19.0 || >=20.5.0}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -1709,6 +1783,10 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  figures@6.1.0:
+    resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
+    engines: {node: '>=18'}
 
   focus-trap@7.8.0:
     resolution: {integrity: sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==}
@@ -1733,10 +1811,6 @@ packages:
     resolution: {integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==}
     engines: {node: '>=18'}
 
-  get-npm-tarball-url@2.1.0:
-    resolution: {integrity: sha512-ro+DiMu5DXgRBabqXupW38h7WPZ9+Ad8UjwhvsmmN8w1sU7ab0nzAXvVZ4kqYg57OrqomRtJvepX5/xvFKNtjA==}
-    engines: {node: '>=12.17'}
-
   get-or-throw@3.0.1:
     resolution: {integrity: sha512-J77JrdGrKB9odvRd3RAWcCV+2wPkZof38cEAWEY7PdgA21esGWwaKqKIVywWFRcGPcYlVesoLTvls+RWxYp6Hw==}
     engines: {node: '>=22.12.0'}
@@ -1744,6 +1818,10 @@ packages:
   get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
+
+  get-stream@9.0.1:
+    resolution: {integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==}
+    engines: {node: '>=18'}
 
   get-tsconfig@4.14.0:
     resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
@@ -1797,6 +1875,10 @@ packages:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
 
+  human-signals@8.0.1:
+    resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
+    engines: {node: '>=18.18.0'}
+
   husky@9.1.7:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
     engines: {node: '>=18'}
@@ -1844,9 +1926,21 @@ packages:
     resolution: {integrity: sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==}
     engines: {node: '>=8'}
 
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
+
   is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
+
+  is-stream@4.0.1:
+    resolution: {integrity: sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==}
+    engines: {node: '>=18'}
+
+  is-unicode-supported@2.1.0:
+    resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
+    engines: {node: '>=18'}
 
   is-what@5.5.0:
     resolution: {integrity: sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==}
@@ -2101,6 +2195,9 @@ packages:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
 
+  normalize-registry-url@2.0.1:
+    resolution: {integrity: sha512-Ad5kiOvJFA62l6bkzuekf3AbEyCPweePeGIfU9iHtqem68EVKu2Tr6YM+xmO1dkwTzKgTCqzb3NqfIEtWWbQBg==}
+
   npm-bundled@5.0.0:
     resolution: {integrity: sha512-JLSpbzh6UUXIEoqPsYBvVNVmyrjVZ1fzEFbqxKkTJQkWBO3xFzFT+KDnSKQWwOQNbuWRwt5LSD6HOTLGIWzfrw==}
     engines: {node: ^20.17.0 || >=22.9.0}
@@ -2132,6 +2229,10 @@ packages:
   npm-run-path@4.0.1:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
     engines: {node: '>=8'}
+
+  npm-run-path@6.0.0:
+    resolution: {integrity: sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==}
+    engines: {node: '>=18'}
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
@@ -2194,6 +2295,10 @@ packages:
     resolution: {integrity: sha512-ZHEmNKMq1wyJXNwLxyHnluPfRAFSIliBvbK/UiOceROt4Xh9Pz0fq49NytIaeaCUf5VR86hwQ/34FCcNU5/LKQ==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
+  parse-ms@4.0.0:
+    resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
+    engines: {node: '>=18'}
+
   path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
     engines: {node: '>=0.10.0'}
@@ -2201,6 +2306,10 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  path-key@4.0.0:
+    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
+    engines: {node: '>=12'}
 
   path-name@1.0.0:
     resolution: {integrity: sha512-/dcAb5vMXH0f51yvMuSUqFpxUcA8JelbRmE5mW/p4CUJxrNgK24IkstnV7ENtg2IDGBOu6izKTG6eilbnbNKWQ==}
@@ -2232,6 +2341,10 @@ packages:
 
   preact@10.29.1:
     resolution: {integrity: sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==}
+
+  pretty-ms@9.3.1:
+    resolution: {integrity: sha512-HzMy3Geq23nVALD/M2LliU+F+M+gVNsvkQWWqeBZ8HDiCgzo6YPJ/Omrmtq24EFrIsk0a3EkQGEd7bDOo+IhGA==}
+    engines: {node: '>=18'}
 
   proc-log@6.1.0:
     resolution: {integrity: sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==}
@@ -2323,6 +2436,10 @@ packages:
     resolution: {integrity: sha512-vdTshSQ2JsRCgT8eKZWNJIL26C6bVqy1SOmuCMlKHegVeo8KYRobRrefOdUq9OozSPUUiSxrylteeRmLOMFfWg==}
     engines: {node: '>=12'}
 
+  safe-execa@0.3.0:
+    resolution: {integrity: sha512-LMzgcWXnnL60sDuAzlmGehx7OHa4ajy0R/3djFOfnZwj4aksZUcdHfZgIIWLNcqverOAQJ2qOe7BDFm7Qpxd6Q==}
+    engines: {node: '>=22.13'}
+
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
@@ -2331,6 +2448,11 @@ packages:
 
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -2382,6 +2504,10 @@ packages:
   sort-keys@4.2.0:
     resolution: {integrity: sha512-aUYIEU/UviqPgc8mHR6IW1EGxkAXpeRETYcrzg8cLAvUPZcpAlleSXHV2mY7G12GphSH6Gzv+4MMVSSkbdteHg==}
     engines: {node: '>=8'}
+
+  sort-keys@6.0.1:
+    resolution: {integrity: sha512-w7xWRu8U9MneKNna8ptG194jp9PLtbd/Rl6gwrmbK4yUeKbE66a64rHgl0iKTBBDr/hpanx7zMGP1Qo8MRkc/w==}
+    engines: {node: '>=20'}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -2450,9 +2576,17 @@ packages:
     resolution: {integrity: sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==}
     engines: {node: '>=8'}
 
+  strip-bom@5.0.0:
+    resolution: {integrity: sha512-p+byADHF7SzEcVnLvc/r3uognM1hUhObuHXxJcgLCfD194XAkaLbjq3Wzb0N5G2tgIjH0dgT708Z51QxMeu60A==}
+    engines: {node: '>=12'}
+
   strip-final-newline@2.0.0:
     resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
     engines: {node: '>=6'}
+
+  strip-final-newline@4.0.0:
+    resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
+    engines: {node: '>=18'}
 
   strip-json-comments@5.0.3:
     resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
@@ -2566,6 +2700,10 @@ packages:
   undici@6.25.0:
     resolution: {integrity: sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==}
     engines: {node: '>=18.17'}
+
+  unicorn-magic@0.3.0:
+    resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
+    engines: {node: '>=18'}
 
   unist-util-is@6.0.1:
     resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
@@ -2783,6 +2921,10 @@ packages:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
     hasBin: true
+
+  yoctocolors@2.2.0:
+    resolution: {integrity: sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg==}
+    engines: {node: '>=18'}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -3347,6 +3489,15 @@ snapshots:
   '@oxlint/binding-win32-x64-msvc@1.64.0':
     optional: true
 
+  '@pnpm/config.normalize-registries@1101.0.0':
+    dependencies:
+      '@pnpm/constants': 1102.0.0
+      '@pnpm/types': 1102.0.0
+      normalize-registry-url: 2.0.1
+      ramda: '@pnpm/ramda@0.28.1'
+
+  '@pnpm/constants@1102.0.0': {}
+
   '@pnpm/constants@7.1.1': {}
 
   '@pnpm/constants@8.0.0': {}
@@ -3358,6 +3509,11 @@ snapshots:
   '@pnpm/crypto.base32-hash@3.0.0':
     dependencies:
       rfc4648: 1.5.4
+
+  '@pnpm/crypto.hash@1100.0.2':
+    dependencies:
+      '@pnpm/fs.graceful-fs': 1100.1.1
+      ssri: 13.0.1
 
   '@pnpm/dependency-path@2.1.8':
     dependencies:
@@ -3372,21 +3528,41 @@ snapshots:
       '@pnpm/types': 10.0.0
       semver: 7.7.4
 
+  '@pnpm/deps.path@1101.0.0':
+    dependencies:
+      '@pnpm/crypto.hash': 1100.0.2
+      '@pnpm/types': 1102.0.0
+      semver: 7.8.5
+
+  '@pnpm/error@1100.1.3':
+    dependencies:
+      '@pnpm/constants': 1102.0.0
+
   '@pnpm/error@5.0.3':
     dependencies:
       '@pnpm/constants': 7.1.1
 
-  '@pnpm/error@6.0.0':
+  '@pnpm/fetching.fetcher-base@1100.2.8':
     dependencies:
-      '@pnpm/constants': 8.0.0
+      '@pnpm/resolving.resolver-base': 1101.1.1
+      '@pnpm/types': 1102.0.0
+      '@types/ssri': 7.1.5
+
+  '@pnpm/fs.graceful-fs@1100.1.1':
+    dependencies:
+      graceful-fs: 4.2.11
 
   '@pnpm/git-utils@1.0.0':
     dependencies:
       execa: safe-execa@0.1.2
 
-  '@pnpm/git-utils@2.0.0':
+  '@pnpm/hooks.types@1101.0.0':
     dependencies:
-      execa: safe-execa@0.1.2
+      '@pnpm/fetching.fetcher-base': 1100.2.8
+      '@pnpm/lockfile.types': 1100.0.20
+      '@pnpm/resolving.resolver-base': 1101.1.1
+      '@pnpm/store.cafs-types': 1100.0.2
+      '@pnpm/types': 1102.0.0
 
   '@pnpm/lockfile-file@8.1.8(@pnpm/logger@1100.0.0)':
     dependencies:
@@ -3409,28 +3585,6 @@ snapshots:
       strip-bom: 4.0.0
       write-file-atomic: 5.0.1
 
-  '@pnpm/lockfile-file@9.0.0(@pnpm/logger@1100.0.0)':
-    dependencies:
-      '@pnpm/constants': 8.0.0
-      '@pnpm/dependency-path': 3.0.0
-      '@pnpm/error': 6.0.0
-      '@pnpm/git-utils': 2.0.0
-      '@pnpm/lockfile-types': 6.0.0
-      '@pnpm/lockfile-utils': 10.0.0
-      '@pnpm/logger': 1100.0.0
-      '@pnpm/merge-lockfile-changes': 6.0.0
-      '@pnpm/types': 10.0.0
-      '@pnpm/util.lex-comparator': 1.0.0
-      '@zkochan/rimraf': 2.1.3
-      comver-to-semver: 1.0.0
-      js-yaml: '@zkochan/js-yaml@0.0.7'
-      normalize-path: 3.0.0
-      ramda: '@pnpm/ramda@0.28.1'
-      semver: 7.7.4
-      sort-keys: 4.2.0
-      strip-bom: 4.0.0
-      write-file-atomic: 5.0.1
-
   '@pnpm/lockfile-types@5.1.5':
     dependencies:
       '@pnpm/types': 9.4.2
@@ -3439,14 +3593,52 @@ snapshots:
     dependencies:
       '@pnpm/types': 10.0.0
 
-  '@pnpm/lockfile-utils@10.0.0':
+  '@pnpm/lockfile.fs@1100.2.4(@pnpm/logger@1100.0.0)':
     dependencies:
-      '@pnpm/dependency-path': 3.0.0
-      '@pnpm/lockfile-types': 6.0.0
-      '@pnpm/pick-fetcher': 3.0.0
-      '@pnpm/resolver-base': 12.0.0
-      '@pnpm/types': 10.0.0
-      get-npm-tarball-url: 2.1.0
+      '@pnpm/constants': 1102.0.0
+      '@pnpm/deps.path': 1101.0.0
+      '@pnpm/error': 1100.1.3
+      '@pnpm/lockfile.merger': 1100.0.20
+      '@pnpm/lockfile.types': 1100.0.20
+      '@pnpm/lockfile.utils': 1102.0.0
+      '@pnpm/logger': 1100.0.0
+      '@pnpm/network.git-utils': 1100.0.3
+      '@pnpm/object.key-sorting': 1100.0.2
+      '@pnpm/types': 1102.0.0
+      '@zkochan/rimraf': 4.0.0
+      comver-to-semver: 2.0.0
+      js-yaml: '@zkochan/js-yaml@0.0.11'
+      normalize-path: 3.0.0
+      ramda: '@pnpm/ramda@0.28.1'
+      semver: 7.8.5
+      strip-bom: 5.0.0
+      write-file-atomic: 7.0.1
+
+  '@pnpm/lockfile.merger@1100.0.20':
+    dependencies:
+      '@pnpm/lockfile.types': 1100.0.20
+      '@pnpm/types': 1102.0.0
+      comver-to-semver: 2.0.0
+      ramda: '@pnpm/ramda@0.28.1'
+      semver: 7.8.5
+
+  '@pnpm/lockfile.types@1100.0.20':
+    dependencies:
+      '@pnpm/patching.types': 1100.0.1
+      '@pnpm/resolving.resolver-base': 1101.1.1
+      '@pnpm/types': 1102.0.0
+
+  '@pnpm/lockfile.utils@1102.0.0':
+    dependencies:
+      '@pnpm/config.normalize-registries': 1101.0.0
+      '@pnpm/constants': 1102.0.0
+      '@pnpm/deps.path': 1101.0.0
+      '@pnpm/error': 1100.1.3
+      '@pnpm/hooks.types': 1101.0.0
+      '@pnpm/lockfile.types': 1100.0.20
+      '@pnpm/resolving.resolver-base': 1101.1.1
+      '@pnpm/resolving.tarball-url': 1101.0.0
+      '@pnpm/types': 1102.0.0
       ramda: '@pnpm/ramda@0.28.1'
 
   '@pnpm/logger@1100.0.0':
@@ -3461,14 +3653,16 @@ snapshots:
       ramda: '@pnpm/ramda@0.28.1'
       semver: 7.7.4
 
-  '@pnpm/merge-lockfile-changes@6.0.0':
+  '@pnpm/network.git-utils@1100.0.3':
     dependencies:
-      '@pnpm/lockfile-types': 6.0.0
-      comver-to-semver: 1.0.0
-      ramda: '@pnpm/ramda@0.28.1'
-      semver: 7.7.4
+      execa: safe-execa@0.3.0
 
-  '@pnpm/pick-fetcher@3.0.0': {}
+  '@pnpm/object.key-sorting@1100.0.2':
+    dependencies:
+      '@pnpm/util.lex-comparator': 4.0.1
+      sort-keys: 6.0.1
+
+  '@pnpm/patching.types@1100.0.1': {}
 
   '@pnpm/prune-lockfile@5.0.10':
     dependencies:
@@ -3488,17 +3682,27 @@ snapshots:
 
   '@pnpm/ramda@0.28.1': {}
 
-  '@pnpm/resolver-base@12.0.0':
+  '@pnpm/resolving.resolver-base@1101.1.1':
     dependencies:
-      '@pnpm/types': 10.0.0
+      '@pnpm/types': 1102.0.0
+
+  '@pnpm/resolving.tarball-url@1101.0.0':
+    dependencies:
+      '@pnpm/types': 1102.0.0
+
+  '@pnpm/store.cafs-types@1100.0.2': {}
 
   '@pnpm/types@10.0.0': {}
 
   '@pnpm/types@1001.3.0': {}
 
+  '@pnpm/types@1102.0.0': {}
+
   '@pnpm/types@9.4.2': {}
 
   '@pnpm/util.lex-comparator@1.0.0': {}
+
+  '@pnpm/util.lex-comparator@4.0.1': {}
 
   '@quansync/fs@1.0.0':
     dependencies:
@@ -3630,6 +3834,8 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.60.3':
     optional: true
 
+  '@sec-ant/readable-stream@0.4.1': {}
+
   '@shikijs/core@2.5.0':
     dependencies:
       '@shikijs/engine-javascript': 2.5.0
@@ -3702,6 +3908,8 @@ snapshots:
       '@sigstore/core': 3.2.0
       '@sigstore/protobuf-specs': 0.5.1
 
+  '@sindresorhus/merge-streams@4.0.0': {}
+
   '@standard-schema/spec@1.1.0': {}
 
   '@tufjs/canonical-json@2.0.0': {}
@@ -3769,6 +3977,10 @@ snapshots:
   '@types/source-map-support@0.5.10':
     dependencies:
       source-map: 0.6.1
+
+  '@types/ssri@7.1.5':
+    dependencies:
+      '@types/node': 25.7.0
 
   '@types/tar-fs@2.0.4':
     dependencies:
@@ -3930,17 +4142,19 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@zkochan/js-yaml@0.0.6':
+  '@zkochan/js-yaml@0.0.11':
     dependencies:
       argparse: 2.0.1
 
-  '@zkochan/js-yaml@0.0.7':
+  '@zkochan/js-yaml@0.0.6':
     dependencies:
       argparse: 2.0.1
 
   '@zkochan/rimraf@2.1.3':
     dependencies:
       rimraf: 3.0.2
+
+  '@zkochan/rimraf@4.0.0': {}
 
   '@zkochan/which@2.0.3':
     dependencies:
@@ -4097,6 +4311,8 @@ snapshots:
 
   comver-to-semver@1.0.0: {}
 
+  comver-to-semver@2.0.0: {}
+
   concat-map@0.0.1: {}
 
   consola@3.4.2: {}
@@ -4209,6 +4425,21 @@ snapshots:
       signal-exit: 3.0.7
       strip-final-newline: 2.0.0
 
+  execa@9.6.1:
+    dependencies:
+      '@sindresorhus/merge-streams': 4.0.0
+      cross-spawn: 7.0.6
+      figures: 6.1.0
+      get-stream: 9.0.1
+      human-signals: 8.0.1
+      is-plain-obj: 4.1.0
+      is-stream: 4.0.1
+      npm-run-path: 6.0.0
+      pretty-ms: 9.3.1
+      signal-exit: 4.1.0
+      strip-final-newline: 4.0.0
+      yoctocolors: 2.2.0
+
   expect-type@1.3.0: {}
 
   exponential-backoff@3.1.3: {}
@@ -4220,6 +4451,10 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  figures@6.1.0:
+    dependencies:
+      is-unicode-supported: 2.1.0
 
   focus-trap@7.8.0:
     dependencies:
@@ -4242,11 +4477,14 @@ snapshots:
 
   get-east-asian-width@1.6.0: {}
 
-  get-npm-tarball-url@2.1.0: {}
-
   get-or-throw@3.0.1: {}
 
   get-stream@6.0.1: {}
+
+  get-stream@9.0.1:
+    dependencies:
+      '@sec-ant/readable-stream': 0.4.1
+      is-stream: 4.0.1
 
   get-tsconfig@4.14.0:
     dependencies:
@@ -4319,6 +4557,8 @@ snapshots:
 
   human-signals@2.1.0: {}
 
+  human-signals@8.0.1: {}
+
   husky@9.1.7: {}
 
   iconv-lite@0.7.2:
@@ -4353,7 +4593,13 @@ snapshots:
 
   is-plain-obj@2.1.0: {}
 
+  is-plain-obj@4.1.0: {}
+
   is-stream@2.0.1: {}
+
+  is-stream@4.0.1: {}
+
+  is-unicode-supported@2.1.0: {}
 
   is-what@5.5.0: {}
 
@@ -4597,6 +4843,8 @@ snapshots:
 
   normalize-path@3.0.0: {}
 
+  normalize-registry-url@2.0.1: {}
+
   npm-bundled@5.0.0:
     dependencies:
       npm-normalize-package-bin: 5.0.0
@@ -4642,6 +4890,11 @@ snapshots:
   npm-run-path@4.0.1:
     dependencies:
       path-key: 3.1.1
+
+  npm-run-path@6.0.0:
+    dependencies:
+      path-key: 4.0.0
+      unicorn-magic: 0.3.0
 
   obug@2.1.1: {}
 
@@ -4753,9 +5006,13 @@ snapshots:
       just-diff: 6.0.2
       just-diff-apply: 5.5.0
 
+  parse-ms@4.0.0: {}
+
   path-is-absolute@1.0.1: {}
 
   path-key@3.1.1: {}
+
+  path-key@4.0.0: {}
 
   path-name@1.0.0: {}
 
@@ -4784,6 +5041,10 @@ snapshots:
       source-map-js: 1.2.1
 
   preact@10.29.1: {}
+
+  pretty-ms@9.3.1:
+    dependencies:
+      parse-ms: 4.0.0
 
   proc-log@6.1.0: {}
 
@@ -4905,12 +5166,20 @@ snapshots:
       execa: 5.1.1
       path-name: 1.0.0
 
+  safe-execa@0.3.0:
+    dependencies:
+      '@zkochan/which': 2.0.3
+      execa: 9.6.1
+      path-name: 1.0.0
+
   safer-buffer@2.1.2:
     optional: true
 
   search-insights@2.17.3: {}
 
   semver@7.7.4: {}
+
+  semver@7.8.5: {}
 
   shebang-command@2.0.0:
     dependencies:
@@ -4974,6 +5243,10 @@ snapshots:
   sort-keys@4.2.0:
     dependencies:
       is-plain-obj: 2.1.0
+
+  sort-keys@6.0.1:
+    dependencies:
+      is-plain-obj: 4.1.0
 
   source-map-js@1.2.1: {}
 
@@ -5040,7 +5313,11 @@ snapshots:
 
   strip-bom@4.0.0: {}
 
+  strip-bom@5.0.0: {}
+
   strip-final-newline@2.0.0: {}
+
+  strip-final-newline@4.0.0: {}
 
   strip-json-comments@5.0.3: {}
 
@@ -5159,6 +5436,8 @@ snapshots:
   undici-types@7.21.0: {}
 
   undici@6.25.0: {}
+
+  unicorn-magic@0.3.0: {}
 
   unist-util-is@6.0.1:
     dependencies:
@@ -5350,5 +5629,7 @@ snapshots:
   yallist@5.0.0: {}
 
   yaml@2.9.0: {}
+
+  yoctocolors@2.2.0: {}
 
   zwitch@2.0.4: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,9 @@ allowBuilds:
   esbuild: true
 minimumReleaseAge: 10080 # 7 days in minutes
 
+overrides:
+  # pretty-ms@9.3.1 was published 2026-08-28 and is inside the minimumReleaseAge
+  # window above. It arrives transitively via @pnpm/lockfile.fs -> network.git-utils
+  # -> safe-execa -> execa. 9.3.0 satisfies execa's ^9.2.0 range and is a year old.
+  # Drop this override once 9.3.1 has aged past the cutoff.
+  pretty-ms: 9.3.0

--- a/src/lib/lockfile/helpers/__fixtures__/pnpm-config-dependencies/workspace/apps/svc/package.json
+++ b/src/lib/lockfile/helpers/__fixtures__/pnpm-config-dependencies/workspace/apps/svc/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "svc",
+  "version": "1.0.0",
+  "files": [
+    "dist"
+  ],
+  "main": "./dist/index.js",
+  "dependencies": {
+    "left-pad": "1.3.0"
+  }
+}

--- a/src/lib/lockfile/helpers/__fixtures__/pnpm-config-dependencies/workspace/package.json
+++ b/src/lib/lockfile/helpers/__fixtures__/pnpm-config-dependencies/workspace/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "root",
+  "private": true,
+  "packageManager": "pnpm@12.0.0"
+}

--- a/src/lib/lockfile/helpers/__fixtures__/pnpm-config-dependencies/workspace/pnpm-lock.yaml
+++ b/src/lib/lockfile/helpers/__fixtures__/pnpm-config-dependencies/workspace/pnpm-lock.yaml
@@ -1,0 +1,132 @@
+---
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    configDependencies:
+      my-config:
+        specifier: 1.0.0
+        version: 1.0.0
+    packageManagerDependencies:
+      pnpm:
+        specifier: 12.0.0
+        version: 12.0.0
+
+packages:
+
+  '@pnpm/exe.darwin-arm64@12.0.0':
+    resolution: {integrity: sha512-sqeoPfVMIfQhbwzDrKraXY2ynyuWClFqzvfImzAS/yczEru1m5SGvQ9kgFPDvQzJZ9AetedgJeDZC6qYvH8/tQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@pnpm/exe.darwin-x64@12.0.0':
+    resolution: {integrity: sha512-Quc3J6c9cGTy+LDgz1cLVgCNOU9IERuyAlDoEj0DCilKqvo50Jx1GV8k74iwn4J9fFSKkm8JrwNvtTDj3uWnUA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@pnpm/exe.linux-arm64-musl@12.0.0':
+    resolution: {integrity: sha512-EVWd3OTmgsMFhXx69b5JxIzoabG9Ma7m4OeTaf0ZKBzMnfYi8u21NDQo92ToMrdYL5dYDDCHsyYIjXzk+d0HhA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/exe.linux-arm64@12.0.0':
+    resolution: {integrity: sha512-cXHHW8M4rAPsYNkKZO9WVcpLLK55i9EaIsZPfIqUuY2eopd5LqnFyBge54HCh1GC0yCX8ySn0hYIi+4OyAEoDg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.linux-x64-musl@12.0.0':
+    resolution: {integrity: sha512-UcXwMdFjly0mpddkGigHKTxe27IMv2fUK4IWW/MHmJ3yMguxXmkwNlEI4aE+G1HO2TLo20uNEUWD4ymLe/DaCQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/exe.linux-x64@12.0.0':
+    resolution: {integrity: sha512-6Rsl+zEWMOmus7v7/9J3OE8EMvHyNAfxYmDfmhQG4J0985OuT3G3Ho9NSGHjkBn4aU4bgklWifRhe1HX8dUSyw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.win32-arm64@12.0.0':
+    resolution: {integrity: sha512-O5F76A4oVFrpDGdFxEszRIThOSBfjHdH5c006gR+7UTCfiXrukr1XfqPungUI1DXcSR5gb9jBsPQqQZOAoOOxw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@pnpm/exe.win32-x64@12.0.0':
+    resolution: {integrity: sha512-5dKFajIEWJ1ai+KHXFJvskY6vchbunmLwSUV2ywbLymcmJjfY5XJVpgzPCyIoVCMVG0zHorr66+hM8h8b3aRfQ==}
+    cpu: [x64]
+    os: [win32]
+
+  my-config@1.0.0:
+    resolution: {integrity: sha512-AAAAw5EZlYaNyUuBdcIXwn6VQI+gO0oidJd48rNPdzt3zdOznt6BcbIvzVO+ajU0Lp+smUimjvWN9kiM6Jp+Zw==}
+
+  pnpm@12.0.0:
+    resolution: {integrity: sha512-ni49w5EZlYaNyUuBdcIXwn6VQI+gO0oidJd48rNPdzt3zdOznt6BcbIvzVO+ajU0Lp+smUimjvWN9kiM6Jp+Zw==}
+    engines: {node: '>=18.*'}
+    hasBin: true
+
+snapshots:
+
+  '@pnpm/exe.darwin-arm64@12.0.0':
+    optional: true
+
+  '@pnpm/exe.darwin-x64@12.0.0':
+    optional: true
+
+  '@pnpm/exe.linux-arm64-musl@12.0.0':
+    optional: true
+
+  '@pnpm/exe.linux-arm64@12.0.0':
+    optional: true
+
+  '@pnpm/exe.linux-x64-musl@12.0.0':
+    optional: true
+
+  '@pnpm/exe.linux-x64@12.0.0':
+    optional: true
+
+  '@pnpm/exe.win32-arm64@12.0.0':
+    optional: true
+
+  '@pnpm/exe.win32-x64@12.0.0':
+    optional: true
+
+  pnpm@12.0.0:
+    optionalDependencies:
+      '@pnpm/exe.darwin-arm64': 12.0.0
+      '@pnpm/exe.darwin-x64': 12.0.0
+      '@pnpm/exe.linux-arm64': 12.0.0
+      '@pnpm/exe.linux-arm64-musl': 12.0.0
+      '@pnpm/exe.linux-x64': 12.0.0
+      '@pnpm/exe.linux-x64-musl': 12.0.0
+      '@pnpm/exe.win32-arm64': 12.0.0
+      '@pnpm/exe.win32-x64': 12.0.0
+
+---
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .: {}
+
+  apps/svc:
+    dependencies:
+      left-pad:
+        specifier: 1.3.0
+        version: 1.3.0
+
+packages:
+
+  left-pad@1.3.0:
+    resolution: {integrity: sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==}
+    deprecated: use String.prototype.padStart()
+
+snapshots:
+
+  left-pad@1.3.0: {}

--- a/src/lib/lockfile/helpers/__fixtures__/pnpm-config-dependencies/workspace/pnpm-workspace.yaml
+++ b/src/lib/lockfile/helpers/__fixtures__/pnpm-config-dependencies/workspace/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+packages:
+  - apps/*
+configDependencies:
+  my-config: 1.0.0+sha512-AAAAw5EZlYaNyUuBdcIXwn6VQI+gO0oidJd48rNPdzt3zdOznt6BcbIvzVO+ajU0Lp+smUimjvWN9kiM6Jp+Zw==

--- a/src/lib/lockfile/helpers/__fixtures__/pnpm-two-document/workspace/apps/svc/package.json
+++ b/src/lib/lockfile/helpers/__fixtures__/pnpm-two-document/workspace/apps/svc/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "svc",
+  "version": "1.0.0",
+  "files": [
+    "dist"
+  ],
+  "main": "./dist/index.js",
+  "dependencies": {
+    "left-pad": "1.3.0"
+  }
+}

--- a/src/lib/lockfile/helpers/__fixtures__/pnpm-two-document/workspace/package.json
+++ b/src/lib/lockfile/helpers/__fixtures__/pnpm-two-document/workspace/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "root",
+  "private": true,
+  "packageManager": "pnpm@12.0.0"
+}

--- a/src/lib/lockfile/helpers/__fixtures__/pnpm-two-document/workspace/pnpm-lock.yaml
+++ b/src/lib/lockfile/helpers/__fixtures__/pnpm-two-document/workspace/pnpm-lock.yaml
@@ -1,0 +1,126 @@
+---
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    configDependencies: {}
+    packageManagerDependencies:
+      pnpm:
+        specifier: 12.0.0
+        version: 12.0.0
+
+packages:
+
+  '@pnpm/exe.darwin-arm64@12.0.0':
+    resolution: {integrity: sha512-sqeoPfVMIfQhbwzDrKraXY2ynyuWClFqzvfImzAS/yczEru1m5SGvQ9kgFPDvQzJZ9AetedgJeDZC6qYvH8/tQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@pnpm/exe.darwin-x64@12.0.0':
+    resolution: {integrity: sha512-Quc3J6c9cGTy+LDgz1cLVgCNOU9IERuyAlDoEj0DCilKqvo50Jx1GV8k74iwn4J9fFSKkm8JrwNvtTDj3uWnUA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@pnpm/exe.linux-arm64-musl@12.0.0':
+    resolution: {integrity: sha512-EVWd3OTmgsMFhXx69b5JxIzoabG9Ma7m4OeTaf0ZKBzMnfYi8u21NDQo92ToMrdYL5dYDDCHsyYIjXzk+d0HhA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/exe.linux-arm64@12.0.0':
+    resolution: {integrity: sha512-cXHHW8M4rAPsYNkKZO9WVcpLLK55i9EaIsZPfIqUuY2eopd5LqnFyBge54HCh1GC0yCX8ySn0hYIi+4OyAEoDg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.linux-x64-musl@12.0.0':
+    resolution: {integrity: sha512-UcXwMdFjly0mpddkGigHKTxe27IMv2fUK4IWW/MHmJ3yMguxXmkwNlEI4aE+G1HO2TLo20uNEUWD4ymLe/DaCQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/exe.linux-x64@12.0.0':
+    resolution: {integrity: sha512-6Rsl+zEWMOmus7v7/9J3OE8EMvHyNAfxYmDfmhQG4J0985OuT3G3Ho9NSGHjkBn4aU4bgklWifRhe1HX8dUSyw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.win32-arm64@12.0.0':
+    resolution: {integrity: sha512-O5F76A4oVFrpDGdFxEszRIThOSBfjHdH5c006gR+7UTCfiXrukr1XfqPungUI1DXcSR5gb9jBsPQqQZOAoOOxw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@pnpm/exe.win32-x64@12.0.0':
+    resolution: {integrity: sha512-5dKFajIEWJ1ai+KHXFJvskY6vchbunmLwSUV2ywbLymcmJjfY5XJVpgzPCyIoVCMVG0zHorr66+hM8h8b3aRfQ==}
+    cpu: [x64]
+    os: [win32]
+
+  pnpm@12.0.0:
+    resolution: {integrity: sha512-ni49w5EZlYaNyUuBdcIXwn6VQI+gO0oidJd48rNPdzt3zdOznt6BcbIvzVO+ajU0Lp+smUimjvWN9kiM6Jp+Zw==}
+    engines: {node: '>=18.*'}
+    hasBin: true
+
+snapshots:
+
+  '@pnpm/exe.darwin-arm64@12.0.0':
+    optional: true
+
+  '@pnpm/exe.darwin-x64@12.0.0':
+    optional: true
+
+  '@pnpm/exe.linux-arm64-musl@12.0.0':
+    optional: true
+
+  '@pnpm/exe.linux-arm64@12.0.0':
+    optional: true
+
+  '@pnpm/exe.linux-x64-musl@12.0.0':
+    optional: true
+
+  '@pnpm/exe.linux-x64@12.0.0':
+    optional: true
+
+  '@pnpm/exe.win32-arm64@12.0.0':
+    optional: true
+
+  '@pnpm/exe.win32-x64@12.0.0':
+    optional: true
+
+  pnpm@12.0.0:
+    optionalDependencies:
+      '@pnpm/exe.darwin-arm64': 12.0.0
+      '@pnpm/exe.darwin-x64': 12.0.0
+      '@pnpm/exe.linux-arm64': 12.0.0
+      '@pnpm/exe.linux-arm64-musl': 12.0.0
+      '@pnpm/exe.linux-x64': 12.0.0
+      '@pnpm/exe.linux-x64-musl': 12.0.0
+      '@pnpm/exe.win32-arm64': 12.0.0
+      '@pnpm/exe.win32-x64': 12.0.0
+
+---
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .: {}
+
+  apps/svc:
+    dependencies:
+      left-pad:
+        specifier: 1.3.0
+        version: 1.3.0
+
+packages:
+
+  left-pad@1.3.0:
+    resolution: {integrity: sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==}
+    deprecated: use String.prototype.padStart()
+
+snapshots:
+
+  left-pad@1.3.0: {}

--- a/src/lib/lockfile/helpers/__fixtures__/pnpm-two-document/workspace/pnpm-workspace.yaml
+++ b/src/lib/lockfile/helpers/__fixtures__/pnpm-two-document/workspace/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - apps/*

--- a/src/lib/lockfile/helpers/generate-pnpm-lockfile.integration.test.ts
+++ b/src/lib/lockfile/helpers/generate-pnpm-lockfile.integration.test.ts
@@ -55,6 +55,11 @@ function rootImporterOf(document: Record<string, unknown> | undefined) {
  * followed by the project document. Nothing here is mocked — the point of the
  * test is that the reader actually accepts that stream, which `js-yaml.load()`
  * in `@pnpm/lockfile-file@9` did not.
+ *
+ * These assert the structure of the emitted lockfile, not that pnpm accepts it:
+ * running a real `pnpm install --frozen-lockfile` would need pnpm 12 and the
+ * network in CI. That end of the contract is verified by hand against a real
+ * pnpm 12 workspace when this code changes.
  */
 describe("generatePnpmLockfile integration", () => {
   let cleanupPaths: string[] = [];

--- a/src/lib/lockfile/helpers/generate-pnpm-lockfile.integration.test.ts
+++ b/src/lib/lockfile/helpers/generate-pnpm-lockfile.integration.test.ts
@@ -50,11 +50,14 @@ function rootImporterOf(document: Record<string, unknown> | undefined) {
 /**
  * Reproduction of https://github.com/0x80/isolate-package/issues/205.
  *
- * The fixture holds a real `pnpm-lock.yaml` written by pnpm 12, which is a
- * stream of two YAML documents: an env document pinning the package manager,
- * followed by the project document. Nothing here is mocked — the point of the
- * test is that the reader actually accepts that stream, which `js-yaml.load()`
- * in `@pnpm/lockfile-file@9` did not.
+ * The `pnpm-two-document` fixture is a `pnpm-lock.yaml` captured from a real
+ * pnpm 12 install: a stream of two YAML documents, an env document pinning the
+ * package manager followed by the project document. The
+ * `pnpm-config-dependencies` fixture is that file hand-edited to add a config
+ * dependency, so its integrity hashes are placeholders rather than real ones —
+ * it reproduces the shape, which is all these assertions read. Nothing is
+ * mocked: the point is that the reader accepts the stream, which
+ * `js-yaml.load()` in `@pnpm/lockfile-file@9` did not.
  *
  * These assert the structure of the emitted lockfile, not that pnpm accepts it:
  * running a real `pnpm install --frozen-lockfile` would need pnpm 12 and the
@@ -77,12 +80,23 @@ describe("generatePnpmLockfile integration", () => {
   async function isolate({
     packageManager,
     fixture = "pnpm-two-document",
+    mutateLockfile,
   }: {
     packageManager: string | undefined;
     fixture?: string;
+    /** Rewrite the workspace lockfile before isolating, to shape its env document */
+    mutateLockfile?: (lockfile: string) => string;
   }) {
     const { tmpBase, workspaceRoot } = await setupFixture(fixture);
     cleanupPaths.push(tmpBase);
+
+    if (mutateLockfile) {
+      const lockfilePath = path.join(workspaceRoot, "pnpm-lock.yaml");
+      await fs.writeFile(
+        lockfilePath,
+        mutateLockfile(await fs.readFile(lockfilePath, "utf8")),
+      );
+    }
 
     const targetPackageDir = path.join(workspaceRoot, "apps/svc");
     const isolateDir = path.join(targetPackageDir, "isolate");
@@ -161,6 +175,36 @@ describe("generatePnpmLockfile integration", () => {
       "my-config": { specifier: "1.0.0", version: "1.0.0" },
     });
     expect(rootImporter).not.toHaveProperty("packageManagerDependencies");
+  });
+
+  /**
+   * The reader returns null for a lockfile with no env document, and declines
+   * one it cannot recognize. Neither may abort the run, and only the second
+   * costs the output anything — so both are exercised against real files.
+   */
+  it("emits a single-document lockfile when the source has no env document", async () => {
+    const { content, documents } = await isolate({
+      packageManager: "pnpm@12.0.0",
+      mutateLockfile: (lockfile) =>
+        lockfile.split("\n---\n").slice(1).join("\n---\n"),
+    });
+
+    expect(documents).toHaveLength(1);
+    expect(content.startsWith("---\n")).toBe(false);
+    expect(rootImporterOf(documents[0])).toBeDefined();
+  });
+
+  it("still emits the project document when the env document is unreadable", async () => {
+    const { documents } = await isolate({
+      packageManager: "pnpm@12.0.0",
+      mutateLockfile: (lockfile) =>
+        `---\n\tthis is not: valid: yaml\n---\n${lockfile.split("\n---\n").slice(1).join("\n---\n")}`,
+    });
+
+    expect(documents).toHaveLength(1);
+    expect(rootImporterOf(documents[0])).toMatchObject({
+      dependencies: { "left-pad": { specifier: "1.3.0", version: "1.3.0" } },
+    });
   });
 
   it("keeps both env pins when packageManager is retained", async () => {

--- a/src/lib/lockfile/helpers/generate-pnpm-lockfile.integration.test.ts
+++ b/src/lib/lockfile/helpers/generate-pnpm-lockfile.integration.test.ts
@@ -1,0 +1,172 @@
+import fs from "fs-extra";
+import os from "node:os";
+import path from "node:path";
+import { parseAllDocuments } from "yaml";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { generatePnpmLockfile } from "./generate-pnpm-lockfile";
+
+const FIXTURES_DIR = path.join(import.meta.dirname, "__fixtures__");
+
+/**
+ * Copy a fixture's `workspace/` tree into a fresh tmp directory so the
+ * integration test runs the real `@pnpm/lockfile.fs` reader and writer against
+ * real files without polluting the checked-in fixture.
+ */
+async function setupFixture(name: string) {
+  const srcWorkspace = path.join(FIXTURES_DIR, name, "workspace");
+  const tmpBase = await fs.mkdtemp(
+    path.join(os.tmpdir(), `isolate-package-${name}-`),
+  );
+  const workspaceRoot = path.join(tmpBase, "workspace");
+  await fs.copy(srcWorkspace, workspaceRoot);
+  return { tmpBase, workspaceRoot };
+}
+
+/**
+ * The isolate output is written as a YAML stream, so read it back as one and
+ * return the parsed documents in order.
+ */
+async function readLockfileDocuments(isolateDir: string) {
+  const content = await fs.readFile(
+    path.join(isolateDir, "pnpm-lock.yaml"),
+    "utf8",
+  );
+
+  return {
+    content,
+    documents: parseAllDocuments(content).map(
+      (document) => document.toJS() as Record<string, unknown>,
+    ),
+  };
+}
+
+/** The root importer of a parsed lockfile document, as a plain record */
+function rootImporterOf(document: Record<string, unknown> | undefined) {
+  const importers = (document?.importers ?? {}) as Record<string, unknown>;
+
+  return importers["."] as Record<string, unknown> | undefined;
+}
+
+/**
+ * Reproduction of https://github.com/0x80/isolate-package/issues/205.
+ *
+ * The fixture holds a real `pnpm-lock.yaml` written by pnpm 12, which is a
+ * stream of two YAML documents: an env document pinning the package manager,
+ * followed by the project document. Nothing here is mocked — the point of the
+ * test is that the reader actually accepts that stream, which `js-yaml.load()`
+ * in `@pnpm/lockfile-file@9` did not.
+ */
+describe("generatePnpmLockfile integration", () => {
+  let cleanupPaths: string[] = [];
+
+  beforeEach(() => {
+    cleanupPaths = [];
+  });
+
+  afterEach(async () => {
+    for (const p of cleanupPaths) {
+      await fs.remove(p).catch(() => undefined);
+    }
+  });
+
+  async function isolate({
+    packageManager,
+    fixture = "pnpm-two-document",
+  }: {
+    packageManager: string | undefined;
+    fixture?: string;
+  }) {
+    const { tmpBase, workspaceRoot } = await setupFixture(fixture);
+    cleanupPaths.push(tmpBase);
+
+    const targetPackageDir = path.join(workspaceRoot, "apps/svc");
+    const isolateDir = path.join(targetPackageDir, "isolate");
+    await fs.ensureDir(isolateDir);
+
+    await generatePnpmLockfile({
+      workspaceRootDir: workspaceRoot,
+      targetPackageDir,
+      isolateDir,
+      internalDepPackageNames: [],
+      packagesRegistry: {},
+      targetPackageManifest: {
+        name: "svc",
+        version: "1.0.0",
+        dependencies: { "left-pad": "1.3.0" },
+        ...(packageManager ? { packageManager } : {}),
+      },
+      majorVersion: 12,
+      includeDevDependencies: false,
+    });
+
+    return readLockfileDocuments(isolateDir);
+  }
+
+  it("reads the two-document lockfile pnpm 12 writes", async () => {
+    const { documents } = await isolate({ packageManager: "pnpm@12.0.0" });
+
+    const projectDocument = documents.at(-1);
+
+    expect(projectDocument?.lockfileVersion).toBe("9.0");
+    expect(rootImporterOf(projectDocument)).toMatchObject({
+      dependencies: { "left-pad": { specifier: "1.3.0", version: "1.3.0" } },
+    });
+  });
+
+  it("carries the env document into the isolated lockfile", async () => {
+    const { content, documents } = await isolate({
+      packageManager: "pnpm@12.0.0",
+    });
+
+    expect(documents).toHaveLength(2);
+    expect(content.startsWith("---\n")).toBe(true);
+
+    expect(rootImporterOf(documents[0])).toMatchObject({
+      packageManagerDependencies: {
+        pnpm: { specifier: "12.0.0", version: "12.0.0" },
+      },
+    });
+  });
+
+  it("omits the env document when the output manifest drops packageManager", async () => {
+    const { content, documents } = await isolate({ packageManager: undefined });
+
+    expect(documents).toHaveLength(1);
+    expect(content.startsWith("---\n")).toBe(false);
+    expect(rootImporterOf(documents[0])).toBeDefined();
+  });
+
+  /**
+   * `pnpm-workspace.yaml` is copied to the isolate verbatim, so its
+   * `configDependencies` specifiers keep being declared there. Their
+   * resolutions live only in the env document, which therefore has to survive
+   * `omitPackageManager` even though the package manager pin does not.
+   */
+  it("keeps the env document for its config dependencies when packageManager is dropped", async () => {
+    const { documents } = await isolate({
+      packageManager: undefined,
+      fixture: "pnpm-config-dependencies",
+    });
+
+    expect(documents).toHaveLength(2);
+
+    const rootImporter = rootImporterOf(documents[0]);
+
+    expect(rootImporter?.configDependencies).toMatchObject({
+      "my-config": { specifier: "1.0.0", version: "1.0.0" },
+    });
+    expect(rootImporter).not.toHaveProperty("packageManagerDependencies");
+  });
+
+  it("keeps both env pins when packageManager is retained", async () => {
+    const { documents } = await isolate({
+      packageManager: "pnpm@12.0.0",
+      fixture: "pnpm-config-dependencies",
+    });
+
+    const rootImporter = rootImporterOf(documents[0]);
+
+    expect(rootImporter?.configDependencies).toHaveProperty("my-config");
+    expect(rootImporter?.packageManagerDependencies).toHaveProperty("pnpm");
+  });
+});

--- a/src/lib/lockfile/helpers/generate-pnpm-lockfile.test.ts
+++ b/src/lib/lockfile/helpers/generate-pnpm-lockfile.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import type { PackageManifest } from "#/lib/types";
 import { generatePnpmLockfile } from "./generate-pnpm-lockfile";
 
 /** Mock utils */
@@ -20,6 +21,8 @@ vi.mock("pnpm_lockfile_file_v8", () => ({
 vi.mock("pnpm_lockfile_file_v9", () => ({
   readWantedLockfile: vi.fn(),
   writeWantedLockfile: vi.fn(),
+  readEnvLockfile: vi.fn(),
+  writeEnvLockfile: vi.fn(),
   getLockfileImporterId: vi.fn((_root: string, pkgDir: string) =>
     pkgDir.replace(/.*\//, "").replace(/\\/g, "/"),
   ),
@@ -47,6 +50,8 @@ const {
 const {
   readWantedLockfile: readWantedLockfile_v9,
   writeWantedLockfile: writeWantedLockfile_v9,
+  readEnvLockfile: readEnvLockfile_v9,
+  writeEnvLockfile: writeEnvLockfile_v9,
   getLockfileImporterId: getLockfileImporterId_v9,
 } = vi.mocked(await import("pnpm_lockfile_file_v9"));
 
@@ -98,7 +103,7 @@ describe("generatePnpmLockfile", () => {
   it("should use v9 API when majorVersion >= 9", async () => {
     const lockfile = createMockLockfile();
     readWantedLockfile_v9.mockResolvedValue(lockfile as never);
-    getLockfileImporterId_v9.mockReturnValue("apps/my-app");
+    getLockfileImporterId_v9.mockReturnValue("apps/my-app" as never);
 
     pruneLockfile_v9.mockReturnValue(lockfile as never);
 
@@ -158,7 +163,7 @@ describe("generatePnpmLockfile", () => {
   it("should remap target importer to root (.)", async () => {
     const lockfile = createMockLockfile();
     readWantedLockfile_v9.mockResolvedValue(lockfile as never);
-    getLockfileImporterId_v9.mockReturnValue("apps/my-app");
+    getLockfileImporterId_v9.mockReturnValue("apps/my-app" as never);
 
     pruneLockfile_v9.mockImplementation((lf) => lf as never);
 
@@ -191,7 +196,7 @@ describe("generatePnpmLockfile", () => {
   it("should filter importers to only relevant packages", async () => {
     const lockfile = createMockLockfile();
     readWantedLockfile_v9.mockResolvedValue(lockfile as never);
-    getLockfileImporterId_v9.mockReturnValue("apps/my-app");
+    getLockfileImporterId_v9.mockReturnValue("apps/my-app" as never);
 
     pruneLockfile_v9.mockImplementation((lf) => lf as never);
 
@@ -231,7 +236,7 @@ describe("generatePnpmLockfile", () => {
       overrides: { lodash: "4.17.21" },
     };
     readWantedLockfile_v9.mockResolvedValue(lockfile as never);
-    getLockfileImporterId_v9.mockReturnValue("apps/my-app");
+    getLockfileImporterId_v9.mockReturnValue("apps/my-app" as never);
 
     /** Simulate prune removing overrides */
     pruneLockfile_v9.mockImplementation((lf) => {
@@ -270,7 +275,7 @@ describe("generatePnpmLockfile", () => {
       packageExtensionsChecksum: "abc123",
     };
     readWantedLockfile_v9.mockResolvedValue(lockfile as never);
-    getLockfileImporterId_v9.mockReturnValue("apps/my-app");
+    getLockfileImporterId_v9.mockReturnValue("apps/my-app" as never);
 
     /** Simulate prune removing packageExtensionsChecksum */
     pruneLockfile_v9.mockImplementation((lf) => {
@@ -317,7 +322,7 @@ describe("generatePnpmLockfile", () => {
       catalogs,
     };
     readWantedLockfile_v9.mockResolvedValue(lockfile as never);
-    getLockfileImporterId_v9.mockReturnValue("apps/my-app");
+    getLockfileImporterId_v9.mockReturnValue("apps/my-app" as never);
 
     /** Simulate prune dropping the catalogs snapshot */
     pruneLockfile_v9.mockImplementation((lf) => {
@@ -359,7 +364,7 @@ describe("generatePnpmLockfile", () => {
   it("should not set catalogs when the source lockfile has none", async () => {
     const lockfile = createMockLockfile();
     readWantedLockfile_v9.mockResolvedValue(lockfile as never);
-    getLockfileImporterId_v9.mockReturnValue("apps/my-app");
+    getLockfileImporterId_v9.mockReturnValue("apps/my-app" as never);
     pruneLockfile_v9.mockImplementation((lf) => lf as never);
 
     await generatePnpmLockfile({
@@ -387,7 +392,7 @@ describe("generatePnpmLockfile", () => {
   it("should include patchedDependencies in written lockfile", async () => {
     const lockfile = createMockLockfile();
     readWantedLockfile_v9.mockResolvedValue(lockfile as never);
-    getLockfileImporterId_v9.mockReturnValue("apps/my-app");
+    getLockfileImporterId_v9.mockReturnValue("apps/my-app" as never);
     pruneLockfile_v9.mockImplementation((lf) => lf as never);
 
     const patchedDependencies = {
@@ -440,7 +445,7 @@ describe("generatePnpmLockfile", () => {
     isRushWorkspace.mockReturnValue(true);
     const lockfile = createMockLockfile();
     readWantedLockfile_v9.mockResolvedValue(lockfile as never);
-    getLockfileImporterId_v9.mockReturnValue("apps/my-app");
+    getLockfileImporterId_v9.mockReturnValue("apps/my-app" as never);
     pruneLockfile_v9.mockImplementation((lf) => lf as never);
 
     await generatePnpmLockfile({
@@ -464,5 +469,136 @@ describe("generatePnpmLockfile", () => {
       "/workspace/common/config/rush",
       expect.any(Object),
     );
+  });
+
+  describe("lockfile env document", () => {
+    /**
+     * The env document pnpm 12 writes ahead of the project document, holding
+     * `configDependencies` and `packageManagerDependencies`.
+     */
+    const envLockfile = {
+      lockfileVersion: "9.0",
+      importers: {
+        ".": {
+          configDependencies: {},
+          packageManagerDependencies: {
+            pnpm: { specifier: "12.0.0", version: "12.0.0" },
+          },
+        },
+      },
+      packages: {},
+      snapshots: {},
+    };
+
+    beforeEach(() => {
+      isRushWorkspace.mockReturnValue(false);
+      const lockfile = createMockLockfile();
+      readWantedLockfile_v9.mockResolvedValue(lockfile as never);
+      getLockfileImporterId_v9.mockReturnValue("apps/my-app" as never);
+      pruneLockfile_v9.mockImplementation((lf) => lf as never);
+    });
+
+    async function generate(targetPackageManifest: PackageManifest) {
+      await generatePnpmLockfile({
+        workspaceRootDir: "/workspace",
+        targetPackageDir: "/workspace/apps/my-app",
+        isolateDir: "/workspace/apps/my-app/isolate",
+        internalDepPackageNames: [],
+        packagesRegistry: {},
+        targetPackageManifest,
+        majorVersion: 12,
+        includeDevDependencies: false,
+      });
+    }
+
+    it("should copy the env document when the output keeps a packageManager", async () => {
+      readEnvLockfile_v9.mockResolvedValue(envLockfile as never);
+
+      await generate({
+        name: "my-app",
+        version: "1.0.0",
+        packageManager: "pnpm@12.0.0",
+      });
+
+      expect(readEnvLockfile_v9).toHaveBeenCalledWith("/workspace");
+      expect(writeEnvLockfile_v9).toHaveBeenCalledWith(
+        "/workspace/apps/my-app/isolate",
+        envLockfile,
+      );
+    });
+
+    it("should write the env document after the project document, since it is appended to the existing file", async () => {
+      readEnvLockfile_v9.mockResolvedValue(envLockfile as never);
+
+      await generate({
+        name: "my-app",
+        version: "1.0.0",
+        packageManager: "pnpm@12.0.0",
+      });
+
+      expect(writeWantedLockfile_v9.mock.invocationCallOrder[0]!).toBeLessThan(
+        writeEnvLockfile_v9.mock.invocationCallOrder[0]!,
+      );
+    });
+
+    it("should skip the env document when the output omits the packageManager", async () => {
+      readEnvLockfile_v9.mockResolvedValue(envLockfile as never);
+
+      await generate({ name: "my-app", version: "1.0.0" });
+
+      expect(writeEnvLockfile_v9).not.toHaveBeenCalled();
+    });
+
+    it("should skip the env document when the workspace lockfile has none", async () => {
+      readEnvLockfile_v9.mockResolvedValue(null as never);
+
+      await generate({
+        name: "my-app",
+        version: "1.0.0",
+        packageManager: "pnpm@12.0.0",
+      });
+
+      expect(writeEnvLockfile_v9).not.toHaveBeenCalled();
+    });
+
+    it("should read the env document from the Rush lockfile directory", async () => {
+      isRushWorkspace.mockReturnValue(true);
+      readEnvLockfile_v9.mockResolvedValue(null as never);
+
+      await generate({
+        name: "my-app",
+        version: "1.0.0",
+        packageManager: "pnpm@12.0.0",
+      });
+
+      expect(readEnvLockfile_v9).toHaveBeenCalledWith(
+        "/workspace/common/config/rush",
+      );
+    });
+  });
+
+  it("should not touch the env document on the v8 path", async () => {
+    const lockfile = createMockLockfile();
+    readWantedLockfile_v8.mockResolvedValue(lockfile as never);
+    getLockfileImporterId_v8.mockReturnValue("apps/my-app");
+    pruneLockfile_v8.mockImplementation((lf) => lf as never);
+
+    await generatePnpmLockfile({
+      workspaceRootDir: "/workspace",
+      targetPackageDir: "/workspace/apps/my-app",
+      isolateDir: "/workspace/apps/my-app/isolate",
+      internalDepPackageNames: [],
+      packagesRegistry: {},
+      targetPackageManifest: {
+        name: "my-app",
+        version: "1.0.0",
+        packageManager: "pnpm@8.15.0",
+      },
+      majorVersion: 8,
+      includeDevDependencies: false,
+    });
+
+    expect(readEnvLockfile_v9).not.toHaveBeenCalled();
+    expect(writeEnvLockfile_v9).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/lockfile/helpers/generate-pnpm-lockfile.test.ts
+++ b/src/lib/lockfile/helpers/generate-pnpm-lockfile.test.ts
@@ -4,9 +4,27 @@ import type { PackageManifest } from "#/lib/types";
 import { generatePnpmLockfile } from "./generate-pnpm-lockfile";
 
 /** Mock utils */
+/**
+ * Hoisted so the `#/lib/utils` factory below can use it for both
+ * `isRushWorkspace` and the `getPnpmLockfileDir` that is derived from it.
+ */
+const isRushWorkspaceMock = vi.hoisted(() =>
+  vi.fn((_workspaceRootDir: string) => false),
+);
+
 vi.mock("#/lib/utils", () => ({
   getErrorMessage: vi.fn((err: Error) => err.message),
-  isRushWorkspace: vi.fn(() => false),
+  isRushWorkspace: isRushWorkspaceMock,
+  /**
+   * Mirrors the real helper, which is a pure path computation on top of the
+   * mocked `isRushWorkspace` above — so the Rush cases still exercise the
+   * branch rather than a hard-coded answer.
+   */
+  getPnpmLockfileDir: vi.fn((workspaceRootDir: string) =>
+    isRushWorkspaceMock(workspaceRootDir)
+      ? `${workspaceRootDir}/common/config/rush`
+      : workspaceRootDir,
+  ),
 }));
 
 /** Mock pnpm v8 lockfile functions */
@@ -533,7 +551,12 @@ describe("generatePnpmLockfile", () => {
       );
     });
 
-    it("should write the env document after the project document, since the env writer preserves what is already on disk", async () => {
+    /**
+     * Only the call order is checked here, since these are mocks: that the real
+     * writer preserves the project document is a property of the library, and
+     * the integration test is what actually asserts it.
+     */
+    it("should write the env document after the project document", async () => {
       readEnvLockfile_v9.mockResolvedValue(envLockfile);
 
       await generate({

--- a/src/lib/lockfile/helpers/generate-pnpm-lockfile.test.ts
+++ b/src/lib/lockfile/helpers/generate-pnpm-lockfile.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import type { EnvLockfile } from "pnpm_lockfile_file_v9";
 import type { PackageManifest } from "#/lib/types";
 import { generatePnpmLockfile } from "./generate-pnpm-lockfile";
 
@@ -94,6 +95,12 @@ function createMockLockfile() {
 describe("generatePnpmLockfile", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    /**
+     * `clearAllMocks` resets calls but not implementations, so the Rush default
+     * has to be reapplied here — otherwise the one test that turns it on leaks
+     * into whatever runs next.
+     */
+    isRushWorkspace.mockReturnValue(false);
   });
 
   afterEach(() => {
@@ -488,10 +495,9 @@ describe("generatePnpmLockfile", () => {
       },
       packages: {},
       snapshots: {},
-    };
+    } satisfies EnvLockfile;
 
     beforeEach(() => {
-      isRushWorkspace.mockReturnValue(false);
       const lockfile = createMockLockfile();
       readWantedLockfile_v9.mockResolvedValue(lockfile as never);
       getLockfileImporterId_v9.mockReturnValue("apps/my-app" as never);
@@ -512,7 +518,7 @@ describe("generatePnpmLockfile", () => {
     }
 
     it("should copy the env document when the output keeps a packageManager", async () => {
-      readEnvLockfile_v9.mockResolvedValue(envLockfile as never);
+      readEnvLockfile_v9.mockResolvedValue(envLockfile);
 
       await generate({
         name: "my-app",
@@ -527,8 +533,8 @@ describe("generatePnpmLockfile", () => {
       );
     });
 
-    it("should write the env document after the project document, since it is appended to the existing file", async () => {
-      readEnvLockfile_v9.mockResolvedValue(envLockfile as never);
+    it("should write the env document after the project document, since the env writer preserves what is already on disk", async () => {
+      readEnvLockfile_v9.mockResolvedValue(envLockfile);
 
       await generate({
         name: "my-app",
@@ -542,7 +548,7 @@ describe("generatePnpmLockfile", () => {
     });
 
     it("should skip the env document when the output omits the packageManager", async () => {
-      readEnvLockfile_v9.mockResolvedValue(envLockfile as never);
+      readEnvLockfile_v9.mockResolvedValue(envLockfile);
 
       await generate({ name: "my-app", version: "1.0.0" });
 
@@ -550,7 +556,7 @@ describe("generatePnpmLockfile", () => {
     });
 
     it("should skip the env document when the workspace lockfile has none", async () => {
-      readEnvLockfile_v9.mockResolvedValue(null as never);
+      readEnvLockfile_v9.mockResolvedValue(null);
 
       await generate({
         name: "my-app",
@@ -563,7 +569,7 @@ describe("generatePnpmLockfile", () => {
 
     it("should read the env document from the Rush lockfile directory", async () => {
       isRushWorkspace.mockReturnValue(true);
-      readEnvLockfile_v9.mockResolvedValue(null as never);
+      readEnvLockfile_v9.mockResolvedValue(null);
 
       await generate({
         name: "my-app",

--- a/src/lib/lockfile/helpers/generate-pnpm-lockfile.test.ts
+++ b/src/lib/lockfile/helpers/generate-pnpm-lockfile.test.ts
@@ -114,11 +114,13 @@ describe("generatePnpmLockfile", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     /**
-     * `clearAllMocks` resets calls but not implementations, so the Rush default
-     * has to be reapplied here — otherwise the one test that turns it on leaks
-     * into whatever runs next.
+     * `clearAllMocks` resets calls but not implementations, so the defaults
+     * have to be reapplied here — otherwise the one test that turns Rush on
+     * leaks into whatever runs next, and the env reader resolves to undefined
+     * rather than to the "no env document" answer its contract allows.
      */
     isRushWorkspace.mockReturnValue(false);
+    readEnvLockfile_v9.mockResolvedValue(null);
   });
 
   afterEach(() => {

--- a/src/lib/lockfile/helpers/generate-pnpm-lockfile.ts
+++ b/src/lib/lockfile/helpers/generate-pnpm-lockfile.ts
@@ -5,9 +5,17 @@ import {
   readWantedLockfile as readWantedLockfile_v8,
   writeWantedLockfile as writeWantedLockfile_v8,
 } from "pnpm_lockfile_file_v8";
+/**
+ * The `_v9` alias names the lockfile format, not the package. It resolves to
+ * `@pnpm/lockfile.fs`, the maintained successor of `@pnpm/lockfile-file`, whose
+ * last release predates the two-document lockfile that pnpm 12 writes (see
+ * issue #205). Both read and write lockfile format v9.
+ */
 import {
   getLockfileImporterId as getLockfileImporterId_v9,
+  readEnvLockfile as readEnvLockfile_v9,
   readWantedLockfile as readWantedLockfile_v9,
+  writeEnvLockfile as writeEnvLockfile_v9,
   writeWantedLockfile as writeWantedLockfile_v9,
 } from "pnpm_lockfile_file_v9";
 import { pruneLockfile as pruneLockfile_v8 } from "pnpm_prune_lockfile_v8";
@@ -21,8 +29,8 @@ import { pnpmMapImporter } from "./pnpm-map-importer";
 /**
  * A pnpm catalog snapshot as stored in the lockfile: a map of catalog name
  * (e.g. "default") to a map of dependency name to its resolved entry. The
- * pinned `@pnpm/lockfile-file` types predate catalogs, so we model the shape
- * locally for the cast below.
+ * lockfile object is a union of the v8 and v9 reader types and the v8 one
+ * predates catalogs, so we model the shape locally for the cast below.
  */
 type CatalogSnapshots = Record<
   string,
@@ -65,23 +73,18 @@ export async function generatePnpmLockfile({
   try {
     const isRush = isRushWorkspace(workspaceRootDir);
 
+    /** In a Rush workspace the lockfile does not live in the workspace root */
+    const lockfileRootDir = isRush
+      ? path.join(workspaceRootDir, "common/config/rush")
+      : workspaceRootDir;
+
     const lockfile = useVersion9
-      ? await readWantedLockfile_v9(
-          isRush
-            ? path.join(workspaceRootDir, "common/config/rush")
-            : workspaceRootDir,
-          {
-            ignoreIncompatible: false,
-          },
-        )
-      : await readWantedLockfile_v8(
-          isRush
-            ? path.join(workspaceRootDir, "common/config/rush")
-            : workspaceRootDir,
-          {
-            ignoreIncompatible: false,
-          },
-        );
+      ? await readWantedLockfile_v9(lockfileRootDir, {
+          ignoreIncompatible: false,
+        })
+      : await readWantedLockfile_v8(lockfileRootDir, {
+          ignoreIncompatible: false,
+        });
 
     assert(lockfile, `No input lockfile found at ${workspaceRootDir}`);
 
@@ -163,9 +166,23 @@ export async function generatePnpmLockfile({
 
     log.debug("Pruning the lockfile");
 
+    /**
+     * The reader and the pruner are separate packages with their own copies of
+     * the lockfile types, and since v9 the reader brands its importer keys with
+     * `ProjectId`. The shapes are structurally the same, so we cast to whatever
+     * the matching pruner declares.
+     */
     const prunedLockfile = useVersion9
-      ? pruneLockfile_v9(lockfile, targetPackageManifest, ".")
-      : pruneLockfile_v8(lockfile, targetPackageManifest, ".");
+      ? pruneLockfile_v9(
+          lockfile as Parameters<typeof pruneLockfile_v9>[0],
+          targetPackageManifest,
+          ".",
+        )
+      : pruneLockfile_v8(
+          lockfile as Parameters<typeof pruneLockfile_v8>[0],
+          targetPackageManifest,
+          ".",
+        );
 
     /** Pruning seems to remove the overrides from the lockfile */
     if (lockfile.overrides) {
@@ -200,9 +217,24 @@ export async function generatePnpmLockfile({
      * structure, preserving the original folder structure (not flattened).
      */
     if (useVersion9) {
+      /**
+       * The pruner and the writer come from separate packages with their own
+       * copies of the lockfile types, which disagree on `lockfileVersion` and on
+       * `patchedDependencies`: the modern writer types the latter as a map of
+       * bare hashes, because pnpm 11 simplified the on-disk format (see issue
+       * #201). We keep writing the `{ path, hash }` form that pnpm 9 and 10
+       * expect — pnpm 11 and up migrate it when reading, and the writer passes
+       * the value through untouched.
+       */
       await writeWantedLockfile_v9(isolateDir, {
         ...prunedLockfile,
         patchedDependencies,
+      } as unknown as Parameters<typeof writeWantedLockfile_v9>[1]);
+
+      await copyEnvLockfile({
+        lockfileRootDir,
+        isolateDir,
+        targetPackageManifest,
       });
     } else {
       await writeWantedLockfile_v8(isolateDir, {
@@ -216,4 +248,47 @@ export async function generatePnpmLockfile({
     log.error(`Failed to generate lockfile: ${getErrorMessage(error)}`);
     throw error;
   }
+}
+
+/**
+ * Since pnpm 12 the lockfile can be a stream of two YAML documents: an "env"
+ * document holding `configDependencies` and `packageManagerDependencies`,
+ * followed by the project document. The env document is what pins the package
+ * manager itself, so an isolated output that keeps the root `packageManager`
+ * field but drops the env document is rejected by
+ * `pnpm install --frozen-lockfile` with
+ * ERR_PNPM_FROZEN_LOCKFILE_WITH_OUTDATED_LOCKFILE.
+ *
+ * The env document describes the environment rather than the workspace graph,
+ * so there is nothing to prune — it is copied verbatim. When the output omits
+ * `packageManager` we skip it, because then pnpm would consider the pinned
+ * package manager dependencies stale for the opposite reason.
+ */
+async function copyEnvLockfile({
+  lockfileRootDir,
+  isolateDir,
+  targetPackageManifest,
+}: {
+  lockfileRootDir: string;
+  isolateDir: string;
+  targetPackageManifest: PackageManifest;
+}) {
+  const log = useLogger();
+
+  const envLockfile = await readEnvLockfile_v9(lockfileRootDir);
+
+  if (!envLockfile) {
+    return;
+  }
+
+  if (!targetPackageManifest.packageManager) {
+    log.debug(
+      "Skipping the lockfile env document because the output manifest has no packageManager field",
+    );
+    return;
+  }
+
+  log.debug("Copying the lockfile env document");
+
+  await writeEnvLockfile_v9(isolateDir, envLockfile);
 }

--- a/src/lib/lockfile/helpers/generate-pnpm-lockfile.ts
+++ b/src/lib/lockfile/helpers/generate-pnpm-lockfile.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert";
+import fs from "node:fs/promises";
 import path from "node:path";
 import {
   getLockfileImporterId as getLockfileImporterId_v8,
@@ -24,7 +25,11 @@ import { pruneLockfile as pruneLockfile_v9 } from "pnpm_prune_lockfile_v9";
 import { omit, pick } from "remeda";
 import { useLogger } from "#/lib/logger";
 import type { PackageManifest, PackagesRegistry, PatchFile } from "#/lib/types";
-import { getErrorMessage, isRushWorkspace } from "#/lib/utils";
+import {
+  getErrorMessage,
+  getPnpmLockfileDir,
+  isRushWorkspace,
+} from "#/lib/utils";
 import { pnpmMapImporter } from "./pnpm-map-importer";
 
 /**
@@ -74,10 +79,7 @@ export async function generatePnpmLockfile({
   try {
     const isRush = isRushWorkspace(workspaceRootDir);
 
-    /** In a Rush workspace the lockfile does not live in the workspace root */
-    const lockfileRootDir = isRush
-      ? path.join(workspaceRootDir, "common/config/rush")
-      : workspaceRootDir;
+    const lockfileRootDir = getPnpmLockfileDir(workspaceRootDir);
 
     const lockfile = useVersion9
       ? await readWantedLockfile_v9(lockfileRootDir, {
@@ -232,6 +234,12 @@ export async function generatePnpmLockfile({
         patchedDependencies,
       } as unknown as Parameters<typeof writeWantedLockfile_v9>[1]);
 
+      /**
+       * Must run after the project document is on disk: `writeEnvLockfile`
+       * reads the existing lockfile back, extracts its main document, and
+       * rewrites the file as `<env>\n---\n<main>`. Called first, it would
+       * write an env-only lockfile that the project write then overwrites.
+       */
       await copyEnvLockfile({
         lockfileRootDir,
         isolateDir,
@@ -284,6 +292,17 @@ async function copyEnvLockfile({
   const envLockfile = await readEnvLockfile_v9(lockfileRootDir);
 
   if (!envLockfile) {
+    /**
+     * The reader returns null both for a single-document lockfile — the
+     * ordinary pnpm 9 to 11 case — and for a two-document one whose env
+     * document it could not recognize. Only the second is a problem, so log
+     * which of the two this was rather than returning silently.
+     */
+    log.debug(
+      (await startsWithEnvDocument(lockfileRootDir))
+        ? "The lockfile starts with an env document but the reader did not recognize it, so the isolated lockfile will not carry one"
+        : "No lockfile env document to copy",
+    );
     return;
   }
 
@@ -296,7 +315,7 @@ async function copyEnvLockfile({
 
   const withoutPackageManager = omitEnvPackageManagerDependencies(envLockfile);
 
-  if (!hasEnvConfigDependencies(withoutPackageManager)) {
+  if (!pinsConfigDependencies(withoutPackageManager)) {
     log.debug(
       "Skipping the lockfile env document because the output manifest has no packageManager field and the document pins no config dependencies",
     );
@@ -313,9 +332,13 @@ async function copyEnvLockfile({
 /**
  * Strip the `packageManagerDependencies` pin from every importer of an env
  * document, leaving the rest of it untouched. The `packages` and `snapshots`
- * entries the pin resolved to are left in place: pnpm tolerates entries no
- * importer references, the same way it does for the catalogs snapshot above,
- * and dropping them would mean re-deriving the resolution graph here.
+ * entries the pin resolved to are left in place, because nothing reads them:
+ * verified by running `pnpm install --frozen-lockfile` (pnpm 12) against
+ * exactly this output — the lockfile is accepted as up to date, and env
+ * entries never enter the isolate's virtual store whether an importer
+ * references them or not. Pruning them would be a reachability walk from the
+ * remaining `configDependencies` rather than a re-resolution, so it is
+ * affordable; it is left undone because the residue is some unread YAML.
  */
 function omitEnvPackageManagerDependencies(
   envLockfile: EnvLockfile,
@@ -331,9 +354,31 @@ function omitEnvPackageManagerDependencies(
   };
 }
 
-/** Whether an env document still pins anything once the package manager is out */
-function hasEnvConfigDependencies(envLockfile: EnvLockfile) {
+/** Whether an env document pins any config dependency */
+function pinsConfigDependencies(envLockfile: EnvLockfile) {
   return Object.values(envLockfile.importers).some(
     (importer) => Object.keys(importer.configDependencies ?? {}).length > 0,
   );
+}
+
+/**
+ * Whether the workspace lockfile begins with a YAML document-start marker,
+ * which is how pnpm 12 signals that an env document precedes the project one.
+ * Used only to tell "there is no env document" apart from "there is one and
+ * the reader rejected it" in the log line above.
+ */
+async function startsWithEnvDocument(lockfileRootDir: string) {
+  try {
+    const handle = await fs.open(path.join(lockfileRootDir, "pnpm-lock.yaml"));
+
+    try {
+      const { buffer, bytesRead } = await handle.read(Buffer.alloc(4), 0, 4, 0);
+
+      return buffer.subarray(0, bytesRead).toString("utf8") === "---\n";
+    } finally {
+      await handle.close();
+    }
+  } catch {
+    return false;
+  }
 }

--- a/src/lib/lockfile/helpers/generate-pnpm-lockfile.ts
+++ b/src/lib/lockfile/helpers/generate-pnpm-lockfile.ts
@@ -289,20 +289,39 @@ async function copyEnvLockfile({
 }) {
   const log = useLogger();
 
-  const envLockfile = await readEnvLockfile_v9(lockfileRootDir);
+  /**
+   * The reader resolves to null for a single-document lockfile — the ordinary
+   * pnpm 9 to 11 case — but it throws rather than returning null when the file
+   * exists and cannot be read or parsed: it special-cases only ENOENT, and the
+   * env document is passed through `yaml.load`. `readWantedLockfile` above has
+   * already succeeded by this point, so failing the whole isolate on the env
+   * document alone would turn a readable workspace into a hard error.
+   */
+  let envLockfile;
+
+  try {
+    envLockfile = await readEnvLockfile_v9(lockfileRootDir);
+  } catch (error) {
+    log.warn(
+      `Could not read the lockfile env document, so the isolated lockfile will not carry one: ${getErrorMessage(error)}`,
+    );
+    return;
+  }
 
   if (!envLockfile) {
     /**
-     * The reader returns null both for a single-document lockfile — the
-     * ordinary pnpm 9 to 11 case — and for a two-document one whose env
-     * document it could not recognize. Only the second is a problem, so log
-     * which of the two this was rather than returning silently.
+     * A null result means either that there is no env document or that the
+     * reader declined the one that is there. Only the second loses something,
+     * so say which it was instead of returning silently.
      */
-    log.debug(
-      (await startsWithEnvDocument(lockfileRootDir))
-        ? "The lockfile starts with an env document but the reader did not recognize it, so the isolated lockfile will not carry one"
-        : "No lockfile env document to copy",
-    );
+    if (await startsWithEnvDocument(lockfileRootDir)) {
+      log.warn(
+        "The lockfile starts with an env document but the reader did not recognize it, so the isolated lockfile will not carry one",
+      );
+    } else {
+      log.debug("No lockfile env document to copy");
+    }
+
     return;
   }
 
@@ -372,9 +391,14 @@ async function startsWithEnvDocument(lockfileRootDir: string) {
     const handle = await fs.open(path.join(lockfileRootDir, "pnpm-lock.yaml"));
 
     try {
-      const { buffer, bytesRead } = await handle.read(Buffer.alloc(4), 0, 4, 0);
+      /**
+       * Five bytes rather than four, so the CRLF spelling is recognized too —
+       * the reader normalizes line endings before it looks for the marker.
+       */
+      const { buffer, bytesRead } = await handle.read(Buffer.alloc(5), 0, 5, 0);
+      const start = buffer.subarray(0, bytesRead).toString("utf8");
 
-      return buffer.subarray(0, bytesRead).toString("utf8") === "---\n";
+      return start.startsWith("---\n") || start.startsWith("---\r\n");
     } finally {
       await handle.close();
     }

--- a/src/lib/lockfile/helpers/generate-pnpm-lockfile.ts
+++ b/src/lib/lockfile/helpers/generate-pnpm-lockfile.ts
@@ -297,7 +297,7 @@ async function copyEnvLockfile({
    * already succeeded by this point, so failing the whole isolate on the env
    * document alone would turn a readable workspace into a hard error.
    */
-  let envLockfile;
+  let envLockfile: EnvLockfile | null;
 
   try {
     envLockfile = await readEnvLockfile_v9(lockfileRootDir);

--- a/src/lib/lockfile/helpers/generate-pnpm-lockfile.ts
+++ b/src/lib/lockfile/helpers/generate-pnpm-lockfile.ts
@@ -11,6 +11,7 @@ import {
  * last release predates the two-document lockfile that pnpm 12 writes (see
  * issue #205). Both read and write lockfile format v9.
  */
+import type { EnvLockfile } from "pnpm_lockfile_file_v9";
 import {
   getLockfileImporterId as getLockfileImporterId_v9,
   readEnvLockfile as readEnvLockfile_v9,
@@ -20,7 +21,7 @@ import {
 } from "pnpm_lockfile_file_v9";
 import { pruneLockfile as pruneLockfile_v8 } from "pnpm_prune_lockfile_v8";
 import { pruneLockfile as pruneLockfile_v9 } from "pnpm_prune_lockfile_v9";
-import { pick } from "remeda";
+import { omit, pick } from "remeda";
 import { useLogger } from "#/lib/logger";
 import type { PackageManifest, PackagesRegistry, PatchFile } from "#/lib/types";
 import { getErrorMessage, isRushWorkspace } from "#/lib/utils";
@@ -252,17 +253,22 @@ export async function generatePnpmLockfile({
 
 /**
  * Since pnpm 12 the lockfile can be a stream of two YAML documents: an "env"
- * document holding `configDependencies` and `packageManagerDependencies`,
- * followed by the project document. The env document is what pins the package
- * manager itself, so an isolated output that keeps the root `packageManager`
- * field but drops the env document is rejected by
+ * document, followed by the project document. The env document pins two
+ * independent things — the package manager itself
+ * (`packageManagerDependencies`) and the workspace's config dependencies
+ * (`configDependencies`) — recording the resolutions and integrity hashes for
+ * specifiers that live in `pnpm-workspace.yaml`. An isolated output that keeps
+ * either of those but drops the env document is rejected by
  * `pnpm install --frozen-lockfile` with
  * ERR_PNPM_FROZEN_LOCKFILE_WITH_OUTDATED_LOCKFILE.
  *
  * The env document describes the environment rather than the workspace graph,
- * so there is nothing to prune — it is copied verbatim. When the output omits
- * `packageManager` we skip it, because then pnpm would consider the pinned
- * package manager dependencies stale for the opposite reason.
+ * so there is nothing to prune from it and it is copied without pruning. The
+ * one thing that can need dropping is `packageManagerDependencies`: when
+ * `omitPackageManager` strips the field from the output manifest, pnpm would
+ * consider that pin stale for the opposite reason. The config dependencies
+ * still have to survive that, because `pnpm-workspace.yaml` is copied to the
+ * isolate verbatim and keeps declaring them.
  */
 async function copyEnvLockfile({
   lockfileRootDir,
@@ -281,14 +287,53 @@ async function copyEnvLockfile({
     return;
   }
 
-  if (!targetPackageManifest.packageManager) {
+  if (targetPackageManifest.packageManager) {
+    log.debug("Copying the lockfile env document");
+
+    await writeEnvLockfile_v9(isolateDir, envLockfile);
+    return;
+  }
+
+  const withoutPackageManager = omitEnvPackageManagerDependencies(envLockfile);
+
+  if (!hasEnvConfigDependencies(withoutPackageManager)) {
     log.debug(
-      "Skipping the lockfile env document because the output manifest has no packageManager field",
+      "Skipping the lockfile env document because the output manifest has no packageManager field and the document pins no config dependencies",
     );
     return;
   }
 
-  log.debug("Copying the lockfile env document");
+  log.debug(
+    "Copying the lockfile env document without its packageManagerDependencies",
+  );
 
-  await writeEnvLockfile_v9(isolateDir, envLockfile);
+  await writeEnvLockfile_v9(isolateDir, withoutPackageManager);
+}
+
+/**
+ * Strip the `packageManagerDependencies` pin from every importer of an env
+ * document, leaving the rest of it untouched. The `packages` and `snapshots`
+ * entries the pin resolved to are left in place: pnpm tolerates entries no
+ * importer references, the same way it does for the catalogs snapshot above,
+ * and dropping them would mean re-deriving the resolution graph here.
+ */
+function omitEnvPackageManagerDependencies(
+  envLockfile: EnvLockfile,
+): EnvLockfile {
+  return {
+    ...envLockfile,
+    importers: Object.fromEntries(
+      Object.entries(envLockfile.importers).map(([importerId, importer]) => [
+        importerId,
+        omit(importer, ["packageManagerDependencies"]),
+      ]),
+    ) as EnvLockfile["importers"],
+  };
+}
+
+/** Whether an env document still pins anything once the package manager is out */
+function hasEnvConfigDependencies(envLockfile: EnvLockfile) {
+  return Object.values(envLockfile.importers).some(
+    (importer) => Object.keys(importer.configDependencies ?? {}).length > 0,
+  );
 }

--- a/src/lib/patches/collect-installed-names-pnpm.test.ts
+++ b/src/lib/patches/collect-installed-names-pnpm.test.ts
@@ -15,12 +15,7 @@ vi.mock("pnpm_lockfile_file_v9", () => ({
   ),
 }));
 
-vi.mock("#/lib/utils", async (importOriginal) => ({
-  /**
-   * Partial mock: `getPnpmLockfileDir` stays real so the Rush path
-   * computation is not re-implemented per test file.
-   */
-  ...(await importOriginal<typeof import("#/lib/utils")>()),
+vi.mock("#/lib/utils", () => ({
   getPackageName: vi.fn((spec: string) => {
     if (spec.startsWith("@")) {
       const parts = spec.split("@");
@@ -29,6 +24,14 @@ vi.mock("#/lib/utils", async (importOriginal) => ({
     return spec.split("@")[0] ?? "";
   }),
   isRushWorkspace: vi.fn(() => false),
+  /**
+   * Neither suite exercises a Rush workspace, so the lockfile directory is the
+   * workspace root. Mocked rather than kept real: the real helper reads
+   * `rush.json` off disk through its own `isRushWorkspace` import, which this
+   * factory cannot intercept, and that would make these tests depend on the
+   * filesystem. `get-pnpm-lockfile-dir.test.ts` covers both of its branches.
+   */
+  getPnpmLockfileDir: vi.fn((workspaceRootDir: string) => workspaceRootDir),
 }));
 
 const { readWantedLockfile: readWantedLockfile_v9 } = vi.mocked(

--- a/src/lib/patches/collect-installed-names-pnpm.test.ts
+++ b/src/lib/patches/collect-installed-names-pnpm.test.ts
@@ -1,6 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { collectInstalledNamesFromPnpmLockfile } from "./collect-installed-names-pnpm";
 
+/**
+ * Hoisted so the `#/lib/utils` factory below can use it for both
+ * `isRushWorkspace` and the `getPnpmLockfileDir` that is derived from it.
+ */
+const isRushWorkspaceMock = vi.hoisted(() =>
+  vi.fn((_workspaceRootDir: string) => false),
+);
+
 vi.mock("pnpm_lockfile_file_v8", () => ({
   readWantedLockfile: vi.fn(() => Promise.resolve(null)),
   getLockfileImporterId: vi.fn(
@@ -23,7 +31,17 @@ vi.mock("#/lib/utils", () => ({
     }
     return spec.split("@")[0] ?? "";
   }),
-  isRushWorkspace: vi.fn(() => false),
+  isRushWorkspace: isRushWorkspaceMock,
+  /**
+   * Mirrors the real helper, which is a pure path computation on top of the
+   * mocked `isRushWorkspace` above — so the Rush cases still exercise the
+   * branch rather than a hard-coded answer.
+   */
+  getPnpmLockfileDir: vi.fn((workspaceRootDir: string) =>
+    isRushWorkspaceMock(workspaceRootDir)
+      ? `${workspaceRootDir}/common/config/rush`
+      : workspaceRootDir,
+  ),
 }));
 
 const { readWantedLockfile: readWantedLockfile_v9 } = vi.mocked(

--- a/src/lib/patches/collect-installed-names-pnpm.test.ts
+++ b/src/lib/patches/collect-installed-names-pnpm.test.ts
@@ -1,14 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { collectInstalledNamesFromPnpmLockfile } from "./collect-installed-names-pnpm";
 
-/**
- * Hoisted so the `#/lib/utils` factory below can use it for both
- * `isRushWorkspace` and the `getPnpmLockfileDir` that is derived from it.
- */
-const isRushWorkspaceMock = vi.hoisted(() =>
-  vi.fn((_workspaceRootDir: string) => false),
-);
-
 vi.mock("pnpm_lockfile_file_v8", () => ({
   readWantedLockfile: vi.fn(() => Promise.resolve(null)),
   getLockfileImporterId: vi.fn(
@@ -23,7 +15,12 @@ vi.mock("pnpm_lockfile_file_v9", () => ({
   ),
 }));
 
-vi.mock("#/lib/utils", () => ({
+vi.mock("#/lib/utils", async (importOriginal) => ({
+  /**
+   * Partial mock: `getPnpmLockfileDir` stays real so the Rush path
+   * computation is not re-implemented per test file.
+   */
+  ...(await importOriginal<typeof import("#/lib/utils")>()),
   getPackageName: vi.fn((spec: string) => {
     if (spec.startsWith("@")) {
       const parts = spec.split("@");
@@ -31,17 +28,7 @@ vi.mock("#/lib/utils", () => ({
     }
     return spec.split("@")[0] ?? "";
   }),
-  isRushWorkspace: isRushWorkspaceMock,
-  /**
-   * Mirrors the real helper, which is a pure path computation on top of the
-   * mocked `isRushWorkspace` above — so the Rush cases still exercise the
-   * branch rather than a hard-coded answer.
-   */
-  getPnpmLockfileDir: vi.fn((workspaceRootDir: string) =>
-    isRushWorkspaceMock(workspaceRootDir)
-      ? `${workspaceRootDir}/common/config/rush`
-      : workspaceRootDir,
-  ),
+  isRushWorkspace: vi.fn(() => false),
 }));
 
 const { readWantedLockfile: readWantedLockfile_v9 } = vi.mocked(

--- a/src/lib/patches/collect-installed-names-pnpm.test.ts
+++ b/src/lib/patches/collect-installed-names-pnpm.test.ts
@@ -290,7 +290,7 @@ describe("collectInstalledNamesFromPnpmLockfile", () => {
     const { getLockfileImporterId } = vi.mocked(
       await import("pnpm_lockfile_file_v9"),
     );
-    getLockfileImporterId.mockReturnValueOnce("packages\\consumer");
+    getLockfileImporterId.mockReturnValueOnce("packages\\consumer" as never);
 
     readWantedLockfile_v9.mockResolvedValue({
       lockfileVersion: "9.0",

--- a/src/lib/patches/collect-installed-names-pnpm.ts
+++ b/src/lib/patches/collect-installed-names-pnpm.ts
@@ -81,10 +81,17 @@ export async function collectInstalledNamesFromPnpmLockfile({
     const packages = (lockfile as { packages?: Record<string, PnpmPackage> })
       .packages;
 
+    /**
+     * The v9 reader keys its importers by the branded `ProjectId` type while
+     * the v8 reader uses plain strings, so widen to a string-keyed record to
+     * look entries up by the ids we assembled above.
+     */
+    const importers = lockfile.importers as Record<string, PnpmImporter>;
+
     if (!packages) {
       log.debug("Lockfile has no packages section to walk");
       return collectImporterDirectNames(
-        lockfile.importers,
+        importers,
         importerIds,
         targetImporterId,
         includeDevDependencies,
@@ -96,7 +103,7 @@ export async function collectInstalledNamesFromPnpmLockfile({
     const queue: string[] = [];
 
     for (const importerId of importerIds) {
-      const importer = lockfile.importers[importerId];
+      const importer = importers[importerId];
       if (!importer) continue;
 
       const isTarget = importerId === targetImporterId;

--- a/src/lib/patches/collect-installed-names-pnpm.ts
+++ b/src/lib/patches/collect-installed-names-pnpm.ts
@@ -9,7 +9,11 @@ import {
 } from "pnpm_lockfile_file_v9";
 import { useLogger } from "#/lib/logger";
 import type { PackagesRegistry } from "#/lib/types";
-import { getPackageName, isRushWorkspace } from "#/lib/utils";
+import {
+  getPackageName,
+  getPnpmLockfileDir,
+  isRushWorkspace,
+} from "#/lib/utils";
 
 /**
  * Walk the workspace pnpm lockfile starting from the target package and its
@@ -43,9 +47,7 @@ export async function collectInstalledNamesFromPnpmLockfile({
   try {
     const useVersion9 = majorVersion >= 9;
     const isRush = isRushWorkspace(workspaceRootDir);
-    const lockfileDir = isRush
-      ? path.join(workspaceRootDir, "common/config/rush")
-      : workspaceRootDir;
+    const lockfileDir = getPnpmLockfileDir(workspaceRootDir);
 
     const lockfile = useVersion9
       ? await readWantedLockfile_v9(lockfileDir, { ignoreIncompatible: false })

--- a/src/lib/patches/copy-patches.test.ts
+++ b/src/lib/patches/copy-patches.test.ts
@@ -3,6 +3,14 @@ import type { PackageManifest, PnpmSettings } from "#/lib/types";
 import { copyPatches } from "./copy-patches";
 
 /** Mock fs-extra */
+/**
+ * Hoisted so the `#/lib/utils` factory below can use it for both
+ * `isRushWorkspace` and the `getPnpmLockfileDir` that is derived from it.
+ */
+const isRushWorkspaceMock = vi.hoisted(() =>
+  vi.fn((_workspaceRootDir: string) => false),
+);
+
 vi.mock("fs-extra", () => ({
   default: {
     ensureDir: vi.fn(),
@@ -23,7 +31,17 @@ vi.mock("#/lib/utils", () => ({
     return spec.split("@")[0] ?? "";
   }),
   getRootRelativeLogPath: vi.fn((p: string) => p),
-  isRushWorkspace: vi.fn(() => false),
+  isRushWorkspace: isRushWorkspaceMock,
+  /**
+   * Mirrors the real helper, which is a pure path computation on top of the
+   * mocked `isRushWorkspace` above — so the Rush cases still exercise the
+   * branch rather than a hard-coded answer.
+   */
+  getPnpmLockfileDir: vi.fn((workspaceRootDir: string) =>
+    isRushWorkspaceMock(workspaceRootDir)
+      ? `${workspaceRootDir}/common/config/rush`
+      : workspaceRootDir,
+  ),
   readTypedJson: vi.fn(),
   readTypedJsonSync: vi.fn(),
   readTypedYamlSync: vi.fn(),

--- a/src/lib/patches/copy-patches.test.ts
+++ b/src/lib/patches/copy-patches.test.ts
@@ -12,12 +12,7 @@ vi.mock("fs-extra", () => ({
 }));
 
 /** Mock the utils */
-vi.mock("#/lib/utils", async (importOriginal) => ({
-  /**
-   * Partial mock: `getPnpmLockfileDir` stays real so the Rush path
-   * computation is not re-implemented per test file.
-   */
-  ...(await importOriginal<typeof import("#/lib/utils")>()),
+vi.mock("#/lib/utils", () => ({
   filterPatchedDependencies: vi.fn(),
   getIsolateRelativeLogPath: vi.fn((p: string) => p),
   getPackageName: vi.fn((spec: string) => {
@@ -29,6 +24,14 @@ vi.mock("#/lib/utils", async (importOriginal) => ({
   }),
   getRootRelativeLogPath: vi.fn((p: string) => p),
   isRushWorkspace: vi.fn(() => false),
+  /**
+   * Neither suite exercises a Rush workspace, so the lockfile directory is the
+   * workspace root. Mocked rather than kept real: the real helper reads
+   * `rush.json` off disk through its own `isRushWorkspace` import, which this
+   * factory cannot intercept, and that would make these tests depend on the
+   * filesystem. `get-pnpm-lockfile-dir.test.ts` covers both of its branches.
+   */
+  getPnpmLockfileDir: vi.fn((workspaceRootDir: string) => workspaceRootDir),
   readTypedJson: vi.fn(),
   readTypedJsonSync: vi.fn(),
   readTypedYamlSync: vi.fn(),

--- a/src/lib/patches/copy-patches.test.ts
+++ b/src/lib/patches/copy-patches.test.ts
@@ -3,14 +3,6 @@ import type { PackageManifest, PnpmSettings } from "#/lib/types";
 import { copyPatches } from "./copy-patches";
 
 /** Mock fs-extra */
-/**
- * Hoisted so the `#/lib/utils` factory below can use it for both
- * `isRushWorkspace` and the `getPnpmLockfileDir` that is derived from it.
- */
-const isRushWorkspaceMock = vi.hoisted(() =>
-  vi.fn((_workspaceRootDir: string) => false),
-);
-
 vi.mock("fs-extra", () => ({
   default: {
     ensureDir: vi.fn(),
@@ -20,7 +12,12 @@ vi.mock("fs-extra", () => ({
 }));
 
 /** Mock the utils */
-vi.mock("#/lib/utils", () => ({
+vi.mock("#/lib/utils", async (importOriginal) => ({
+  /**
+   * Partial mock: `getPnpmLockfileDir` stays real so the Rush path
+   * computation is not re-implemented per test file.
+   */
+  ...(await importOriginal<typeof import("#/lib/utils")>()),
   filterPatchedDependencies: vi.fn(),
   getIsolateRelativeLogPath: vi.fn((p: string) => p),
   getPackageName: vi.fn((spec: string) => {
@@ -31,17 +28,7 @@ vi.mock("#/lib/utils", () => ({
     return spec.split("@")[0] ?? "";
   }),
   getRootRelativeLogPath: vi.fn((p: string) => p),
-  isRushWorkspace: isRushWorkspaceMock,
-  /**
-   * Mirrors the real helper, which is a pure path computation on top of the
-   * mocked `isRushWorkspace` above — so the Rush cases still exercise the
-   * branch rather than a hard-coded answer.
-   */
-  getPnpmLockfileDir: vi.fn((workspaceRootDir: string) =>
-    isRushWorkspaceMock(workspaceRootDir)
-      ? `${workspaceRootDir}/common/config/rush`
-      : workspaceRootDir,
-  ),
+  isRushWorkspace: vi.fn(() => false),
   readTypedJson: vi.fn(),
   readTypedJsonSync: vi.fn(),
   readTypedYamlSync: vi.fn(),

--- a/src/lib/patches/copy-patches.ts
+++ b/src/lib/patches/copy-patches.ts
@@ -14,7 +14,7 @@ import type {
 import {
   filterPatchedDependencies,
   getRootRelativeLogPath,
-  isRushWorkspace,
+  getPnpmLockfileDir,
   readTypedJson,
   readTypedYamlSync,
 } from "#/lib/utils";
@@ -212,7 +212,9 @@ export async function copyPatches({
  *
  * The value type is `PatchFile | string` because pnpm 11 simplified the format
  * to store the bare hash string per selector, while pnpm <=10 stored a
- * `{ path, hash }` object. See issue #201.
+ * `{ path, hash }` object (see issue #201). On the v9 path the string arrives
+ * for a second reason as well: `@pnpm/lockfile.fs` migrates the object form to
+ * a bare hash while reading, so only the v8 reader still yields an object.
  */
 async function readLockfilePatchedDependencies(
   workspaceRootDir: string,
@@ -220,11 +222,7 @@ async function readLockfilePatchedDependencies(
   try {
     const { majorVersion } = usePackageManager();
     const useVersion9 = majorVersion >= 9;
-    const isRush = isRushWorkspace(workspaceRootDir);
-
-    const lockfileDir = isRush
-      ? path.join(workspaceRootDir, "common/config/rush")
-      : workspaceRootDir;
+    const lockfileDir = getPnpmLockfileDir(workspaceRootDir);
 
     const lockfile = useVersion9
       ? await readWantedLockfile_v9(lockfileDir, { ignoreIncompatible: false })

--- a/src/lib/utils/get-pnpm-lockfile-dir.test.ts
+++ b/src/lib/utils/get-pnpm-lockfile-dir.test.ts
@@ -1,0 +1,47 @@
+import fs from "fs-extra";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { getPnpmLockfileDir } from "./get-pnpm-lockfile-dir";
+
+/**
+ * Exercises the real helper against real directories, since what it decides is
+ * whether `rush.json` is present. The consumer test suites mock it, so this is
+ * the only place the actual path computation is covered.
+ */
+describe("getPnpmLockfileDir", () => {
+  const cleanupPaths: string[] = [];
+
+  afterEach(async () => {
+    for (const p of cleanupPaths.splice(0)) {
+      await fs.remove(p).catch(() => undefined);
+    }
+  });
+
+  async function makeWorkspace({ isRush }: { isRush: boolean }) {
+    const dir = await fs.mkdtemp(
+      path.join(os.tmpdir(), "isolate-package-lockfile-dir-"),
+    );
+    cleanupPaths.push(dir);
+
+    if (isRush) {
+      await fs.writeJson(path.join(dir, "rush.json"), {});
+    }
+
+    return dir;
+  }
+
+  it("returns the workspace root for a regular workspace", async () => {
+    const dir = await makeWorkspace({ isRush: false });
+
+    expect(getPnpmLockfileDir(dir)).toBe(dir);
+  });
+
+  it("returns common/config/rush for a Rush workspace", async () => {
+    const dir = await makeWorkspace({ isRush: true });
+
+    expect(getPnpmLockfileDir(dir)).toBe(
+      path.join(dir, "common", "config", "rush"),
+    );
+  });
+});

--- a/src/lib/utils/get-pnpm-lockfile-dir.ts
+++ b/src/lib/utils/get-pnpm-lockfile-dir.ts
@@ -1,0 +1,14 @@
+import path from "node:path";
+import { isRushWorkspace } from "./is-rush-workspace";
+
+/**
+ * The directory holding the workspace `pnpm-lock.yaml`. Rush keeps it under
+ * `common/config/rush` rather than in the workspace root, and every reader of
+ * the pnpm lockfile has to account for that, so the rule lives here instead of
+ * being restated at each call site.
+ */
+export function getPnpmLockfileDir(workspaceRootDir: string) {
+  return isRushWorkspace(workspaceRootDir)
+    ? path.join(workspaceRootDir, "common/config/rush")
+    : workspaceRootDir;
+}

--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -3,6 +3,7 @@ export * from "./filter-patched-dependencies";
 export * from "./get-dirname";
 export * from "./get-error-message";
 export * from "./get-package-name";
+export * from "./get-pnpm-lockfile-dir";
 export * from "./inspect-value";
 export * from "./is-present";
 export * from "./is-rush-workspace";


### PR DESCRIPTION
`isolate-package@1.36.0` fails on any workspace installed with pnpm 12. pnpm now writes `pnpm-lock.yaml` as a stream of two YAML documents, an env document holding `configDependencies` and `packageManagerDependencies` followed by the project document. The pinned reader `@pnpm/lockfile-file@9.0.0` parses with `js-yaml.load()`, which rejects multi-document streams, so the run dies with "The lockfile at ... is broken: expected a single document in the stream, but found more".

The `pnpm_lockfile_file_v9` alias now resolves to `@pnpm/lockfile.fs@1100.2.2`, the maintained successor of `@pnpm/lockfile-file`, whose last release predates the format. It reads both shapes and still writes lockfile format v9. For a pnpm 11 workspace the isolated lockfile is byte-identical to what the old reader produced, so nothing changes for anyone already on a working version. The newer types needed a few casts where they meet `@pnpm/prune-lockfile`, which carries its own copy of the lockfile types and brands importer keys.

Reading the lockfile is only half of it. The issue reports a second failure behind the first: the isolated manifest keeps the root `packageManager` field, but the isolated lockfile had no env document, so `pnpm install --frozen-lockfile` inside the isolate fails with `ERR_PNPM_FROZEN_LOCKFILE_WITH_OUTDATED_LOCKFILE`. The env document is now carried into the isolated lockfile. When `--omit-package-manager` drops the field, only `packageManagerDependencies` is stripped and the document still goes out if it pins `configDependencies`, because `pnpm-workspace.yaml` is copied verbatim and keeps declaring them.

Verified by hand against real pnpm 12 workspaces, since the automated tests assert the shape of the emitted lockfile rather than that pnpm accepts it: a plain workspace, one with an internal workspace dependency and a catalog, and the `--omit-package-manager` path. Each isolate installs with `pnpm install --frozen-lockfile --prod` and resolves at runtime.

Closes #205

Follow-ups: #207 (the isolated lockfile still writes `patchedDependencies` in the pre-pnpm-11 shape), #208 (the v8/v9 reader fork is written out in three modules), #209 (env document edge cases left unhandled, including Rush with config dependencies)

Decisions:
- Absorbed the env document propagation, which the issue reports as a separate follow-up failure. It is the same feature: without it the fix buys a readable lockfile and an isolate you cannot install. It is most of the non-test diff.
- Pinned `@pnpm/lockfile.fs` to 1100.2.2 rather than the current 1100.2.4. CI rejected 1100.2.4 under the repo's 7-day `minimumReleaseAge` policy, since it was published five days ago. 1100.2.2 is two weeks old and exports the same `readEnvLockfile`, `writeEnvLockfile` and `extractMainDocument`.
- Held `pretty-ms` at 9.3.0 through a `pnpm-workspace.yaml` override, for the same policy. It arrives transitively through `network.git-utils` and `safe-execa`, and its newest patch was published a day before this branch. The override is temporary and can go once that version has aged past the cutoff. Pinning to an older release was the conservative option; excluding the package from the policy would have weakened it.
- Kept the alias name `pnpm_lockfile_file_v9` even though it now resolves to a differently named package. It names the lockfile format rather than the package, which matches `pnpm_prune_lockfile_v9`, and renaming it would touch four files for no behavior change.
- Left the v8/v9 reader dispatch duplicated across three modules while sharing only the Rush path computation. The three call sites differ in error handling, and two of them are in the patch code the issue reporter never exercised. Filed as #208.
- An unreadable env document warns instead of throwing. The project document is written first, so letting that read abort the run left the isolate holding a lockfile nobody could install.
- Added one line to `.claude/CLAUDE.md`: a change made to get different behavior out of a dependency needs at least one test that exercises that dependency unmocked. This branch shipped its first round with every test mocking the package the whole change was about.
